### PR TITLE
Bug fix/quiz question rendering

### DIFF
--- a/frontend/components/draft/lesson/add-block.tsx
+++ b/frontend/components/draft/lesson/add-block.tsx
@@ -82,6 +82,28 @@ export function AddBlock({ add }: { add: (block: any) => void }) {
           >
             Video Block
           </Button>
+          <Button
+            onClick={() => {
+              setOpen(false);
+              add({
+                __component: "droplets.quiz",
+                questions: [
+                  {
+                    id: Math.random(),
+                    content: "",
+                    answerOptions: [
+                      { id: Math.random(), content: "", isCorrect: true },
+                      { id: Math.random(), content: "", isCorrect: false },
+                    ],
+                  },
+                ],
+              });
+            }}
+            variant="ghost"
+            className="w-full border border-slate-200"
+          >
+            Quiz Block
+          </Button>
         </PopoverContent>
       </Popover>
     </div>

--- a/frontend/components/draft/lesson/blocks/quiz-question-editor.tsx
+++ b/frontend/components/draft/lesson/blocks/quiz-question-editor.tsx
@@ -1,0 +1,99 @@
+import { QuizQuestion, QuizAnswerOption } from "@/types";
+import { Button } from "@/components/ui/button";
+import { TrashIcon, PlusIcon } from "lucide-react";
+import { GenericBlockInput as TipTapEditor } from "@/components/ui/tiptap/generic-block-input";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
+
+interface QuizQuestionEditorProps {
+  question: QuizQuestion;
+  onUpdate: (question: QuizQuestion) => void;
+  onDelete: () => void;
+}
+
+export function QuizQuestionEditor({
+  question,
+  onUpdate,
+  onDelete,
+}: QuizQuestionEditorProps) {
+  const updateContent = (content: string) => {
+    onUpdate({ ...question, content });
+  };
+
+  const updateAnswer = (index: number, content: string) => {
+    const updatedAnswers = question.answerOptions.map((answer, i) =>
+      i === index ? { ...answer, content } : answer
+    );
+    onUpdate({ ...question, answerOptions: updatedAnswers });
+  };
+
+  const setCorrectAnswer = (answerId: string) => {
+    const updatedAnswers = question.answerOptions.map((answer) => ({
+      ...answer,
+      isCorrect: answer.id.toString() === answerId,
+    }));
+    onUpdate({ ...question, answerOptions: updatedAnswers });
+  };
+
+  const addAnswer = () => {
+    const newAnswer: QuizAnswerOption = {
+      id: Math.random(),
+      content: "",
+      isCorrect: false,
+    };
+    onUpdate({
+      ...question,
+      answerOptions: [...question.answerOptions, newAnswer],
+    });
+  };
+
+  return (
+    <div className="p-6 border rounded-lg bg-white">
+      <div className="flex justify-between items-start mb-4">
+        <h4 className="font-semibold">Question</h4>
+        <Button variant="ghost" size="sm" onClick={onDelete}>
+          <TrashIcon className="w-4 h-4" />
+        </Button>
+      </div>
+
+      <TipTapEditor
+        initialContent={question.content}
+        updateContent={updateContent}
+        revalidate={() => {}}
+        // className="min-h-[100px] mb-4"
+      />
+
+      <div className="space-y-4 pt-4">
+        <h5 className="font-semibold">Answer Options</h5>
+        <RadioGroup
+          value={question.answerOptions.find((a) => a.isCorrect)?.id.toString()}
+          onValueChange={setCorrectAnswer}
+        >
+          {question.answerOptions.map((answer, index) => (
+            <div key={answer.id} className="flex items-center space-x-2 w-full">
+              <RadioGroupItem
+                value={answer.id.toString()}
+                id={answer.id.toString()}
+              />
+              <div className="flex-1">
+                <TipTapEditor
+                  initialContent={answer.content}
+                  updateContent={(content) => updateAnswer(index, content)}
+                  revalidate={() => {}}
+                  // className="flex-1 min-h-[50px]"
+                />
+              </div>
+            </div>
+          ))}
+        </RadioGroup>
+
+        {question.answerOptions.length < 4 && (
+          <Button variant="outline" size="sm" onClick={addAnswer}>
+            <PlusIcon className="w-4 h-4 mr-2" />
+            Add Answer Option
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/draft/lesson/blocks/quiz-question-editor.tsx
+++ b/frontend/components/draft/lesson/blocks/quiz-question-editor.tsx
@@ -22,7 +22,7 @@ export function QuizQuestionEditor({
 
   const updateAnswer = (index: number, content: string) => {
     const updatedAnswers = question.answerOptions.map((answer, i) =>
-      i === index ? { ...answer, content } : answer
+      i === index ? { ...answer, content } : answer,
     );
     onUpdate({ ...question, answerOptions: updatedAnswers });
   };

--- a/frontend/components/draft/lesson/blocks/quiz.tsx
+++ b/frontend/components/draft/lesson/blocks/quiz.tsx
@@ -1,0 +1,91 @@
+import { Quiz, QuizQuestion } from "@/types";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { PlusIcon, TrashIcon } from "lucide-react";
+// import { QuizQuestionEditor } from "./quiz-question-editor";
+import { QuizQuestionEditor } from "./quiz-question-editor";
+
+interface QuizEditorProps {
+  block: {
+    id?: number;
+    __component: string;
+    questions: QuizQuestion[];
+  };
+  updateBlock: (block: Partial<Block>) => void;
+  deleteBlock: () => void;
+}
+
+interface Block {
+  __component: string;
+  content?: string;
+  id?: number;
+  [key: string]: any;
+}
+
+export function QuizEditor({
+  block,
+  updateBlock,
+  deleteBlock,
+}: QuizEditorProps) {
+  const [questions, setQuestions] = useState<QuizQuestion[]>(
+    block.questions || []
+  );
+
+  const addQuestion = () => {
+    const newQuestion: QuizQuestion = {
+      id: Math.random(), // Temporary ID for new questions
+      content: "",
+      answerOptions: [
+        { id: Math.random(), content: "", isCorrect: true },
+        { id: Math.random(), content: "", isCorrect: false },
+      ],
+    };
+
+    const updatedQuestions = [...questions, newQuestion];
+    setQuestions(updatedQuestions);
+    updateBlock({ questions: updatedQuestions });
+  };
+
+  const updateQuestion = (index: number, updatedQuestion: QuizQuestion) => {
+    const updatedQuestions = questions.map((q, i) =>
+      i === index ? updatedQuestion : q
+    );
+    setQuestions(updatedQuestions);
+    updateBlock({ questions: updatedQuestions });
+  };
+
+  const removeQuestion = (index: number) => {
+    const updatedQuestions = questions.filter((_, i) => i !== index);
+    setQuestions(updatedQuestions);
+    updateBlock({ questions: updatedQuestions });
+  };
+
+  return (
+    <div className="w-full max-w-2xl">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-xl font-bold">Quiz</h3>
+        <Button variant="ghost" size="sm" onClick={deleteBlock}>
+          <TrashIcon className="w-4 h-4" />
+        </Button>
+      </div>
+
+      <div className="space-y-6">
+        {questions.map((question, index) => (
+          <QuizQuestionEditor
+            key={question.id}
+            question={question}
+            onUpdate={(updatedQuestion) =>
+              updateQuestion(index, updatedQuestion)
+            }
+            onDelete={() => removeQuestion(index)}
+          />
+        ))}
+      </div>
+
+      <Button onClick={addQuestion} variant="outline" className="mt-4">
+        <PlusIcon className="w-4 h-4 mr-2" />
+        Add Question
+      </Button>
+    </div>
+  );
+}

--- a/frontend/components/draft/lesson/blocks/quiz.tsx
+++ b/frontend/components/draft/lesson/blocks/quiz.tsx
@@ -28,7 +28,7 @@ export function QuizEditor({
   deleteBlock,
 }: QuizEditorProps) {
   const [questions, setQuestions] = useState<QuizQuestion[]>(
-    block.questions || []
+    block.questions || [],
   );
 
   const addQuestion = () => {
@@ -48,7 +48,7 @@ export function QuizEditor({
 
   const updateQuestion = (index: number, updatedQuestion: QuizQuestion) => {
     const updatedQuestions = questions.map((q, i) =>
-      i === index ? updatedQuestion : q
+      i === index ? updatedQuestion : q,
     );
     setQuestions(updatedQuestions);
     updateBlock({ questions: updatedQuestions });

--- a/frontend/components/draft/lesson/lesson-renderer.tsx
+++ b/frontend/components/draft/lesson/lesson-renderer.tsx
@@ -42,7 +42,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
 
   const [blocks, setBlocks] = useState<Block[]>(lesson.blocks);
   const [lastSavedBlocks, setLastSavedBlocks] = useState<Block[]>(
-    lesson.blocks
+    lesson.blocks,
   );
   const lastSavedBlocksRef = useRef<Block[]>(lastSavedBlocks);
   const [name, setName] = useState(lesson.name);
@@ -57,7 +57,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
         return;
       }
     },
-    [lesson.id]
+    [lesson.id],
   );
 
   const updateBlocksBackendReload = useCallback(
@@ -65,7 +65,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
       await updateLesson(lesson.id, { blocks }, { reload: true });
       console.log("Updated Blocks while reloading");
     },
-    [lesson.id]
+    [lesson.id],
   );
 
   const updateNameBackend = useCallback(
@@ -76,7 +76,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
         router.replace(`/draft/d/${dropletSlug}/${slug}`);
       }
     },
-    [lesson.id, dropletSlug, router]
+    [lesson.id, dropletSlug, router],
   );
 
   const regenerateSlug = useCallback(
@@ -84,14 +84,14 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
       const response = await updateLesson(
         lesson.id,
         { name },
-        { regenerateSlug: true }
+        { regenerateSlug: true },
       );
       if (response && !response.error) {
         const slug = response.data.attributes.slug;
         router.replace(`/draft/d/${dropletSlug}/${slug}`);
       }
     },
-    [lesson.id, dropletSlug, router]
+    [lesson.id, dropletSlug, router],
   );
 
   const deleteLessonBackend = useCallback(async () => {
@@ -108,7 +108,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
   const setBlock = useCallback((index: number) => {
     return (block: Partial<Block>) => {
       setBlocks((prevBlocks) =>
-        prevBlocks.map((b, i) => (i === index ? { ...b, ...block } : b))
+        prevBlocks.map((b, i) => (i === index ? { ...b, ...block } : b)),
       );
     };
   }, []);
@@ -121,7 +121,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
         updateBlocksBackendReload(updatedBlocks);
       };
     },
-    [blocks, updateBlocksBackendReload]
+    [blocks, updateBlocksBackendReload],
   );
 
   const addBlock = useCallback(
@@ -132,18 +132,18 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
         updateBlocksBackendReload(updatedBlocks);
       };
     },
-    [blocks, updateBlocksBackendReload]
+    [blocks, updateBlocksBackendReload],
   );
 
   // Debounced updates
   const debounceUpdate = useMemo(
     () => debounce(updateBlocksBackend, 1000, { maxWait: 3000 }),
-    [updateBlocksBackend]
+    [updateBlocksBackend],
   );
 
   const debouncedNameUpdate = useMemo(
     () => debounce(updateNameBackend, 1000),
-    [updateNameBackend]
+    [updateNameBackend],
   );
 
   // Effects
@@ -195,7 +195,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
           return null;
       }
     },
-    [setBlock, deleteBlock]
+    [setBlock, deleteBlock],
   );
 
   return (

--- a/frontend/components/draft/lesson/lesson-renderer.tsx
+++ b/frontend/components/draft/lesson/lesson-renderer.tsx
@@ -17,6 +17,8 @@ import { toast } from "sonner";
 import { useTransition } from "react";
 import { useMemo } from "react";
 import { LessonNameInput } from "@/components/ui/tiptap/lesson-name-input";
+import { QuizEditor } from "./blocks/quiz";
+import { QuizQuestion } from "@/types";
 
 interface Block {
   __component: string;
@@ -26,6 +28,7 @@ interface Block {
   type?: string;
   label?: string;
   url?: string;
+  questions?: QuizQuestion[];
 }
 
 interface LessonRendererProps {
@@ -39,7 +42,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
 
   const [blocks, setBlocks] = useState<Block[]>(lesson.blocks);
   const [lastSavedBlocks, setLastSavedBlocks] = useState<Block[]>(
-    lesson.blocks,
+    lesson.blocks
   );
   const lastSavedBlocksRef = useRef<Block[]>(lastSavedBlocks);
   const [name, setName] = useState(lesson.name);
@@ -54,7 +57,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
         return;
       }
     },
-    [lesson.id],
+    [lesson.id]
   );
 
   const updateBlocksBackendReload = useCallback(
@@ -62,7 +65,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
       await updateLesson(lesson.id, { blocks }, { reload: true });
       console.log("Updated Blocks while reloading");
     },
-    [lesson.id],
+    [lesson.id]
   );
 
   const updateNameBackend = useCallback(
@@ -73,7 +76,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
         router.replace(`/draft/d/${dropletSlug}/${slug}`);
       }
     },
-    [lesson.id, dropletSlug, router],
+    [lesson.id, dropletSlug, router]
   );
 
   const regenerateSlug = useCallback(
@@ -81,14 +84,14 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
       const response = await updateLesson(
         lesson.id,
         { name },
-        { regenerateSlug: true },
+        { regenerateSlug: true }
       );
       if (response && !response.error) {
         const slug = response.data.attributes.slug;
         router.replace(`/draft/d/${dropletSlug}/${slug}`);
       }
     },
-    [lesson.id, dropletSlug, router],
+    [lesson.id, dropletSlug, router]
   );
 
   const deleteLessonBackend = useCallback(async () => {
@@ -105,7 +108,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
   const setBlock = useCallback((index: number) => {
     return (block: Partial<Block>) => {
       setBlocks((prevBlocks) =>
-        prevBlocks.map((b, i) => (i === index ? { ...b, ...block } : b)),
+        prevBlocks.map((b, i) => (i === index ? { ...b, ...block } : b))
       );
     };
   }, []);
@@ -118,7 +121,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
         updateBlocksBackendReload(updatedBlocks);
       };
     },
-    [blocks, updateBlocksBackendReload],
+    [blocks, updateBlocksBackendReload]
   );
 
   const addBlock = useCallback(
@@ -129,18 +132,18 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
         updateBlocksBackendReload(updatedBlocks);
       };
     },
-    [blocks, updateBlocksBackendReload],
+    [blocks, updateBlocksBackendReload]
   );
 
   // Debounced updates
   const debounceUpdate = useMemo(
     () => debounce(updateBlocksBackend, 1000, { maxWait: 3000 }),
-    [updateBlocksBackend],
+    [updateBlocksBackend]
   );
 
   const debouncedNameUpdate = useMemo(
     () => debounce(updateNameBackend, 1000),
-    [updateNameBackend],
+    [updateNameBackend]
   );
 
   // Effects
@@ -177,11 +180,22 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
           return <VideoEditor {...props} />;
         case "droplets.callout":
           return <CalloutEditor {...props} />;
+        case "droplets.quiz":
+          return (
+            <QuizEditor
+              block={{
+                ...props.block,
+                questions: props.block.questions || [],
+              }}
+              updateBlock={props.updateBlock}
+              deleteBlock={props.deleteBlock}
+            />
+          );
         default:
           return null;
       }
     },
-    [setBlock, deleteBlock],
+    [setBlock, deleteBlock]
   );
 
   return (

--- a/frontend/components/droplets/lessons/quiz-question.tsx
+++ b/frontend/components/droplets/lessons/quiz-question.tsx
@@ -30,7 +30,7 @@ export function QuizQuestionBlock({ question }: { question: QuizQuestion }) {
   const [showResult, setShowResult] = useState(false);
   const correctAnswer = useMemo(
     () => question.answerOptions.find((option) => option.isCorrect),
-    [question]
+    [question],
   );
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -69,7 +69,8 @@ export function QuizQuestionBlock({ question }: { question: QuizQuestion }) {
               <p className="mt-4 font-bold text-pretty">
                 {
                   question.answerOptions.find(
-                    (option) => String(option.id) === form.getValues("answerId")
+                    (option) =>
+                      String(option.id) === form.getValues("answerId"),
                   )!.content
                 }
               </p>
@@ -86,7 +87,7 @@ export function QuizQuestionBlock({ question }: { question: QuizQuestion }) {
                   {
                     question.answerOptions.find(
                       (option) =>
-                        String(option.id) === form.getValues("answerId")
+                        String(option.id) === form.getValues("answerId"),
                     )!.content
                   }
                 </p>

--- a/frontend/components/droplets/lessons/quiz-question.tsx
+++ b/frontend/components/droplets/lessons/quiz-question.tsx
@@ -30,7 +30,7 @@ export function QuizQuestionBlock({ question }: { question: QuizQuestion }) {
   const [showResult, setShowResult] = useState(false);
   const correctAnswer = useMemo(
     () => question.answerOptions.find((option) => option.isCorrect),
-    [question],
+    [question]
   );
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -69,8 +69,7 @@ export function QuizQuestionBlock({ question }: { question: QuizQuestion }) {
               <p className="mt-4 font-bold text-pretty">
                 {
                   question.answerOptions.find(
-                    (option) =>
-                      String(option.id) === form.getValues("answerId"),
+                    (option) => String(option.id) === form.getValues("answerId")
                   )!.content
                 }
               </p>
@@ -87,7 +86,7 @@ export function QuizQuestionBlock({ question }: { question: QuizQuestion }) {
                   {
                     question.answerOptions.find(
                       (option) =>
-                        String(option.id) === form.getValues("answerId"),
+                        String(option.id) === form.getValues("answerId")
                     )!.content
                   }
                 </p>
@@ -141,7 +140,12 @@ export function QuizQuestionBlock({ question }: { question: QuizQuestion }) {
                                       ? "D"
                                       : "?"}
                             </span>
-                            {answer.content}
+                            <div
+                              className="prose prose-m w-full"
+                              dangerouslySetInnerHTML={{
+                                __html: answer.content,
+                              }}
+                            />
                           </FormLabel>
                         </FormItem>
                       ))}

--- a/frontend/lib/requests/lesson.ts
+++ b/frontend/lib/requests/lesson.ts
@@ -10,7 +10,7 @@ import { fetchAPI } from "../utils";
  */
 export async function getLessonBySlug<T extends Partial<Lesson> = Lesson>(
   slug: string,
-  { sort, filters, populate = "*", fields = ["*"] }: StrapiRequestParams = {}
+  { sort, filters, populate = "*", fields = ["*"] }: StrapiRequestParams = {},
 ): Promise<T> {
   const path = `/lessons`;
   const urlParams = {

--- a/frontend/lib/requests/lesson.ts
+++ b/frontend/lib/requests/lesson.ts
@@ -10,13 +10,21 @@ import { fetchAPI } from "../utils";
  */
 export async function getLessonBySlug<T extends Partial<Lesson> = Lesson>(
   slug: string,
-  { sort, filters, populate = "*", fields = ["*"] }: StrapiRequestParams = {},
+  { sort, filters, populate = "*", fields = ["*"] }: StrapiRequestParams = {}
 ): Promise<T> {
   const path = `/lessons`;
   const urlParams = {
     sort,
     filters: { ...filters, slug },
-    populate,
+    populate: {
+      blocks: {
+        populate: {
+          questions: {
+            populate: ["answerOptions"],
+          },
+        },
+      },
+    },
     fields,
     pagination: {
       pageSize: 1,


### PR DESCRIPTION
Fixed the quiz question rendering issue in user's (reader's) view by updating the populate section of the strapi API call (questions weren't being returned). 

Added functionality in draft mode to edit existing quiz questions. 

Added functionality in draft mode to add a new quiz question block by adding a button to the popover shown when user clicks "add block"

Updated quiz question rendering in user/reader view to handle the HTML included from the tip tap editor. 