### PR TITLE
added default callout and ability to toggle icon + prettier

### DIFF
--- a/backend/src/components/droplets/callout.json
+++ b/backend/src/components/droplets/callout.json
@@ -24,6 +24,10 @@
       "type": "string",
       "default": "bg-sky-50",
       "required": true
+    },
+    "iconEnabled": {
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -11,7 +11,7 @@
       "url": "https://khouryodyssey.org"
     },
     "license": null,
-    "x-generation-date": "2025-02-14T20:21:06.156Z"
+    "x-generation-date": "2025-02-17T16:17:45.616Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -1588,6 +1588,9 @@
                                                                                       },
                                                                                       "color": {
                                                                                         "type": "string"
+                                                                                      },
+                                                                                      "iconEnabled": {
+                                                                                        "type": "boolean"
                                                                                       }
                                                                                     }
                                                                                   },
@@ -4815,6 +4818,9 @@
                                                                                         },
                                                                                         "color": {
                                                                                           "type": "string"
+                                                                                        },
+                                                                                        "iconEnabled": {
+                                                                                          "type": "boolean"
                                                                                         }
                                                                                       }
                                                                                     },
@@ -7994,6 +8000,9 @@
                                                             },
                                                             "color": {
                                                               "type": "string"
+                                                            },
+                                                            "iconEnabled": {
+                                                              "type": "boolean"
                                                             }
                                                           }
                                                         },
@@ -11300,6 +11309,9 @@
                                                                           },
                                                                           "color": {
                                                                             "type": "string"
+                                                                          },
+                                                                          "iconEnabled": {
+                                                                            "type": "boolean"
                                                                           }
                                                                         }
                                                                       },
@@ -14452,6 +14464,9 @@
                                                               },
                                                               "color": {
                                                                 "type": "string"
+                                                              },
+                                                              "iconEnabled": {
+                                                                "type": "boolean"
                                                               }
                                                             }
                                                           },
@@ -17750,6 +17765,9 @@
                                                                                       },
                                                                                       "color": {
                                                                                         "type": "string"
+                                                                                      },
+                                                                                      "iconEnabled": {
+                                                                                        "type": "boolean"
                                                                                       }
                                                                                     }
                                                                                   },
@@ -20748,6 +20766,9 @@
                                                                         },
                                                                         "color": {
                                                                           "type": "string"
+                                                                        },
+                                                                        "iconEnabled": {
+                                                                          "type": "boolean"
                                                                         }
                                                                       }
                                                                     },
@@ -23797,6 +23818,9 @@
                                                                           },
                                                                           "color": {
                                                                             "type": "string"
+                                                                          },
+                                                                          "iconEnabled": {
+                                                                            "type": "boolean"
                                                                           }
                                                                         }
                                                                       },
@@ -26906,6 +26930,9 @@
                                                                           },
                                                                           "color": {
                                                                             "type": "string"
+                                                                          },
+                                                                          "iconEnabled": {
+                                                                            "type": "boolean"
                                                                           }
                                                                         }
                                                                       },
@@ -30065,6 +30092,9 @@
                                                                         },
                                                                         "color": {
                                                                           "type": "string"
+                                                                        },
+                                                                        "iconEnabled": {
+                                                                          "type": "boolean"
                                                                         }
                                                                       }
                                                                     },
@@ -33275,6 +33305,9 @@
                                                                                         },
                                                                                         "color": {
                                                                                           "type": "string"
+                                                                                        },
+                                                                                        "iconEnabled": {
+                                                                                          "type": "boolean"
                                                                                         }
                                                                                       }
                                                                                     },
@@ -35482,6 +35515,9 @@
           },
           "color": {
             "type": "string"
+          },
+          "iconEnabled": {
+            "type": "boolean"
           }
         }
       },
@@ -35745,6 +35781,9 @@
                                 },
                                 "color": {
                                   "type": "string"
+                                },
+                                "iconEnabled": {
+                                  "type": "boolean"
                                 }
                               }
                             },
@@ -39618,6 +39657,9 @@
                                                                                         },
                                                                                         "color": {
                                                                                           "type": "string"
+                                                                                        },
+                                                                                        "iconEnabled": {
+                                                                                          "type": "boolean"
                                                                                         }
                                                                                       }
                                                                                     },
@@ -43152,6 +43194,9 @@
                                                                                         },
                                                                                         "color": {
                                                                                           "type": "string"
+                                                                                        },
+                                                                                        "iconEnabled": {
+                                                                                          "type": "boolean"
                                                                                         }
                                                                                       }
                                                                                     },
@@ -45392,8 +45437,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -45898,8 +45942,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -46404,8 +46447,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -46910,8 +46952,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -47416,8 +47457,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -47922,8 +47962,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -48428,8 +48467,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -48934,8 +48972,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -49440,8 +49477,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -49946,8 +49982,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -50452,8 +50487,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -50958,8 +50992,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -51464,8 +51497,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -51970,8 +52002,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -52476,8 +52507,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },
@@ -52982,8 +53012,7 @@
             "deprecated": false,
             "required": false,
             "schema": {
-              "type": "object",
-              "additionalProperties": true
+              "type": "object"
             },
             "style": "deepObject"
           },

--- a/backend/types/generated/components.d.ts
+++ b/backend/types/generated/components.d.ts
@@ -15,6 +15,7 @@ export interface DropletsCallout extends Schema.Component {
     color: Attribute.String &
       Attribute.Required &
       Attribute.DefaultTo<'bg-sky-50'>;
+    iconEnabled: Attribute.Boolean & Attribute.DefaultTo<true>;
   };
 }
 

--- a/frontend/components/draft/lesson/add-block.tsx
+++ b/frontend/components/draft/lesson/add-block.tsx
@@ -230,10 +230,32 @@ export function AddBlock({ add }: { add: (block: any) => void }) {
                     });
                   }}
                   variant={dropdownVariants}
-                  className="w-full border border-slate-200 bg-amber-300"
+                  className="w-full border border-slate-200 bg-amber-300 mb-1"
                 >
                   Caution
                   {<CalloutIcon color={"bg-amber-300"}></CalloutIcon>}
+                </Button>
+                <Button
+                  onClick={(e) => {
+                    setOpen(false);
+                    e.preventDefault();
+                    add({
+                      __component: "droplets.callout",
+                      content: [
+                        {
+                          type: "paragraph",
+                          children: [{ type: "text", text: "" }],
+                        },
+                      ],
+                      color: "bg-sky-50",
+                      type: "info",
+                    });
+                  }}
+                  variant={dropdownVariants}
+                  className="w-full border border-slate-200 bg-sky-50"
+                >
+                  Default
+                  {<CalloutIcon color={"bg-sky-50"}></CalloutIcon>}
                 </Button>
               </div>
             </PopoverContent>

--- a/frontend/components/draft/lesson/blocks/callout.tsx
+++ b/frontend/components/draft/lesson/blocks/callout.tsx
@@ -5,7 +5,7 @@ import { revalidateLesson } from "@/lib/actions";
 import { strapiJSONToTiptapJSON, tiptapJSONToStrapiJSON } from "@/lib/utils";
 import { useCallback } from "react";
 import { debounce } from "lodash";
-import { Trash2Icon } from "lucide-react";
+import { Trash2Icon, Ban } from "lucide-react";
 import { CalloutBlockInput } from "@/components/ui/tiptap/callout-block-input";
 import { useState, useEffect } from "react";
 import CalloutTypeTool from "@/components/ui/tiptap/toolbar/tools/callout-type-tool";
@@ -21,6 +21,7 @@ export function CalloutEditor({
   updateBlock: (block: any) => void;
   deleteBlock: () => void;
 }) {
+  const [iconEnabled, setIconEnabled] = useState(block.iconEnabled);
   const handleUpdate = useCallback((content: any) => {
     console.log(" --> callout.tsx: handleUpdate useCallback handler");
     let temp: any = JSON.parse(
@@ -36,6 +37,17 @@ export function CalloutEditor({
 
   const debounceUpdate = useCallback(debounce(handleUpdate, 1000), []);
 
+  const handleToggleIcon = () => {
+    updateBlock({
+      __component: "droplets.callout",
+      content: block.content,
+      type: "info",
+      color: block.color,
+      iconEnabled: !iconEnabled,
+    });
+    setIconEnabled(!iconEnabled);
+  };
+
   return (
     <>
       <div
@@ -45,14 +57,25 @@ export function CalloutEditor({
           className={`w-full flex flex-row  mb-4 justify-between items-center`}
         >
           <div className="flex flex-row items-center">
-            <h2 className="text-lg font-bold text-white mr-3">Callout Block</h2>
-            <CalloutIcon color={block.color || "bg-sky-300"}></CalloutIcon>
+            <h2 className="text-lg font-bold text-black mr-3">Callout Block</h2>
+            {!block.color.includes("sky") && (
+              <div className="relative">
+                <Button variant="transparent" onClick={handleToggleIcon}>
+                  <CalloutIcon
+                    color={block.color || "bg-sky-300"}
+                  ></CalloutIcon>
+                  {!iconEnabled && (
+                    <Ban className="absolute top-0 left-0 w-full h-full text-red-500" />
+                  )}
+                </Button>
+              </div>
+            )}
           </div>
           <div className="flex flex-row items-center">
             <CalloutTypeTool block={block} updateBlock={updateBlock} />
 
             <Trash2Icon
-              className="cursor-pointer text-white"
+              className="cursor-pointer text-black"
               onClick={deleteBlock}
               size={30}
             />

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -297,9 +297,11 @@ function LessonBlockRenderer({
         <div
           className={`flex flex-row items-center px-6 py-6 border rounded-md md:-mx-8 ${block.color || "bg-sky-50"}`}
         >
-          <div className="">
-            <CalloutIcon color={block.color || "bg-sky-300"}></CalloutIcon>
-          </div>
+          {block.iconEnabled && (
+            <div className="">
+              <CalloutIcon color={block.color || "bg-sky-300"}></CalloutIcon>
+            </div>
+          )}
           <div className="">
             <div className="pl-8 mx-auto prose prose-sky text-center">
               <BlocksRenderer content={block.content} />

--- a/frontend/components/ui/callout-icons.tsx
+++ b/frontend/components/ui/callout-icons.tsx
@@ -1,5 +1,4 @@
 import {
-  LockIcon,
   CircleAlert,
   CircleHelp,
   TriangleAlert,
@@ -10,7 +9,7 @@ import {
 
 export function CalloutIcon({ color }: { color: string }) {
   return (() => {
-    const iconStyle = "text-white";
+    const iconStyle = "text-black";
     switch (color.split("-")[1]) {
       case "red":
         return <TriangleAlert className={iconStyle} strokeWidth={2.5} />;
@@ -22,8 +21,10 @@ export function CalloutIcon({ color }: { color: string }) {
         return <BookOpenText className={iconStyle} strokeWidth={2.5} />;
       case "purple":
         return <BadgeInfo className={iconStyle} strokeWidth={2.5} />;
-      default:
+      case "amber":
         return <Bell className={iconStyle} strokeWidth={2.5} />;
+      default:
+        return <div />;
     }
   })();
 }

--- a/frontend/components/ui/tiptap/toolbar/tools/callout-type-tool.tsx
+++ b/frontend/components/ui/tiptap/toolbar/tools/callout-type-tool.tsx
@@ -47,7 +47,7 @@ export default function CalloutTypeTool({
             "p-2.5 rounded-md border border-transparent",
           )}
         >
-          <Menu color="#ffffff" />
+          <Menu color="#000000" />
         </button>
       </PopoverTrigger>
       <PopoverContent>
@@ -153,6 +153,23 @@ export default function CalloutTypeTool({
           >
             Caution
             {<CalloutIcon color={"bg-amber-300"}></CalloutIcon>}
+          </Button>
+          <Button
+            onClick={(e) => {
+              setOpen(false);
+              e.preventDefault();
+              updateBlock({
+                __component: "droplets.callout",
+                content: block.content,
+                type: "info",
+                color: "bg-sky-50",
+              });
+            }}
+            variant={dropdownVariants}
+            className="bg-sky-50 w-full border border-slate-200"
+          >
+            Default
+            {<CalloutIcon color={"bg-sky-50"}></CalloutIcon>}
           </Button>
         </div>
       </PopoverContent>


### PR DESCRIPTION
Added a default callout option to the editor with basic bg-sky-50 and no icon. This helps support old droplets that used these callouts. Also added the ability to click the icon in callout editor to toggle its visibility in the droplet.