### PR TITLE
Feature/droplet tile changes

### DIFF
--- a/frontend/app/(general)/features/page.tsx
+++ b/frontend/app/(general)/features/page.tsx
@@ -23,7 +23,9 @@ export default async function FeaturesPage() {
 
   return (
     <GradientBackground className="flex-grow">
-      <StaggeredGallery gallery={gallery} />
+      <div className="max-w-7xl mx-auto">
+        <StaggeredGallery gallery={gallery} />
+      </div>
     </GradientBackground>
   );
 }

--- a/frontend/app/(general)/features/page.tsx
+++ b/frontend/app/(general)/features/page.tsx
@@ -23,7 +23,7 @@ export default async function FeaturesPage() {
 
   return (
     <GradientBackground className="flex-grow">
-      <div className="max-w-7xl mx-auto">
+      <div className="mx-auto max-w-7xl">
         <StaggeredGallery gallery={gallery} />
       </div>
     </GradientBackground>

--- a/frontend/app/(general)/feed/page.tsx
+++ b/frontend/app/(general)/feed/page.tsx
@@ -23,7 +23,7 @@ export default async function FeedPage() {
           Check out what&apos;s happening right now
         </p>
       </div>
-      <div className="w-full px-4 sm:px-16 max-w-7xl mx-auto">
+      <div className="mx-auto w-full max-w-7xl px-4 sm:px-16">
         <FeedContainer authUser={authUser} />
       </div>
     </>

--- a/frontend/app/(general)/feed/page.tsx
+++ b/frontend/app/(general)/feed/page.tsx
@@ -23,7 +23,7 @@ export default async function FeedPage() {
           Check out what&apos;s happening right now
         </p>
       </div>
-      <div className="w-full px-4 sm:px-16">
+      <div className="w-full px-4 sm:px-16 max-w-7xl mx-auto">
         <FeedContainer authUser={authUser} />
       </div>
     </>

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -35,6 +35,7 @@ export function DropletTile({
   dueDate,
 }: DropletTileProps) {
   const [averageRating, setAverageRating] = useState<number>(0);
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
 
   const dropletLessonIds = droplet.lessons?.map((l) => l.id) || [];
   const completedLessonsInDroplet = completedLessonIds.filter((id) =>
@@ -43,8 +44,8 @@ export function DropletTile({
   const completionPercentage =
     dropletLessonIds.length > 0
       ? Math.round(
-          (completedLessonsInDroplet.length / dropletLessonIds.length) * 100,
-        )
+        (completedLessonsInDroplet.length / dropletLessonIds.length) * 100,
+      )
       : 0;
 
   let daysUntil = 0;
@@ -202,10 +203,49 @@ export function DropletTile({
               </Badge>
             ))}
           </div>
+          <div className="flex flex-col justify-center gap-1">
+            <span className="block w-full place-self-end text-3xl font-black text-slate-950 dark:text-slate-300">
+              {droplet.name}
+            </span>
 
-          <span className="block w-full place-self-end text-3xl font-black text-slate-950 dark:text-slate-300">
-            {droplet.name}
-          </span>
+            {droplet.description &&
+              droplet.description.trim() !== "<p></p>" &&
+              droplet.description.trim() !== "" && (
+                <>
+                  <p
+                    className={`${descriptionExpanded ? "line-clamp-none" : "line-clamp-2"
+                      } text-md font-black text-slate-700 dark:text-slate-300`}
+                  >
+                    {droplet.description}
+                  </p>
+                  <p>
+                    {descriptionExpanded ? (
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setDescriptionExpanded(false);
+                        }}
+                        className="text-sm text-sky-700 dark:text-slate-300"
+                      >
+                        See Less
+                      </button>
+                    ) : (
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setDescriptionExpanded(true);
+                        }}
+                        className="text-sm text-sky-700 dark:text-slate-300"
+                      >
+                        See More
+                      </button>
+                    )}
+                  </p>
+                </>
+              )}
+
+
+          </div>
 
           {averageRating != 0 ? (
             <div className="flex w-full origin-left scale-[0.55] items-start">

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -227,7 +227,7 @@ export function DropletTile({
                             e.preventDefault();
                             setDescriptionExpanded(false);
                           }}
-                          className="text-sm text-sky-700 dark:text-slate-300"
+                          className="text-sm text-sky-700 dark:text-sky-500"
                         >
                           See Less
                         </button>
@@ -237,7 +237,7 @@ export function DropletTile({
                             e.preventDefault();
                             setDescriptionExpanded(true);
                           }}
-                          className="text-sm text-sky-700 dark:text-slate-300"
+                          className="text-sm text-sky-700 dark:text-sky-500"
                         >
                           See More
                         </button>

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -152,99 +152,101 @@ export function DropletTile({
             </span>
           </div>
         </Button>
-        <div className="flex flex-col justify-end gap-3 p-4">
-          <div className="flex flex-0 flex-row flex-wrap gap-1.5">
-            {droplet.status == "draft" ? (
-              <Badge variant="destructive">Draft</Badge>
-            ) : null}
+        <div className="flex flex-col justify-between gap-3 p-4 h-full">
+          <div className="space-y-3">
+            <div className="flex flex-0 flex-row flex-wrap gap-1.5">
+              {droplet.status == "draft" ? (
+                <Badge variant="destructive">Draft</Badge>
+              ) : null}
 
-            {dueDate && dueDate !== "" && daysUntil > -2 && (
-              <Badge
-                className={getDueDateBadgeColor(daysUntil, true)}
-                variant="outline"
-              >
-                <Clock size={15} className="mr-1" />
+              {dueDate && dueDate !== "" && daysUntil > -2 && (
+                <Badge
+                  className={getDueDateBadgeColor(daysUntil, true)}
+                  variant="outline"
+                >
+                  <Clock size={15} className="mr-1" />
 
-                {(() => {
-                  if (
-                    DateTime.fromISO(dueDate).toISODate() ==
-                    DateTime.local().toISODate()
-                  ) {
-                    return "Due today!";
-                  } else if (daysUntil === 1) {
-                    return `Due in 1 day`;
-                  } else if (daysUntil > 0) {
-                    return `Due in ${daysUntil} days`;
-                  } else {
-                    return "Late!";
-                  }
-                })()}
-              </Badge>
-            )}
-
-            {isEnrolled && dropletLessonIds.length > 0 && (
-              <Badge className={getCompletionBadgeColor()} variant="outline">
-                {completionPercentage}% Complete
-              </Badge>
-            )}
-
-            <Badge className="pointer-events-none border-black bg-white text-black dark:bg-slate-300">
-              {uppercaseFirstChar(droplet.focusArea)}
-            </Badge>
-            <Badge className="pointer-events-none border-black bg-white text-black dark:bg-slate-300">
-              {uppercaseFirstChar(droplet.type)}
-            </Badge>
-            {droplet.tags?.map((tag) => (
-              <Badge
-                key={tag.id}
-                className="pointer-events-none border-black bg-white text-black dark:bg-slate-300"
-              >
-                {tag.name}
-              </Badge>
-            ))}
-          </div>
-          <div className="flex flex-col justify-center gap-1">
-            <span className="block w-full place-self-end text-3xl font-black text-slate-950 dark:text-slate-300">
-              {droplet.name}
-            </span>
-
-            {droplet.description &&
-              droplet.description.trim() !== "<p></p>" &&
-              droplet.description.trim() !== "" && (
-                <>
-                  <p
-                    className={`${descriptionExpanded ? "line-clamp-none" : "line-clamp-2"
-                      } text-md font-black text-slate-700 dark:text-slate-300`}
-                  >
-                    {droplet.description}
-                  </p>
-                  <p>
-                    {descriptionExpanded ? (
-                      <button
-                        onClick={(e) => {
-                          e.preventDefault();
-                          setDescriptionExpanded(false);
-                        }}
-                        className="text-sm text-sky-700 dark:text-slate-300"
-                      >
-                        See Less
-                      </button>
-                    ) : (
-                      <button
-                        onClick={(e) => {
-                          e.preventDefault();
-                          setDescriptionExpanded(true);
-                        }}
-                        className="text-sm text-sky-700 dark:text-slate-300"
-                      >
-                        See More
-                      </button>
-                    )}
-                  </p>
-                </>
+                  {(() => {
+                    if (
+                      DateTime.fromISO(dueDate).toISODate() ==
+                      DateTime.local().toISODate()
+                    ) {
+                      return "Due today!";
+                    } else if (daysUntil === 1) {
+                      return `Due in 1 day`;
+                    } else if (daysUntil > 0) {
+                      return `Due in ${daysUntil} days`;
+                    } else {
+                      return "Late!";
+                    }
+                  })()}
+                </Badge>
               )}
 
+              {isEnrolled && dropletLessonIds.length > 0 && (
+                <Badge className={getCompletionBadgeColor()} variant="outline">
+                  {completionPercentage}% Complete
+                </Badge>
+              )}
 
+              <Badge className="pointer-events-none border-black bg-white text-black dark:bg-slate-300">
+                {uppercaseFirstChar(droplet.focusArea)}
+              </Badge>
+              <Badge className="pointer-events-none border-black bg-white text-black dark:bg-slate-300">
+                {uppercaseFirstChar(droplet.type)}
+              </Badge>
+              {droplet.tags?.map((tag) => (
+                <Badge
+                  key={tag.id}
+                  className="pointer-events-none border-black bg-white text-black dark:bg-slate-300"
+                >
+                  {tag.name}
+                </Badge>
+              ))}
+            </div>
+            <div className="flex flex-col justify-center gap-1">
+              <span className="block w-full place-self-end text-3xl font-black text-slate-950 dark:text-slate-300">
+                {droplet.name}
+              </span>
+
+              {droplet.description &&
+                droplet.description.trim() !== "<p></p>" &&
+                droplet.description.trim() !== "" && (
+                  <>
+                    <p
+                      className={`${descriptionExpanded ? "line-clamp-none" : "line-clamp-2"
+                        } text-md font-black text-slate-700 dark:text-slate-300`}
+                    >
+                      {droplet.description}
+                    </p>
+                    <p>
+                      {descriptionExpanded ? (
+                        <button
+                          onClick={(e) => {
+                            e.preventDefault();
+                            setDescriptionExpanded(false);
+                          }}
+                          className="text-sm text-sky-700 dark:text-slate-300"
+                        >
+                          See Less
+                        </button>
+                      ) : (
+                        <button
+                          onClick={(e) => {
+                            e.preventDefault();
+                            setDescriptionExpanded(true);
+                          }}
+                          className="text-sm text-sky-700 dark:text-slate-300"
+                        >
+                          See More
+                        </button>
+                      )}
+                    </p>
+                  </>
+                )}
+
+
+            </div>
           </div>
 
           {averageRating != 0 ? (

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -44,8 +44,8 @@ export function DropletTile({
   const completionPercentage =
     dropletLessonIds.length > 0
       ? Math.round(
-        (completedLessonsInDroplet.length / dropletLessonIds.length) * 100,
-      )
+          (completedLessonsInDroplet.length / dropletLessonIds.length) * 100,
+        )
       : 0;
 
   let daysUntil = 0;
@@ -152,7 +152,7 @@ export function DropletTile({
             </span>
           </div>
         </Button>
-        <div className="flex flex-col justify-between gap-3 p-4 h-full">
+        <div className="flex h-full flex-col justify-between gap-3 p-4">
           <div className="space-y-3">
             <div className="flex flex-0 flex-row flex-wrap gap-1.5">
               {droplet.status == "draft" ? (
@@ -214,8 +214,9 @@ export function DropletTile({
                 droplet.description.trim() !== "" && (
                   <>
                     <p
-                      className={`${descriptionExpanded ? "line-clamp-none" : "line-clamp-2"
-                        } text-md font-black text-slate-700 dark:text-slate-300`}
+                      className={`${
+                        descriptionExpanded ? "line-clamp-none" : "line-clamp-2"
+                      } text-md font-black text-slate-700 dark:text-slate-300`}
                     >
                       {droplet.description}
                     </p>
@@ -244,8 +245,6 @@ export function DropletTile({
                     </p>
                   </>
                 )}
-
-
             </div>
           </div>
 

--- a/frontend/components/friends/friend-requests.tsx
+++ b/frontend/components/friends/friend-requests.tsx
@@ -80,7 +80,7 @@ export function FriendRequests({
                   ))}
             </ul>
           ) : (
-            <p>You have no friend requests</p>
+            <p className="text-center">You have no friend requests</p>
           )}
         </div>
         {totalPages > 1 && (

--- a/frontend/components/ui/slideshow.tsx
+++ b/frontend/components/ui/slideshow.tsx
@@ -11,7 +11,7 @@ function Slideshow({ images }: { images: string[] }) {
 
   return (
     <div
-      className={`relative mx-auto flex h-full w-full scale-100 justify-between overflow-hidden border border-slate-200 bg-slate-50 text-center`}
+      className={`relative mx-auto flex h-full w-full scale-100 justify-between overflow-hidden border border-slate-200 bg-slate-50 text-center shadow-[0px_0px_8px_rgb(29,58,138)] dark:shadow-[0px_0px_12px_rgb(0,255,255)]`}
     >
       <button
         onClick={() => setSlideshowPosition((prev) => prev - 1)}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
         "@radix-ui/react-tooltip": "^1.0.7",
         "@strapi/blocks-react-renderer": "^1.0.0",
         "@tailwindcss/forms": "^0.5.7",
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@tailwindcss/typography": "^0.5.12",
         "@tiptap/core": "^2.11.5",
         "@tiptap/extension-code-block-lowlight": "^2.10.4",
@@ -7772,6 +7773,15 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tailwindcss/typography": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-tooltip": "^1.0.7",
     "@strapi/blocks-react-renderer": "^1.0.0",
     "@tailwindcss/forms": "^0.5.7",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/typography": "^0.5.12",
     "@tiptap/core": "^2.11.5",
     "@tiptap/extension-code-block-lowlight": "^2.10.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^6.4.5",
         "@mui/x-date-pickers": "^7.27.0",
         "@nextui-org/table": "^2.2.8",
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@tiptap/extension-color": "^2.11.5",
         "@tiptap/extension-text-style": "^2.11.5",
         "@types/luxon": "^3.4.2",
@@ -7588,6 +7589,15 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mui/material": "^6.4.5",
     "@mui/x-date-pickers": "^7.27.0",
     "@nextui-org/table": "^2.2.8",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@tiptap/extension-color": "^2.11.5",
     "@tiptap/extension-text-style": "^2.11.5",
     "@types/luxon": "^3.4.2",


### PR DESCRIPTION
Added the droplet's description to its tile, expandable to see the entire description
Changed sizing properties for features and feed pages so that they only expand to a max width, like the explore page
Small style changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Droplet tiles now support expandable descriptions (See More/Less) and display badges for focus area, type, and tags.
- Style
  - Centered and constrained content width on Features and Feed pages for improved readability.
  - Centered “no friend requests” message.
  - Added light/dark shadows to slideshows.
  - Refined tile layout for clearer content hierarchy.
- Chores
  - Added Tailwind line-clamp plugin.
- Documentation
  - Updated autogenerated documentation timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->