### PR TITLE
Fixed content creation bug with add block button

### DIFF
--- a/frontend/components/draft/lesson/draggable_block_list_client.tsx
+++ b/frontend/components/draft/lesson/draggable_block_list_client.tsx
@@ -32,7 +32,7 @@ export function DraggableBlockListClient({
       <div className="grid grid-cols-1 space-y-8">
         {blocks.map((block, index) => (
           <div
-            key={`${block.__component}-${index}`}
+            key={`${block.__component}-${index}-${blocks.length}`}
             className="flex w-full flex-col items-center justify-center"
           >
             <AddBlock add={addBlock(index)} />


### PR DESCRIPTION
Bug: adding or deleting blocks in the content creation portal wouldn't accurately reflect the true state after the change and would need to be refreshed to be correct
Solution: added blocks.length to droplet editor block list to trigger re-renders on block changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the way blocks are identified in the lesson draft editor to enhance rendering consistency.

* **Chores**
  * Updated documentation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->