### PR TITLE
Feature/admin version

### DIFF
--- a/backend/src/api/authorized-user/content-types/authorized-user/schema.json
+++ b/backend/src/api/authorized-user/content-types/authorized-user/schema.json
@@ -110,6 +110,18 @@
     },
     "profilePhoto": {
       "type": "text"
+    },
+    "was_blocked": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::authorized-user.authorized-user",
+      "inversedBy": "blocked"
+    },
+    "blocked": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::authorized-user.authorized-user",
+      "inversedBy": "was_blocked"
     }
   }
 }

--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -11,7 +11,7 @@
       "url": "https://khouryodyssey.org"
     },
     "license": null,
-    "x-generation-date": "2025-01-30T17:14:12.953Z"
+    "x-generation-date": "2025-01-30T19:36:55.400Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -11,7 +11,7 @@
       "url": "https://khouryodyssey.org"
     },
     "license": null,
-    "x-generation-date": "2025-01-30T14:04:45.361Z"
+    "x-generation-date": "2025-01-30T17:14:12.953Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -2648,6 +2648,46 @@
                                                   "profilePhoto": {
                                                     "type": "string"
                                                   },
+                                                  "was_blocked": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "data": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "number"
+                                                            },
+                                                            "attributes": {
+                                                              "type": "object",
+                                                              "properties": {}
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "blocked": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "data": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "number"
+                                                            },
+                                                            "attributes": {
+                                                              "type": "object",
+                                                              "properties": {}
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
                                                   "createdAt": {
                                                     "type": "string",
                                                     "format": "date-time"
@@ -3380,6 +3420,34 @@
               },
               "profilePhoto": {
                 "type": "string"
+              },
+              "was_blocked": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "example": "string or id"
+                }
+              },
+              "blocked": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "example": "string or id"
+                }
               }
             }
           }
@@ -5030,6 +5098,46 @@
                                                                             "profilePhoto": {
                                                                               "type": "string"
                                                                             },
+                                                                            "was_blocked": {
+                                                                              "type": "object",
+                                                                              "properties": {
+                                                                                "data": {
+                                                                                  "type": "array",
+                                                                                  "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                      "id": {
+                                                                                        "type": "number"
+                                                                                      },
+                                                                                      "attributes": {
+                                                                                        "type": "object",
+                                                                                        "properties": {}
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "blocked": {
+                                                                              "type": "object",
+                                                                              "properties": {
+                                                                                "data": {
+                                                                                  "type": "array",
+                                                                                  "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                      "id": {
+                                                                                        "type": "number"
+                                                                                      },
+                                                                                      "attributes": {
+                                                                                        "type": "object",
+                                                                                        "properties": {}
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            },
                                                                             "createdAt": {
                                                                               "type": "string",
                                                                               "format": "date-time"
@@ -5927,6 +6035,46 @@
           },
           "profilePhoto": {
             "type": "string"
+          },
+          "was_blocked": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "attributes": {
+                      "type": "object",
+                      "properties": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "blocked": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "attributes": {
+                      "type": "object",
+                      "properties": {}
+                    }
+                  }
+                }
+              }
+            }
           },
           "createdAt": {
             "type": "string",
@@ -8292,6 +8440,46 @@
                         "profilePhoto": {
                           "type": "string"
                         },
+                        "was_blocked": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number"
+                                  },
+                                  "attributes": {
+                                    "type": "object",
+                                    "properties": {}
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "blocked": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number"
+                                  },
+                                  "attributes": {
+                                    "type": "object",
+                                    "properties": {}
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
                         "createdAt": {
                           "type": "string",
                           "format": "date-time"
@@ -10245,6 +10433,46 @@
                                                                               },
                                                                               "profilePhoto": {
                                                                                 "type": "string"
+                                                                              },
+                                                                              "was_blocked": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                  "data": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                      "type": "object",
+                                                                                      "properties": {
+                                                                                        "id": {
+                                                                                          "type": "number"
+                                                                                        },
+                                                                                        "attributes": {
+                                                                                          "type": "object",
+                                                                                          "properties": {}
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "blocked": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                  "data": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                      "type": "object",
+                                                                                      "properties": {
+                                                                                        "id": {
+                                                                                          "type": "number"
+                                                                                        },
+                                                                                        "attributes": {
+                                                                                          "type": "object",
+                                                                                          "properties": {}
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
                                                                               },
                                                                               "createdAt": {
                                                                                 "type": "string",
@@ -13117,6 +13345,46 @@
                                                 "profilePhoto": {
                                                   "type": "string"
                                                 },
+                                                "was_blocked": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "data": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "id": {
+                                                            "type": "number"
+                                                          },
+                                                          "attributes": {
+                                                            "type": "object",
+                                                            "properties": {}
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "blocked": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "data": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "id": {
+                                                            "type": "number"
+                                                          },
+                                                          "attributes": {
+                                                            "type": "object",
+                                                            "properties": {}
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
                                                 "createdAt": {
                                                   "type": "string",
                                                   "format": "date-time"
@@ -15964,6 +16232,46 @@
                       "profilePhoto": {
                         "type": "string"
                       },
+                      "was_blocked": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "number"
+                                },
+                                "attributes": {
+                                  "type": "object",
+                                  "properties": {}
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "blocked": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "number"
+                                },
+                                "attributes": {
+                                  "type": "object",
+                                  "properties": {}
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
                       "createdAt": {
                         "type": "string",
                         "format": "date-time"
@@ -18412,6 +18720,46 @@
                         },
                         "profilePhoto": {
                           "type": "string"
+                        },
+                        "was_blocked": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number"
+                                  },
+                                  "attributes": {
+                                    "type": "object",
+                                    "properties": {}
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "blocked": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number"
+                                  },
+                                  "attributes": {
+                                    "type": "object",
+                                    "properties": {}
+                                  }
+                                }
+                              }
+                            }
+                          }
                         },
                         "createdAt": {
                           "type": "string",
@@ -20934,6 +21282,46 @@
                         "profilePhoto": {
                           "type": "string"
                         },
+                        "was_blocked": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number"
+                                  },
+                                  "attributes": {
+                                    "type": "object",
+                                    "properties": {}
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "blocked": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number"
+                                  },
+                                  "attributes": {
+                                    "type": "object",
+                                    "properties": {}
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
                         "createdAt": {
                           "type": "string",
                           "format": "date-time"
@@ -23178,6 +23566,46 @@
                                                   },
                                                   "profilePhoto": {
                                                     "type": "string"
+                                                  },
+                                                  "was_blocked": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "data": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "number"
+                                                            },
+                                                            "attributes": {
+                                                              "type": "object",
+                                                              "properties": {}
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "blocked": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "data": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "number"
+                                                            },
+                                                            "attributes": {
+                                                              "type": "object",
+                                                              "properties": {}
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
                                                   },
                                                   "createdAt": {
                                                     "type": "string",
@@ -25816,6 +26244,46 @@
                                                   },
                                                   "profilePhoto": {
                                                     "type": "string"
+                                                  },
+                                                  "was_blocked": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "data": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "number"
+                                                            },
+                                                            "attributes": {
+                                                              "type": "object",
+                                                              "properties": {}
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "blocked": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "data": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "number"
+                                                            },
+                                                            "attributes": {
+                                                              "type": "object",
+                                                              "properties": {}
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
                                                   },
                                                   "createdAt": {
                                                     "type": "string",
@@ -28756,6 +29224,46 @@
                                                   },
                                                   "profilePhoto": {
                                                     "type": "string"
+                                                  },
+                                                  "was_blocked": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "data": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "number"
+                                                            },
+                                                            "attributes": {
+                                                              "type": "object",
+                                                              "properties": {}
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "blocked": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "data": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "number"
+                                                            },
+                                                            "attributes": {
+                                                              "type": "object",
+                                                              "properties": {}
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
                                                   },
                                                   "createdAt": {
                                                     "type": "string",

--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -11,7 +11,7 @@
       "url": "https://khouryodyssey.org"
     },
     "license": null,
-    "x-generation-date": "2025-01-29T18:50:06.889Z"
+    "x-generation-date": "2025-01-30T14:04:45.361Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -521,6 +521,11 @@ export interface ApiAuthorizedUserAuthorizedUser extends Schema.CollectionType {
       Attribute.SetMinMaxLength<{
         maxLength: 400;
       }>;
+    blocked: Attribute.Relation<
+      'api::authorized-user.authorized-user',
+      'manyToMany',
+      'api::authorized-user.authorized-user'
+    >;
     createdAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
       'api::authorized-user.authorized-user',
@@ -595,6 +600,11 @@ export interface ApiAuthorizedUserAuthorizedUser extends Schema.CollectionType {
       'admin::user'
     > &
       Attribute.Private;
+    was_blocked: Attribute.Relation<
+      'api::authorized-user.authorized-user',
+      'manyToMany',
+      'api::authorized-user.authorized-user'
+    >;
   };
 }
 

--- a/frontend/app/(general)/admin/page.tsx
+++ b/frontend/app/(general)/admin/page.tsx
@@ -13,6 +13,7 @@ import { fetchAuthorizedUsers } from "@/lib/requests/authorized-user";
 import { fetchDroplets } from "@/lib/requests/data";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { Droplets } from "@/components/admin/droplets/droplets";
+import { Groups } from "@/components/admin/groups/groups";
 import { Playlists } from "@/components/admin/playlists/playlists";
 
 export default async function Page() {
@@ -71,6 +72,7 @@ export default async function Page() {
           Users: <AuthorizedUsers />,
           Droplets: <Droplets />,
           Playlists: <Playlists />,
+          Groups: <Groups />,
           "Access Manager": <AccessManager user={user} />,
           Reports: <Reports />,
         }}

--- a/frontend/app/(general)/settings/friends/page.tsx
+++ b/frontend/app/(general)/settings/friends/page.tsx
@@ -33,6 +33,7 @@ import {
   getSentRequestIds,
   fetchFriends,
 } from "@/lib/requests/friends";
+import { BlockedUsers } from "@/components/friends/blocked-users";
 
 export default async function AuthorProfileSettings() {
   const authorizedUsers = await fetchAuthorizedUsers();
@@ -68,6 +69,7 @@ export default async function AuthorProfileSettings() {
           "Friend Requests": <FriendRequests />,
           "People You May Know": <FriendSuggestions user={authorizedUser} />,
           "Sent Requests": <FriendSentRequests />,
+          "Blocked Users": <BlockedUsers />,
         }}
       />
     </div>

--- a/frontend/components/admin/groups/create-group.tsx
+++ b/frontend/components/admin/groups/create-group.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { PlusIcon } from "lucide-react";
+import Link from "next/link";
+
+export function CreateGroup() {
+  return (
+    <Link href="/g/management">
+      <Button after={<PlusIcon />}>Create Group</Button>
+    </Link>
+  );
+}

--- a/frontend/components/admin/groups/group-block.tsx
+++ b/frontend/components/admin/groups/group-block.tsx
@@ -1,36 +1,28 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { updateDroplet } from "@/lib/actions";
-import { Droplet } from "@/types";
+import { updateGroup } from "@/lib/requests/groups";
+import { Group, Playlist } from "@/types";
 import { Pencil } from "lucide-react";
+import Link from "next/link";
 import { useFormStatus } from "react-dom";
 import { toast } from "sonner";
-import Link from "next/link";
 
-export function DropletBlock({ droplet }: { droplet: Droplet }) {
-  const linkTo = `/draft/d/${droplet.slug}`;
+export function GroupBlock({ group }: { group: Group }) {
+  const linkTo = `/g/management?slug=${group.slug}`;
 
-  const handleUpdateDroplet = async (formData: FormData) => {
-    const result = await updateDroplet(
-      droplet.id,
-      {
-        isHidden: !droplet.isHidden,
-        name: droplet.name,
-        focusArea: droplet.focusArea,
-        type: droplet.type,
-        tagIds: droplet.tags?.map((tag) => tag.id) || [],
-      },
-      { revalidate: true },
-    );
+  const handleUpdateGroup = async (formData: FormData) => {
+    const result = await updateGroup(group.id, {
+      isArchived: !group.isArchived,
+      groupName: group.groupName,
+    });
 
-    if (result.ok) {
+    if (result) {
       toast.success(
-        `Droplet ${!droplet.isHidden ? "hidden" : "shown"} successfully`,
+        `Group ${!group.isArchived ? "archived" : "unarchived"} successfully`,
       );
     } else {
-      toast.error("Failed to update droplet visibility");
-      console.error(result.error);
+      toast.error("Failed to update group visibility");
     }
   };
 
@@ -39,8 +31,8 @@ export function DropletBlock({ droplet }: { droplet: Droplet }) {
       <div className="flex items-center space-x-4">
         <div className="flex-1 min-w-0">
           <p className="font-medium truncate text-slate-900 dark:text-white">
-            {droplet.name}
-            {droplet.isHidden ? " (Hidden)" : ""}
+            {group.groupName}
+            {group.isArchived ? " (Archived)" : ""}
           </p>
         </div>
 
@@ -50,28 +42,28 @@ export function DropletBlock({ droplet }: { droplet: Droplet }) {
               <div className="relative group">
                 <Pencil className="text-sky-600" />
                 <span className="absolute left-1/2 transform -translate-x-1/2 top-full mt-1 w-max px-2 py-1 text-xs text-white bg-gray-800 rounded opacity-0 group-hover:opacity-100 transition-opacity">
-                  Edit Droplet
+                  Edit Group
                 </span>
               </div>
             </Button>
           </Link>
-          <form action={handleUpdateDroplet}>
+          <form action={handleUpdateGroup}>
             <input
               id="id"
               name="id"
               type="number"
-              defaultValue={droplet.id}
+              defaultValue={group.id}
               hidden
             />
             <input
-              id="isHidden"
-              name="isHidden"
+              id="isArchived"
+              name="isArchived"
               type="text"
-              defaultValue={String(!droplet.isHidden)}
+              defaultValue={String(!group.isArchived)}
               hidden
             />
-            <SubmitButton destructive={!droplet.isHidden}>
-              {droplet.isHidden ? "Show Droplet" : "Hide Droplet"}
+            <SubmitButton destructive={!group.isArchived}>
+              {group.isArchived ? "Unarchive Group" : "Archive Group"}
             </SubmitButton>
           </form>
         </div>

--- a/frontend/components/admin/groups/groups.tsx
+++ b/frontend/components/admin/groups/groups.tsx
@@ -1,0 +1,31 @@
+import { Group } from "@/types";
+import { CreateGroup } from "./create-group";
+import { GroupBlock } from "./group-block";
+import { fetchGroups } from "@/lib/requests/data";
+
+export async function Groups() {
+  const groups = await fetchGroups();
+
+  return (
+    <section>
+      <h1 className="font-bold">Groups</h1>
+      <p>The following groups have been created.</p>
+
+      <div className="mt-4">
+        <CreateGroup />
+      </div>
+
+      <div className="p-4 mt-4 rounded-md bg-slate-100">
+        {groups.length > 0 ? (
+          <ul className="divide-y divide-slate-200 dark:divide-slate-700 md:space-y-4">
+            {groups.map((g: Group) => (
+              <GroupBlock group={g} key={g.id} />
+            ))}
+          </ul>
+        ) : (
+          <p>There are no created groups.</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/admin/users/authorized-user.tsx
+++ b/frontend/components/admin/users/authorized-user.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+import { useState, useCallback } from "react";
+import { useDropzone } from "react-dropzone";
 import { Button } from "@/components/ui/button";
-import { updateAuthorizedUser, updateUserInfo } from "@/lib/actions";
+import {
+  updateAuthorizedUser,
+  updateUserInfo,
+  uploadImage,
+} from "@/lib/actions";
 import { AuthorizedUser } from "@/types";
-import { Pencil } from "lucide-react";
+import { Pencil, User2Icon } from "lucide-react";
 import { useFormStatus } from "react-dom";
-import { isAuthorizedUserAdmin } from "@/lib/utils";
-import { useState } from "react";
+import { getInitials, isAuthorizedUserAdmin } from "@/lib/utils";
 import {
   DialogHeader,
   Dialog,
@@ -20,6 +25,7 @@ import { toast } from "sonner";
 import { AuthorizedUserRoleTitle } from "@/lib/globals";
 import { Checkbox } from "@/components/ui/checkbox";
 import { type } from "os";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 export function AuthorizedUserBlock({ user }: { user: AuthorizedUser }) {
   const [open, setOpen] = useState(false);
@@ -27,6 +33,7 @@ export function AuthorizedUserBlock({ user }: { user: AuthorizedUser }) {
   const [firstName, setFirstName] = useState(user.firstName || "");
   const [lastName, setLastName] = useState(user.lastName || "");
   const [bio, setBio] = useState(user.bio || "");
+  const [profilePhoto, setProfilePhoto] = useState(user.profilePhoto || "");
   const [selectedRoles, setSelectedRoles] = useState<AuthorizedUserRoleTitle[]>(
     user.roles.map((role) => role.title),
   );
@@ -47,6 +54,45 @@ export function AuthorizedUserBlock({ user }: { user: AuthorizedUser }) {
     );
   };
 
+  const onDrop = useCallback(
+    async (acceptedFiles: File[]) => {
+      const file = acceptedFiles[0];
+      if (file) {
+        const newFormData: FormData = new FormData();
+        newFormData.append("image", file as Blob);
+
+        const response = await uploadImage(newFormData);
+        if (response.ok && response.url) {
+          setProfilePhoto(response.url);
+          const updateResult = await updateUserInfo(
+            firstName,
+            lastName,
+            bio,
+            selectedRoles,
+            response.url,
+            user.id,
+          );
+          if (updateResult.success) {
+            toast.success("Profile photo updated successfully");
+          } else {
+            toast.error("Failed to update profile photo");
+          }
+        } else {
+          toast.error("Failed to upload image");
+        }
+      }
+    },
+    [firstName, lastName, bio, selectedRoles, user.id],
+  );
+
+  const { getRootProps, getInputProps } = useDropzone({
+    onDrop,
+    multiple: false,
+    onDragEnter: (e: React.DragEvent) => e.preventDefault(),
+    onDragOver: (e: React.DragEvent) => e.preventDefault(),
+    onDragLeave: (e: React.DragEvent) => e.preventDefault(),
+  });
+
   const handleUpdateUser = async (formData: FormData) => {
     await updateAuthorizedUser(formData);
   };
@@ -57,6 +103,7 @@ export function AuthorizedUserBlock({ user }: { user: AuthorizedUser }) {
       formData.get("lastName") as string,
       formData.get("bio") as string,
       selectedRoles,
+      formData.get("profilePhoto") as string,
       user.id,
     );
     if (result.success) {
@@ -72,13 +119,25 @@ export function AuthorizedUserBlock({ user }: { user: AuthorizedUser }) {
     <li className="py-0 [&:not(:first-child)]:pt-3">
       <div className="flex items-center space-x-4">
         <div className="flex-1 min-w-0">
-          <p className="font-medium truncate text-slate-900 dark:text-white">
-            {user.email}
-            {!user.isEnabled ? " (Disabled)" : ""}
-          </p>
-          <p className="text-sm truncate text-slate-500 dark:text-slate-400">
-            {isAdmin ? "Admin" : ""}
-          </p>
+          <div className="flex items-center space-x-3">
+            <Avatar variant="round" size="sm">
+              <AvatarImage src={user.profilePhoto || undefined} />
+              <AvatarFallback>
+                {user?.firstName ? (
+                  getInitials(user.firstName + user.lastName)
+                ) : (
+                  <User2Icon className="w-4 h-4" />
+                )}
+              </AvatarFallback>
+            </Avatar>
+            <p className="font-medium truncate text-slate-900 dark:text-white">
+              {user.email}
+              {!user.isEnabled ? " (Disabled)" : ""}
+            </p>
+            <p className="text-sm truncate text-slate-500 dark:text-slate-400">
+              {isAdmin ? "Admin" : ""}
+            </p>
+          </div>
         </div>
 
         <div className="inline-flex items-center gap-2">
@@ -99,9 +158,50 @@ export function AuthorizedUserBlock({ user }: { user: AuthorizedUser }) {
                 <DialogTitle>Edit User</DialogTitle>
                 <DialogDescription>Update user information</DialogDescription>
               </DialogHeader>
-
               <form action={handleEditUser} className="space-y-4">
                 <input type="hidden" name="id" value={user.id} />
+                <p>Profile Photo</p>
+                <div
+                  {...getRootProps()}
+                  className="border p-4 rounded-lg cursor-pointer text-center"
+                >
+                  <input {...getInputProps()} name="profilePhoto" />
+                  {profilePhoto ? (
+                    <div className="flex flex-col items-center gap-4">
+                      <img
+                        src={profilePhoto}
+                        alt="Profile"
+                        className="w-32 h-32 rounded-full object-cover mx-auto"
+                      />
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        size="sm"
+                        onClick={async (e) => {
+                          e.stopPropagation();
+                          const result = await updateUserInfo(
+                            firstName,
+                            lastName,
+                            bio,
+                            selectedRoles,
+                            "", // Empty string for profilePhoto
+                            user.id,
+                          );
+                          if (result.success) {
+                            setProfilePhoto("");
+                            toast.success("Profile photo removed successfully");
+                          } else {
+                            toast.error("Failed to remove profile photo");
+                          }
+                        }}
+                      >
+                        Remove Photo
+                      </Button>
+                    </div>
+                  ) : (
+                    <p>Drag & drop a photo here, or click to select one</p>
+                  )}
+                </div>
                 <Input
                   name="firstName"
                   value={firstName}

--- a/frontend/components/friends/blocked-users-block.tsx
+++ b/frontend/components/friends/blocked-users-block.tsx
@@ -1,56 +1,56 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { removeFriend } from "@/lib/requests/friends";
 import { AuthorizedUser } from "@/types";
 import { startTransition } from "react";
 import { toast } from "sonner";
+import { unblockUser } from "@/lib/requests/friends";
 import { UserBlock } from "./user-block";
 
-export function FriendBlock({
+export function BlockedUsersBlock({
   user,
-  friend,
+  blocked,
 }: {
   user: AuthorizedUser;
-  friend: AuthorizedUser;
+  blocked: AuthorizedUser;
 }) {
-  const handleRemove = () => {
+  const handleUnblock = () => {
     startTransition(async () => {
-      const result = await removeFriend(user.id, friend.id);
+      const result = await unblockUser(user.id, blocked.id);
       if (result.success) {
-        toast.success("Friend removed");
+        toast.success("User unblocked");
       } else {
-        toast.error("Failed to remove friend");
+        toast.error("Failed to unblock user");
       }
     });
   };
+
   return (
     <li className="py-0 [&:not(:first-child)]:pt-3">
       <div className="flex items-center space-x-4">
-        {friend.profilePhoto && (
+        {blocked.profilePhoto && (
           <img
-            src={friend.profilePhoto}
-            alt={`${friend.firstName}'s profile`}
+            src={blocked.profilePhoto}
+            alt={`${blocked.firstName}'s profile`}
             className="w-12 h-12 rounded-full object-cover"
           />
         )}
-
         <div className="flex-1 min-w-0">
           <p className="font-medium truncate text-slate-900 dark:text-white">
-            {friend.firstName && friend.lastName
-              ? `${friend.firstName} ${friend.lastName}`
-              : friend.email}
+            {blocked.firstName && blocked.lastName
+              ? `${blocked.firstName} ${blocked.lastName}`
+              : blocked.email}
           </p>
-          {friend.bio && (
+          {blocked.bio && (
             <p className="text-sm truncate text-slate-500 dark:text-slate-400">
-              {friend.bio}
+              {blocked.bio}
             </p>
           )}
         </div>
-        <UserBlock user={friend} curUser={user} />
-        <div className="inline-flex items-center gap-2" onClick={handleRemove}>
+        <UserBlock user={blocked} curUser={user} />
+        <div className="inline-flex items-center gap-2" onClick={handleUnblock}>
           <Button size="sm" variant="outline">
-            Remove Friend
+            Unblock
           </Button>
         </div>
       </div>

--- a/frontend/components/friends/blocked-users.tsx
+++ b/frontend/components/friends/blocked-users.tsx
@@ -1,34 +1,32 @@
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { FriendBlock } from "./friend-block";
 import { getCurrentUser } from "@/lib/auth/session";
 import { redirect } from "next/navigation";
-import { fetchFriends } from "@/lib/requests/friends";
+import { BlockedUsersBlock } from "./blocked-users-block";
 
-export async function Friends() {
+export async function BlockedUsers() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return redirect("/");
   const authUser = await getAuthorizedUserByEmail(user.email);
-
-  const friends = await fetchFriends(authUser);
+  const blockedUsers = authUser.blocked;
 
   return (
     <section>
-      <h1 className="font-bold">Friends</h1>
-      <p>A list of your friends.</p>
+      <h1 className="font-bold">Blocked Users</h1>
+      <p>A list of people you have blocked.</p>
 
       <div className="p-4 mt-4 rounded-md bg-slate-100">
-        {friends.length > 0 ? (
+        {blockedUsers.length > 0 ? (
           <ul className="divide-y divide-slate-200 dark:divide-slate-700 md:space-y-4">
-            {friends.map((friendship) => (
-              <FriendBlock
+            {blockedUsers.map((block) => (
+              <BlockedUsersBlock
                 user={authUser}
-                friend={friendship}
-                key={friendship.id}
+                blocked={block}
+                key={block.id}
               />
             ))}
           </ul>
         ) : (
-          <p>You have no friends &#58;&#40;</p>
+          <p>You have no blocked users</p>
         )}
       </div>
     </section>

--- a/frontend/components/friends/friend-completed-droplets-list.tsx
+++ b/frontend/components/friends/friend-completed-droplets-list.tsx
@@ -1,5 +1,4 @@
 import { Droplet } from "@/types";
-import Link from "next/link";
 import { DropletTile } from "../droplets/droplet-tile";
 
 export function FriendCompletedDropletsList({

--- a/frontend/components/friends/friend-request-block.tsx
+++ b/frontend/components/friends/friend-request-block.tsx
@@ -6,19 +6,10 @@ import {
   rejectFriendRequest,
 } from "@/lib/requests/friends";
 import { AuthorizedUser } from "@/types";
-import { Check, Github, Linkedin, X } from "lucide-react";
+import { Check, X } from "lucide-react";
 import { startTransition, useState } from "react";
 import { toast } from "sonner";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "../ui/dialog";
-import Link from "next/link";
-import { FriendCompletedDroplets } from "./friend-completed-droplets";
+import { UserBlock } from "./user-block";
 
 export function FriendRequestBlock({
   user,
@@ -27,7 +18,6 @@ export function FriendRequestBlock({
   user: AuthorizedUser;
   request: AuthorizedUser;
 }) {
-  const [open, setOpen] = useState(false);
   const handleApprove = () => {
     startTransition(async () => {
       const result = await acceptFriendRequest(user.id, request.id);
@@ -73,52 +63,7 @@ export function FriendRequestBlock({
             </p>
           )}
         </div>
-        <Dialog open={open} onOpenChange={setOpen}>
-          <DialogTrigger asChild>
-            <Button size="sm" variant="outline">
-              View Profile
-            </Button>
-          </DialogTrigger>
-
-          <DialogContent>
-            <DialogHeader>
-              {request.profilePhoto && (
-                <div className="flex justify-center items-center">
-                  <img
-                    src={request.profilePhoto}
-                    alt={`${request.firstName}'s profile`}
-                    className="w-12 h-12 rounded-full object-cover"
-                  />
-                </div>
-              )}
-              <DialogTitle style={{ fontSize: "2rem", textAlign: "center" }}>
-                {request.firstName} {request.lastName}
-              </DialogTitle>
-              <div className="flex justify-center space-x-2">
-                {request.linkedin && (
-                  <Link href={request.linkedin} legacyBehavior>
-                    <a target="_blank" rel="noopener noreferrer">
-                      <Linkedin />
-                    </a>
-                  </Link>
-                )}
-                {request.github && (
-                  <Link href={request.github} legacyBehavior>
-                    <a target="_blank" rel="noopener noreferrer">
-                      <Github />
-                    </a>
-                  </Link>
-                )}
-              </div>
-              <DialogDescription>Email: {request.email}</DialogDescription>
-              {request.bio && (
-                <DialogDescription>Bio: {request.bio}</DialogDescription>
-              )}
-              <DialogDescription>Completed Droplets: </DialogDescription>
-              <FriendCompletedDroplets friend={request} />
-            </DialogHeader>
-          </DialogContent>
-        </Dialog>
+        <UserBlock user={request} curUser={user} />
         <Button
           className="bg-green-600 text-white hover:bg-green-700"
           size="sm"

--- a/frontend/components/friends/friend-requests.tsx
+++ b/frontend/components/friends/friend-requests.tsx
@@ -7,7 +7,10 @@ export async function FriendRequests() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return redirect("/");
   const authUser = await getAuthorizedUserByEmail(user.email);
-  const friendRequests = authUser.received_requests;
+  const friendRequests = authUser.received_requests.filter(
+    (friend) =>
+      !authUser.blocked.some((blockedUser) => blockedUser.id === friend.id),
+  );
 
   return (
     <section>

--- a/frontend/components/friends/friend-requests.tsx
+++ b/frontend/components/friends/friend-requests.tsx
@@ -9,7 +9,8 @@ export async function FriendRequests() {
   const authUser = await getAuthorizedUserByEmail(user.email);
   const friendRequests = authUser.received_requests.filter(
     (friend) =>
-      !authUser.blocked.some((blockedUser) => blockedUser.id === friend.id),
+      !authUser.blocked.some((blockedUser) => blockedUser.id === friend.id) &&
+      !authUser.was_blocked.some((blockedUser) => blockedUser.id === friend.id),
   );
 
   return (

--- a/frontend/components/friends/friend-search.tsx
+++ b/frontend/components/friends/friend-search.tsx
@@ -36,6 +36,9 @@ export function FriendSearch({
     const filtered = authUsers.filter(
       (user) =>
         !curUser.blocked.some((blockedUser) => blockedUser.id === user.id) &&
+        !curUser.was_blocked.some(
+          (blockedUser) => blockedUser.id === user.id,
+        ) &&
         (user.firstName?.toLowerCase().includes(searchTerm.toLowerCase()) ||
           user.lastName?.toLowerCase().includes(searchTerm.toLowerCase()) ||
           user.email

--- a/frontend/components/friends/friend-search.tsx
+++ b/frontend/components/friends/friend-search.tsx
@@ -1,13 +1,9 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { SearchIcon } from "lucide-react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { ChangeEvent } from "react";
 import { AuthorizedUser } from "@/types";
-import { AuthorizedUserBlock } from "../admin/users/authorized-user";
 import { FriendSuggestionsBlock } from "./friend-suggestions-block";
 import { FriendBlock } from "./friend-block";
 
@@ -39,20 +35,19 @@ export function FriendSearch({
 
     const filtered = authUsers.filter(
       (user) =>
-        user.firstName?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        user.lastName?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        user.email
-          ?.split("@")[0]
-          .toLowerCase()
-          .includes(searchTerm.toLowerCase()) ||
-        (
-          user.firstName?.toLowerCase() +
-          " " +
-          user.lastName?.toLowerCase()
-        ).includes(searchTerm.toLowerCase()),
+        !curUser.blocked.some((blockedUser) => blockedUser.id === user.id) &&
+        (user.firstName?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          user.lastName?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          user.email
+            ?.split("@")[0]
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase()) ||
+          (
+            user.firstName?.toLowerCase() +
+            " " +
+            user.lastName?.toLowerCase()
+          ).includes(searchTerm.toLowerCase())),
     );
-
-    //console.log("number of auth users", authUsers)
 
     if (filtered?.length === 0) {
       setSearchResults([]);

--- a/frontend/components/friends/friend-sent-requests-block.tsx
+++ b/frontend/components/friends/friend-sent-requests-block.tsx
@@ -2,21 +2,11 @@
 
 import { Button } from "@/components/ui/button";
 import { AuthorizedUser } from "@/types";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "../ui/dialog";
 import { startTransition, useState } from "react";
-import { Avatar, AvatarFallback } from "../ui/avatar";
-import { getInitials } from "@/lib/utils";
-import Link from "next/link";
-import { Linkedin, Github, X } from "lucide-react";
+import { X } from "lucide-react";
 import { toast } from "sonner";
 import { cancelFriendRequest } from "@/lib/requests/friends";
+import { UserBlock } from "./user-block";
 
 export function FriendSentRequestsBlock({
   user,
@@ -59,51 +49,7 @@ export function FriendSentRequestsBlock({
             </p>
           )}
         </div>
-        <Dialog open={open} onOpenChange={setOpen}>
-          <DialogTrigger asChild>
-            <Button size="sm" variant="outline">
-              View Profile
-            </Button>
-          </DialogTrigger>
-
-          <DialogContent>
-            <DialogHeader>
-              {request.firstName && request.lastName ? (
-                <div className="flex justify-center items-center">
-                  <Avatar variant="round" size="lg">
-                    <AvatarFallback className="text-3xl">
-                      {getInitials(request.firstName + " " + request.lastName)}
-                    </AvatarFallback>
-                  </Avatar>
-                </div>
-              ) : null}
-              <DialogTitle style={{ fontSize: "2rem", textAlign: "center" }}>
-                {request.firstName} {request.lastName}
-              </DialogTitle>
-              <div className="flex justify-center space-x-2">
-                {request.linkedin && (
-                  <Link href={request.linkedin} legacyBehavior>
-                    <a target="_blank" rel="noopener noreferrer">
-                      <Linkedin />
-                    </a>
-                  </Link>
-                )}
-                {request.github && (
-                  <Link href={request.github} legacyBehavior>
-                    <a target="_blank" rel="noopener noreferrer">
-                      <Github />
-                    </a>
-                  </Link>
-                )}
-              </div>
-              <DialogDescription>Email: {request.email}</DialogDescription>
-              {request.bio && (
-                <DialogDescription>Bio: {request.bio}</DialogDescription>
-              )}
-              <DialogDescription>Completed Droplets: </DialogDescription>
-            </DialogHeader>
-          </DialogContent>
-        </Dialog>
+        <UserBlock user={request} curUser={user} />
         <Button variant="destructive" size="sm" onClick={handleReject}>
           <div className="relative group">
             <X />

--- a/frontend/components/friends/friend-sent-requests.tsx
+++ b/frontend/components/friends/friend-sent-requests.tsx
@@ -7,7 +7,10 @@ export async function FriendSentRequests() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return redirect("/");
   const authUser = await getAuthorizedUserByEmail(user.email);
-  const sentRequests = authUser.sent_requests;
+  const sentRequests = authUser.sent_requests.filter(
+    (friend) =>
+      !authUser.blocked.some((blockedUser) => blockedUser.id === friend.id),
+  );
 
   return (
     <section>

--- a/frontend/components/friends/friend-sent-requests.tsx
+++ b/frontend/components/friends/friend-sent-requests.tsx
@@ -9,7 +9,8 @@ export async function FriendSentRequests() {
   const authUser = await getAuthorizedUserByEmail(user.email);
   const sentRequests = authUser.sent_requests.filter(
     (friend) =>
-      !authUser.blocked.some((blockedUser) => blockedUser.id === friend.id),
+      !authUser.blocked.some((blockedUser) => blockedUser.id === friend.id) &&
+      !authUser.was_blocked.some((blockedUser) => blockedUser.id === friend.id),
   );
 
   return (

--- a/frontend/components/friends/friend-suggestions-block.tsx
+++ b/frontend/components/friends/friend-suggestions-block.tsx
@@ -3,19 +3,10 @@
 import { Button } from "@/components/ui/button";
 import { AuthorizedUser } from "@/types";
 import { useState } from "react";
-import {
-  DialogHeader,
-  Dialog,
-  DialogTrigger,
-  DialogContent,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
 import { toast } from "sonner";
-import Link from "next/link";
-import { startTransition, useEffect } from "react";
-import { sendFriendRequest, getSentRequest } from "@/lib/requests/friends";
-import { Github, Linkedin } from "lucide-react";
+import { startTransition } from "react";
+import { sendFriendRequest } from "@/lib/requests/friends";
+import { UserBlock } from "./user-block";
 
 export function FriendSuggestionsBlock({
   suggUser,
@@ -66,42 +57,7 @@ export function FriendSuggestionsBlock({
             </p>
           </div>
 
-          <Dialog open={open} onOpenChange={setOpen}>
-            <DialogTrigger asChild>
-              <Button size="sm" variant="outline">
-                View Profile
-              </Button>
-            </DialogTrigger>
-
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle style={{ fontSize: "2rem", textAlign: "center" }}>
-                  {suggUser.firstName} {suggUser.lastName}
-                </DialogTitle>
-                <div className="flex justify-center space-x-2">
-                  {suggUser.linkedin && (
-                    <Link href={suggUser.linkedin} legacyBehavior>
-                      <a target="_blank" rel="noopener noreferrer">
-                        <Linkedin />
-                      </a>
-                    </Link>
-                  )}
-                  {suggUser.github && (
-                    <Link href={suggUser.github} legacyBehavior>
-                      <a target="_blank" rel="noopener noreferrer">
-                        <Github />
-                      </a>
-                    </Link>
-                  )}
-                </div>
-                <DialogDescription>Email: {suggUser.email}</DialogDescription>
-                {suggUser.bio && (
-                  <DialogDescription>Bio: {suggUser.bio}</DialogDescription>
-                )}
-                <DialogDescription>Completed Droplets: </DialogDescription>
-              </DialogHeader>
-            </DialogContent>
-          </Dialog>
+          <UserBlock user={suggUser} curUser={curUser} />
 
           <div className="inline-flex items-center gap-2">
             <Button

--- a/frontend/components/friends/user-block.tsx
+++ b/frontend/components/friends/user-block.tsx
@@ -1,0 +1,90 @@
+import { AuthorizedUser } from "@/types";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../ui/dialog";
+import { Button } from "../ui/button";
+import Link from "next/link";
+import { Github, Linkedin } from "lucide-react";
+import { FriendCompletedDroplets } from "./friend-completed-droplets";
+import { startTransition, useState } from "react";
+import { toast } from "sonner";
+import { BlockUser } from "@/lib/requests/friends";
+
+export function UserBlock({
+  user,
+  curUser,
+}: {
+  user: AuthorizedUser;
+  curUser: AuthorizedUser;
+}) {
+  const [open, setOpen] = useState(false);
+  const handleBlock = () => {
+    startTransition(async () => {
+      const result = await BlockUser(curUser.id, user.id);
+      if (result.success) {
+        toast.success("User blocked");
+      } else {
+        toast.error("Failed to block user");
+      }
+    });
+  };
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline">
+          View Profile
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          {user.profilePhoto && (
+            <div className="flex justify-center items-center">
+              <img
+                src={user.profilePhoto}
+                alt={`${user.firstName}'s profile`}
+                className="w-12 h-12 rounded-full object-cover"
+              />
+            </div>
+          )}
+          <DialogTitle style={{ fontSize: "2rem", textAlign: "center" }}>
+            {user.firstName} {user.lastName}
+          </DialogTitle>
+          <div className="flex justify-center space-x-2">
+            {user.linkedin && (
+              <Link href={user.linkedin} legacyBehavior>
+                <a target="_blank" rel="noopener noreferrer">
+                  <Linkedin />
+                </a>
+              </Link>
+            )}
+            {user.github && (
+              <Link href={user.github} legacyBehavior>
+                <a target="_blank" rel="noopener noreferrer">
+                  <Github />
+                </a>
+              </Link>
+            )}
+          </div>
+          <DialogDescription>Email: {user.email}</DialogDescription>
+          {user.bio && <DialogDescription>Bio: {user.bio}</DialogDescription>}
+          <DialogDescription>Completed Droplets: </DialogDescription>
+          <FriendCompletedDroplets friend={user} />
+          <div
+            className={`inline-flex items-center gap-2 ${curUser.blocked.includes(user) ? "visibility: hidden" : "visibility: visible"}`}
+            onClick={handleBlock}
+          >
+            <Button size="sm" variant="destructive">
+              Block user
+            </Button>
+          </div>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/lib/actions.ts
+++ b/frontend/lib/actions.ts
@@ -26,6 +26,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { v4 as uuidv4 } from "uuid";
 import { Buffer } from "node:buffer";
+import { GroupSchema } from "./validations/group";
 
 const STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -611,6 +612,7 @@ export async function updateUserInfo(
   last: string | null,
   bio: string | null,
   roles: AuthorizedUserRoleTitle[],
+  profilePhoto: string | null,
   userId: number,
 ) {
   try {
@@ -631,6 +633,7 @@ export async function updateUserInfo(
             firstName: first,
             lastName: last,
             bio: bio,
+            profilePhoto: profilePhoto,
             roles: {
               set: roleIds.map((id) => ({ id })),
             },
@@ -639,12 +642,13 @@ export async function updateUserInfo(
       },
     );
 
-    if (!response.ok) {
-      throw new Error("Failed to update first time status");
-    }
+    // if (!response.ok) {
+    //   throw new Error("Failed to update user info");
+    // }
+    revalidatePath("/admin");
     return { success: true };
   } catch (error) {
-    console.error("Error updating first time status:", error);
+    console.error("Error updating user info:", error);
     return { success: false, error };
   }
 }

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -26,6 +26,12 @@ export async function getAuthorizedUserByEmail<
       sent_requests: {
         fields: ["id", "email", "firstName", "lastName", "bio", "profilePhoto"],
       },
+      blocked: {
+        fields: ["id", "email", "firstName", "lastName", "bio", "profilePhoto"],
+      },
+      was_blocked: {
+        fields: ["id", "email", "firstName", "lastName", "bio", "profilePhoto"],
+      },
     },
     fields = ["*", "firstName", "lastName", "bio", "id"],
   }: StrapiRequestParams = {},

--- a/frontend/lib/requests/data.ts
+++ b/frontend/lib/requests/data.ts
@@ -30,6 +30,52 @@ export async function fetchDroplets() {
   }
 }
 
+export async function fetchGroups() {
+  try {
+    const query = qs.stringify({
+      sort: ["groupName:asc"],
+      fields: ["id", "groupName", "slug", "isArchived"],
+      populate: {
+        members: {
+          fields: ["id", "email"],
+        },
+        admins: {
+          fields: ["id", "email"],
+        },
+        managers: {
+          fields: ["id", "email"],
+        },
+        creator: {
+          fields: ["id", "email"],
+        },
+      },
+      pagination: {
+        pageSize: 25,
+        page: 1,
+      },
+    });
+
+    const response = await fetch(
+      `${NEXT_PUBLIC_STRAPI_API_URL}/api/groups?${query}`,
+      {
+        headers: { Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}` },
+        cache: "no-store",
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch groups");
+    }
+
+    const data = await response.json();
+    const groups = flattenAttributes(data.data);
+    return groups;
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch groups.");
+  }
+}
+
 export async function fetchAccessRequests() {
   try {
     const query = qs.stringify({

--- a/frontend/lib/requests/friends.ts
+++ b/frontend/lib/requests/friends.ts
@@ -28,11 +28,18 @@ export async function fetchFriends(
             "firstName",
             "lastName",
             "bio",
-            "received_requests",
             "github",
             "linkedin",
             "profilePhoto",
           ],
+          populate: {
+            blocked: {
+              fields: ["id"],
+            },
+            was_blocked: {
+              fields: ["id"],
+            },
+          },
         },
       },
       pagination: {
@@ -53,7 +60,11 @@ export async function fetchFriends(
 
     return friendships.flatMap((friendship: Friendship) =>
       friendship.authorized_users.filter(
-        (friend) => friend.id !== authorizedUser.id,
+        (friend) =>
+          friend.id !== authorizedUser.id &&
+          !authorizedUser.blocked.some(
+            (blockedUser) => blockedUser.id === friend.id,
+          ),
       ),
     );
   } catch (error) {
@@ -315,6 +326,72 @@ export async function cancelFriendRequest(userId: number, requestId: number) {
   }
 }
 
+export async function unblockUser(userId: number, requestId: number) {
+  const token = process.env.STRAPI_ACCESS_TOKEN;
+  try {
+    const deleteResponse = await fetch(
+      `${NEXT_PUBLIC_STRAPI_API_URL}/api/authorized-users/${userId}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer " + STRAPI_ACCESS_TOKEN,
+        },
+        body: JSON.stringify({
+          data: {
+            blocked: {
+              disconnect: [requestId],
+            },
+          },
+        }),
+      },
+    );
+
+    if (!deleteResponse.ok) {
+      console.error("Delete Response:", await deleteResponse.text());
+      throw new Error("Failed to unblock user");
+    }
+    revalidatePath("/settings/friends");
+    return { success: true };
+  } catch (error) {
+    console.error("Error:", error);
+    return { success: false, error };
+  }
+}
+
+export async function BlockUser(userId: number, requestId: number) {
+  const token = process.env.STRAPI_ACCESS_TOKEN;
+  try {
+    const deleteResponse = await fetch(
+      `${NEXT_PUBLIC_STRAPI_API_URL}/api/authorized-users/${userId}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer " + STRAPI_ACCESS_TOKEN,
+        },
+        body: JSON.stringify({
+          data: {
+            blocked: {
+              connect: [requestId],
+            },
+          },
+        }),
+      },
+    );
+
+    if (!deleteResponse.ok) {
+      console.error("Delete Response:", await deleteResponse.text());
+      throw new Error("Failed to block user");
+    }
+    revalidatePath("/settings/friends");
+    return { success: true };
+  } catch (error) {
+    console.error("Error:", error);
+    return { success: false, error };
+  }
+}
+
 export async function removeFriend(userId: number, friendId: number) {
   const token = process.env.STRAPI_ACCESS_TOKEN;
   try {
@@ -405,6 +482,14 @@ export async function fetchFriendshipsById(
             "linkedin",
             "profilePhoto",
           ],
+          populate: {
+            blocked: {
+              fields: ["id"],
+            },
+            was_blocked: {
+              fields: ["id"],
+            },
+          },
         },
       },
       pagination: {
@@ -437,7 +522,13 @@ export async function fetchSuggestionsById(
 
     // Get all direct friends (AuthorizedUsers that aren't the userId)
     const directFriends = userFriendships.flatMap((friendship) =>
-      friendship.authorized_users.filter((user) => user.id !== userId),
+      friendship.authorized_users.filter(
+        (user) =>
+          user.id !== userId &&
+          !user.was_blocked.some(
+            (blockedUser: AuthorizedUser) => blockedUser.id === userId,
+          ),
+      ),
     );
 
     // Get all friends of friends
@@ -449,7 +540,12 @@ export async function fetchSuggestionsById(
         // Return all users from these friendships except the direct friend and original user
         return friendFriendships.flatMap((friendship) =>
           friendship.authorized_users.filter(
-            (user) => user.id !== friend.id && user.id !== userId,
+            (user) =>
+              user.id !== friend.id &&
+              user.id !== userId &&
+              !user.was_blocked.some(
+                (blockedUser: AuthorizedUser) => blockedUser.id === userId,
+              ),
           ),
         );
       }),

--- a/frontend/lib/requests/friends.ts
+++ b/frontend/lib/requests/friends.ts
@@ -62,6 +62,9 @@ export async function fetchFriends(
       friendship.authorized_users.filter(
         (friend) =>
           friend.id !== authorizedUser.id &&
+          !authorizedUser.was_blocked.some(
+            (blockedUser) => blockedUser.id === friend.id,
+          ) &&
           !authorizedUser.blocked.some(
             (blockedUser) => blockedUser.id === friend.id,
           ),
@@ -525,8 +528,12 @@ export async function fetchSuggestionsById(
       friendship.authorized_users.filter(
         (user) =>
           user.id !== userId &&
-          !user.was_blocked.some(
-            (blockedUser: AuthorizedUser) => blockedUser.id === userId,
+          !user.blocked.some(
+            (blockedUser: AuthorizedUser) =>
+              blockedUser.id === userId &&
+              !user.was_blocked.some(
+                (blockedUser: AuthorizedUser) => blockedUser.id === userId,
+              ),
           ),
       ),
     );

--- a/frontend/lib/requests/groups.ts
+++ b/frontend/lib/requests/groups.ts
@@ -11,6 +11,7 @@ import { getAuthorizedUserRoleIdByTitle } from "./authorized-user-roles";
 import { createEnrollmentFromEmail } from "@/lib/actions";
 import { getEnrollmentsByAuthorizedUser } from "./enrollment";
 import { createEnrollment } from "@/lib/actions";
+import { revalidatePath } from "next/cache";
 const STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
 /**
@@ -433,6 +434,7 @@ export async function updateGroup(
     groupName?: string;
     description?: string;
     semester?: string;
+    isArchived?: boolean;
     admins?: number[];
     managers?: number[];
     members?: Array<{
@@ -479,6 +481,7 @@ export async function updateGroup(
   if (data.groupName) dataToSend.groupName = data.groupName;
   if (data.description) dataToSend.description = data.description;
   if (data.semester) dataToSend.semester = data.semester;
+  if (data.isArchived !== undefined) dataToSend.isArchived = data.isArchived;
 
   // Handle admins and managers
   if (data.admins) {
@@ -523,6 +526,7 @@ export async function updateGroup(
   }
 
   console.log("  --> updateGroup dataToSend = ", JSON.stringify(dataToSend));
+  revalidatePath("/admin");
 
   return await fetchAPI<Group>(path, {
     options: {

--- a/frontend/lib/validations/group.ts
+++ b/frontend/lib/validations/group.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const GroupSchema = z.object({
+  id: z.number(),
+  groupName: z.string().min(1, "Group name is required"),
+  description: z.string().optional(),
+  semester: z.string().optional(),
+  isArchived: z.boolean().optional().default(false),
+  slug: z.string().optional(),
+  members: z.array(z.any()).optional(),
+  admins: z.array(z.number()).optional(),
+  managers: z.array(z.number()).optional(),
+  droplets: z.array(z.any()).optional(),
+  playlists: z.array(z.any()).optional(),
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10880,7 +10880,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.1.0.tgz",
       "integrity": "sha512-6QtbTRDKM+jA/MZTTefvigNxo0zz+gnBTVFw2CFVvq+f2BuH0nF0vDLNClL045nuTAdOoK/IL1vTP0ZLX0DAyQ==",
-      "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
         "prop-types": "^15.5.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -66,6 +66,7 @@
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.2.0",
+        "react-dropzone": "^14.3.5",
         "react-hook-form": "^7.51.2",
         "react-tabs": "^6.1.0",
         "sonner": "^1.4.41",
@@ -6197,6 +6198,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -7895,6 +7905,18 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fill-range": {
@@ -10752,6 +10774,23 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-dropzone": {
+      "version": "14.3.5",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.5.tgz",
+      "integrity": "sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-hook-form": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.2.0",
+    "react-dropzone": "^14.3.5",
     "react-hook-form": "^7.51.2",
     "react-tabs": "^6.1.0",
     "sonner": "^1.4.41",

--- a/frontend/types/index.d.ts
+++ b/frontend/types/index.d.ts
@@ -41,6 +41,8 @@ export type AuthorizedUser = {
   sent_requests: AuthorizedUser[];
   received_requests: AuthorizedUser[];
   profilePhoto: string;
+  blocked: AuthorizedUser[];
+  was_blocked: AuthorizedUser[];
 };
 
 export type Media = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next": "^15.1.3",
         "npm-check-updates": "^16.14.15",
         "react-confetti": "^6.2.2",
+        "react-dropzone": "^14.3.5",
         "react-tabs": "^6.1.0"
       },
       "devDependencies": {
@@ -4179,6 +4180,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5123,6 +5132,17 @@
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fill-range": {
@@ -7559,6 +7579,22 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-dropzone": {
+      "version": "14.3.5",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.5.tgz",
+      "integrity": "sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7571,7 +7571,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.1.0.tgz",
       "integrity": "sha512-6QtbTRDKM+jA/MZTTefvigNxo0zz+gnBTVFw2CFVvq+f2BuH0nF0vDLNClL045nuTAdOoK/IL1vTP0ZLX0DAyQ==",
-      "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
         "prop-types": "^15.5.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next": "^15.1.3",
     "npm-check-updates": "^16.14.15",
     "react-confetti": "^6.2.2",
+    "react-dropzone": "^14.3.5",
     "react-tabs": "^6.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "install": "^0.13.0",
     "next": "^15.1.3",
     "npm-check-updates": "^16.14.15",
-    "react-tabs": "^6.1.0",
-    "react-confetti": "^6.2.2"
+    "react-confetti": "^6.2.2",
+    "react-tabs": "^6.1.0"
   },
   "devDependencies": {
     "@types/canvas-confetti": "^1.9.0",


### PR DESCRIPTION
Users can now block other users on the friends page. When a user blocks another user, they can't see that other user in the search bar or in any of the tabs on the friends page. That blocked user only shows up in the 'blocked users' tab. In that tab, users can unblock users that they had previously blocked. To block a user, click on the 'block' button on a user's popup profile. Also, if someone else blocks you, you can't see their profile at all until they unblock you.

This PR also includes admin functionality for groups. In the admin tab, admins can view all groups and can press the pencil icon to edit specific groups.