### PR TITLE
Feature/droplet heading sizes

### DIFF
--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -835,9 +835,11 @@ export interface ApiDropletDroplet extends Schema.CollectionType {
       Attribute.SetMinMax<
         {
           max: 5;
+          min: 0;
         },
         number
-      >;
+      > &
+      Attribute.DefaultTo<0>;
     createdAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
       'api::droplet.droplet',

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -246,7 +246,7 @@ export function LessonRenderer({
   return (
     <div className="mx-auto w-full min-w-[300px] py-8 md:min-w-[700px]">
       <div className="relative mx-auto w-full max-w-2xl xl:py-8">
-        <h1 className="text-4xl font-extrabold text-balance">{lesson.name}</h1>
+        <h1 className="text-6xl font-extrabold text-balance">{lesson.name}</h1>
 
         {headings.length > 2 && (
           <div className="mt-8 rounded-md border border-slate-200 bg-slate-50 p-6 dark:border-slate-500 dark:bg-slate-800">

--- a/frontend/components/ui/tiptap/lesson-name-input.tsx
+++ b/frontend/components/ui/tiptap/lesson-name-input.tsx
@@ -20,7 +20,7 @@ export function LessonNameInput({
       Heading.configure({
         levels: [1],
         HTMLAttributes: {
-          class: "text-5xl font-extrabold text-balance",
+          class: "text-6xl font-extrabold text-balance",
         },
       }),
       Text,

--- a/frontend/components/ui/tiptap/lesson-name-input.tsx
+++ b/frontend/components/ui/tiptap/lesson-name-input.tsx
@@ -20,7 +20,7 @@ export function LessonNameInput({
       Heading.configure({
         levels: [1],
         HTMLAttributes: {
-          class: "text-4xl font-extrabold text-balance",
+          class: "text-5xl font-extrabold text-balance",
         },
       }),
       Text,

--- a/frontend/components/ui/tiptap/toolbar/tools/heading-tool.tsx
+++ b/frontend/components/ui/tiptap/toolbar/tools/heading-tool.tsx
@@ -17,7 +17,7 @@ export default function HeadingTool({
         editor
           .chain()
           .focus()
-          .toggleHeading({ level: number as 1 | 2 | 3 })
+          .toggleHeading({ level: number as 2 | 3 | 4 })
           .run()
       }
       className={cn(

--- a/frontend/components/ui/tiptap/toolbar/tools/heading-tool.tsx
+++ b/frontend/components/ui/tiptap/toolbar/tools/heading-tool.tsx
@@ -17,7 +17,7 @@ export default function HeadingTool({
         editor
           .chain()
           .focus()
-          .toggleHeading({ level: number as 2 | 3 | 4 })
+          .toggleHeading({ level: number as 1 | 2 | 3 })
           .run()
       }
       className={cn(


### PR DESCRIPTION
Changed droplet content title sizing for hierarchy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Style
  - Increased lesson title size for improved readability: H1 now displays larger in lesson viewer and in the lesson name editor.

- Documentation
  - Updated internal documentation metadata timestamp; no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->