### PR TITLE
Develop

### DIFF
--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -37,8 +37,7 @@ export default async function GroupDetailPage({ params }: Props) {
   }
 
   const isCreator = group.creator?.id === authorizedUser.id;
-  const isAdmin = group.admins?.some((admin) => admin.id === authorizedUser.id);
-  const canEdit = isCreator || isAdmin || isAuthorizedUserAdmin(user.roles);
+  const canEdit = isCreator || isAuthorizedUserAdmin(user.roles);
 
   const dueDates = await getGroupDueDates(group);
 

--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -12,7 +12,8 @@ import { isAuthorizedUserAdmin } from "@/lib/utils";
 import DueDateAnnouncements from "@/components/group/due-date-announcements";
 import { getGroupDueDates } from "@/lib/requests/groups";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
-import { AuthorizedUser } from "@/types";
+import { AuthorizedUser, DueDate } from "@/types";
+import { DateTime } from "luxon";
 
 export const fetchCache = "force-no-store";
 export const revalidate = 0;
@@ -58,6 +59,20 @@ export default async function GroupDetailPage({ params }: Props) {
   );
 
   const uniqueDueDates = Object.values(filteredDueDates);
+  const getDaysUntil = (dueDate: DueDate) => {
+    let daysUntil = "0";
+    if (dueDate && dueDate.dueDate !== "") {
+      const dueDateObject = DateTime.fromISO(dueDate.dueDate);
+      const today = DateTime.local().startOf("day");
+      const diffDays = dueDateObject.startOf("day").diff(today, "days").days;
+      daysUntil = String(Math.ceil(diffDays));
+    }
+    return daysUntil;
+  };
+
+  const processedDueDates = uniqueDueDates.filter((dueDate) => {
+    return Number(getDaysUntil(dueDate)) >= 0;
+  });
 
   let sortedMembers: AuthorizedUser[] = [];
   const completionStatuses: Record<
@@ -113,7 +128,7 @@ export default async function GroupDetailPage({ params }: Props) {
 
   return (
     <div className="mx-auto w-full max-w-7xl space-y-12 p-8">
-      <GroupHeader group={group} canEdit={canEdit} />
+      {canEdit && <GroupHeader group={group} canEdit={canEdit} />}
 
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         <div className="space-y-8">
@@ -166,11 +181,11 @@ export default async function GroupDetailPage({ params }: Props) {
               group.description || "No Description Provided.",
             )}
           />
-          {dueDates && uniqueDueDates.length > 0 && (
+          {dueDates && processedDueDates.length > 0 && (
             <>
               <Separator />
               <DueDateAnnouncements
-                dueDates={uniqueDueDates}
+                dueDates={processedDueDates}
                 data-testid="due-date-announcements"
               />
             </>

--- a/frontend/app/(groups)/g/dashboard/group-selector.tsx
+++ b/frontend/app/(groups)/g/dashboard/group-selector.tsx
@@ -7,6 +7,7 @@ import {
   PlusCircle,
   PlusCircleIcon,
   ShieldIcon,
+  UserIcon,
   UsersRound,
 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -17,7 +18,7 @@ import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 
 const baseTabs = [
-  // { name: "Member", value: "member", icon: UserIcon },
+  { name: "Member", value: "member", icon: UserIcon },
   { name: "Admin", value: "admin", icon: ShieldIcon },
   { name: "Manager", value: "manager", icon: CircleUserIcon },
   // { name: "Favs", value: "favorites", icon: StarIcon },
@@ -35,7 +36,7 @@ export function GroupsSelector() {
       isAuthorizedUserAdmin(session.user.roles) ||
       isAuthorizedUserFaculty(session.user.roles));
 
-  const currentTab = searchParams.get("tab") || "creator";
+  const currentTab = searchParams.get("tab") || "member";
 
   const createQueryString = (name: string, value: string) => {
     const params = new URLSearchParams(searchParams);

--- a/frontend/app/(groups)/g/dashboard/page.tsx
+++ b/frontend/app/(groups)/g/dashboard/page.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/message";
 import { redirect } from "next/navigation";
 import { GroupCard } from "@/components/group/group-card";
-import { isAuthorizedUserAdmin, isContentCreator } from "@/lib/utils";
 
 type GroupWithRole = {
   group: Group;
@@ -30,11 +29,7 @@ export default async function GroupsPage({ searchParams }: Props) {
   const tab = params.tab || "member";
 
   const user = await getCurrentUser();
-  if (
-    !user ||
-    !user.email ||
-    (!isAuthorizedUserAdmin(user.roles) && !isContentCreator(user.roles))
-  ) {
+  if (!user || !user.email) {
     redirect("/unauthorized");
   }
 

--- a/frontend/app/(groups)/g/management/page.tsx
+++ b/frontend/app/(groups)/g/management/page.tsx
@@ -16,14 +16,7 @@ type Props = {
 
 export default async function GroupManagementPage({ searchParams }: Props) {
   const user = await getCurrentUser();
-  if (
-    !user?.email ||
-    !(
-      isContentCreator(user.roles) ||
-      isAuthorizedUserAdmin(user.roles) ||
-      isAuthorizedUserFaculty(user.roles)
-    )
-  ) {
+  if (!user?.email) {
     return notFound();
   }
 
@@ -39,7 +32,13 @@ export default async function GroupManagementPage({ searchParams }: Props) {
     const isAdmin = group.admins?.some(
       (admin) => admin.id === authorizedUser.id,
     );
-    if (!isCreator && !isAdmin && !isAuthorizedUserAdmin(user.roles)) {
+    if (
+      !isCreator &&
+      !isAdmin &&
+      !isAuthorizedUserAdmin(user.roles) &&
+      !isAuthorizedUserFaculty(user.roles) &&
+      !isContentCreator(user.roles)
+    ) {
       notFound();
     }
   }

--- a/frontend/components/draft/metadata/next-steps/next-step.tsx
+++ b/frontend/components/draft/metadata/next-steps/next-step.tsx
@@ -20,6 +20,7 @@ export function NextStepDisplay({
   const ref = useRef<HTMLLIElement>(null);
   const { open, setOpen } = useOffClick(ref);
   const [nextStep, setNextStep] = useState(initial);
+  const [finalVal, setFinalVal] = useState(nextStep.label ?? nextStep.url);
 
   return (
     <li
@@ -42,6 +43,7 @@ export function NextStepDisplay({
                 url: nextStep.url,
                 label: e.target.value,
               });
+              setFinalVal(nextStep.label ?? nextStep.url);
               update({
                 id: nextStep.id,
                 url: nextStep.url,
@@ -57,6 +59,7 @@ export function NextStepDisplay({
                 url: e.target.value,
                 label: nextStep.label,
               });
+              setFinalVal(nextStep.label ?? nextStep.url);
               update({
                 id: nextStep.id,
                 url: e.target.value,
@@ -70,7 +73,7 @@ export function NextStepDisplay({
           </form>
         </div>
       ) : (
-        (nextStep.label ?? nextStep.url)
+        finalVal
       )}
     </li>
   );

--- a/frontend/components/draft/metadata/next-steps/next-step.tsx
+++ b/frontend/components/draft/metadata/next-steps/next-step.tsx
@@ -70,7 +70,7 @@ export function NextStepDisplay({
           </form>
         </div>
       ) : (
-        nextStep.label ?? nextStep.url
+        (nextStep.label ?? nextStep.url)
       )}
     </li>
   );

--- a/frontend/components/draft/metadata/next-steps/next-step.tsx
+++ b/frontend/components/draft/metadata/next-steps/next-step.tsx
@@ -70,7 +70,7 @@ export function NextStepDisplay({
           </form>
         </div>
       ) : (
-        (nextStep.label ?? nextStep.url)
+        nextStep.label ?? nextStep.url
       )}
     </li>
   );

--- a/frontend/components/group/content-section.tsx
+++ b/frontend/components/group/content-section.tsx
@@ -18,7 +18,7 @@ export function ContentSection({
   return (
     <section className="space-y-4">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-2xl font-semibold">{title}</h2>
+        <h2 className="text-4xl font-semibold">{title}</h2>
         {action}
       </div>
       {content ? (

--- a/frontend/components/group/due-date-announcements.tsx
+++ b/frontend/components/group/due-date-announcements.tsx
@@ -16,7 +16,6 @@ export default function DueDateAnnouncements({
   dueDates,
 }: DueDateAnnouncementsProps) {
   const [visibleDates, setVisibleDates] = useState<number | undefined>(5);
-
   const handleSeeMore = () => {
     if (visibleDates) {
       setVisibleDates(undefined);
@@ -71,7 +70,7 @@ export default function DueDateAnnouncements({
         ))}
       </div>
 
-      {dueDates.length > 5 && (
+      {processedDueDates.length > 5 && (
         <Button
           variant="link"
           size="xs"

--- a/frontend/components/group/due-date-announcements.tsx
+++ b/frontend/components/group/due-date-announcements.tsx
@@ -35,15 +35,11 @@ export default function DueDateAnnouncements({
     return daysUntil;
   };
 
-  const processedDueDates = dueDates.filter((dueDate) => {
-    return Number(getDaysUntil(dueDate)) >= 0;
-  });
-
   return (
     <div className="w-2/3 space-y-3">
       <h2 className="text-2xl font-semibold">Upcoming Due Dates</h2>
       <div className="space-y-5">
-        {processedDueDates.slice(0, visibleDates).map((dueDate, index) => (
+        {dueDates.slice(0, visibleDates).map((dueDate, index) => (
           <Link
             key={index}
             href={`/${dueDate.droplet ? "d" : "p"}/${dueDate.droplet ? dueDate.droplet?.slug : dueDate.playlist?.slug}`}
@@ -70,7 +66,7 @@ export default function DueDateAnnouncements({
         ))}
       </div>
 
-      {processedDueDates.length > 5 && (
+      {dueDates.length > 5 && (
         <Button
           variant="link"
           size="xs"

--- a/frontend/components/group/group-management-dashboard.tsx
+++ b/frontend/components/group/group-management-dashboard.tsx
@@ -40,6 +40,7 @@ export function GroupDashboard({
   const paginatedDroplets = group.droplets?.slice(startIndex, endIndex);
 
   const totalPages = Math.ceil((group.droplets?.length || 0) / lessonsPerPage);
+  const isAdmin = group.admins?.some((admin) => admin.id === authUser.id);
 
   const handleNextPage = () => {
     if (currentPage < totalPages - 1) setCurrentPage(currentPage + 1);
@@ -54,7 +55,7 @@ export function GroupDashboard({
       <TabList className="flex border-b">
         <Tab className={tabStyle}>Droplets</Tab>
         <Tab className={tabStyle}>Playlists</Tab>
-        {canEdit && <Tab className={tabStyle}>Progress</Tab>}
+        {canEdit || (isAdmin && <Tab className={tabStyle}>Progress</Tab>)}
       </TabList>
       <TabPanel>
         <ContentSection
@@ -134,29 +135,30 @@ export function GroupDashboard({
           )}
         </ContentSection>
       </TabPanel>
-      {canEdit && (
-        <TabPanel>
-          <ContentSection
-            title=""
-            emptyMessage="No students are enrolled in any droplets or playlists."
-          >
-            {group.droplets &&
-            group.droplets.length > 0 &&
-            group.members &&
-            group.members.length > 0 ? (
-              <div className="flex flex-row items-start overflow-x-auto">
-                <div className="" key={group.id}>
-                  <GroupProgressGrid group={group} statuses={statuses} />
+      {canEdit ||
+        (isAdmin && (
+          <TabPanel>
+            <ContentSection
+              title=""
+              emptyMessage="No students are enrolled in any droplets or playlists."
+            >
+              {group.droplets &&
+              group.droplets.length > 0 &&
+              group.members &&
+              group.members.length > 0 ? (
+                <div className="flex flex-row items-start overflow-x-auto">
+                  <div className="" key={group.id}>
+                    <GroupProgressGrid group={group} statuses={statuses} />
+                  </div>
                 </div>
-              </div>
-            ) : (
-              <div className="rounded-lg border border-dashed p-8 text-center text-slate-500 dark:border-slate-500 dark:text-slate-300">
-                No droplets or members have been added to this group yet.
-              </div>
-            )}
-          </ContentSection>
-        </TabPanel>
-      )}
+              ) : (
+                <div className="rounded-lg border border-dashed p-8 text-center text-slate-500 dark:border-slate-500 dark:text-slate-300">
+                  No droplets or members have been added to this group yet.
+                </div>
+              )}
+            </ContentSection>
+          </TabPanel>
+        ))}
     </Tabs>
   );
 }

--- a/frontend/components/group/group-management-dashboard.tsx
+++ b/frontend/components/group/group-management-dashboard.tsx
@@ -55,7 +55,7 @@ export function GroupDashboard({
       <TabList className="flex border-b">
         <Tab className={tabStyle}>Droplets</Tab>
         <Tab className={tabStyle}>Playlists</Tab>
-        {canEdit || (isAdmin && <Tab className={tabStyle}>Progress</Tab>)}
+        {(canEdit || isAdmin) && <Tab className={tabStyle}>Progress</Tab>}
       </TabList>
       <TabPanel>
         <ContentSection
@@ -135,30 +135,29 @@ export function GroupDashboard({
           )}
         </ContentSection>
       </TabPanel>
-      {canEdit ||
-        (isAdmin && (
-          <TabPanel>
-            <ContentSection
-              title=""
-              emptyMessage="No students are enrolled in any droplets or playlists."
-            >
-              {group.droplets &&
-              group.droplets.length > 0 &&
-              group.members &&
-              group.members.length > 0 ? (
-                <div className="flex flex-row items-start overflow-x-auto">
-                  <div className="" key={group.id}>
-                    <GroupProgressGrid group={group} statuses={statuses} />
-                  </div>
+      {(canEdit || isAdmin) && (
+        <TabPanel>
+          <ContentSection
+            title=""
+            emptyMessage="No students are enrolled in any droplets or playlists."
+          >
+            {group.droplets &&
+            group.droplets.length > 0 &&
+            group.members &&
+            group.members.length > 0 ? (
+              <div className="flex flex-row items-start overflow-x-auto">
+                <div className="" key={group.id}>
+                  <GroupProgressGrid group={group} statuses={statuses} />
                 </div>
-              ) : (
-                <div className="rounded-lg border border-dashed p-8 text-center text-slate-500 dark:border-slate-500 dark:text-slate-300">
-                  No droplets or members have been added to this group yet.
-                </div>
-              )}
-            </ContentSection>
-          </TabPanel>
-        ))}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-dashed p-8 text-center text-slate-500 dark:border-slate-500 dark:text-slate-300">
+                No droplets or members have been added to this group yet.
+              </div>
+            )}
+          </ContentSection>
+        </TabPanel>
+      )}
     </Tabs>
   );
 }

--- a/frontend/config/general.ts
+++ b/frontend/config/general.ts
@@ -26,10 +26,10 @@ export const getMainNav = (user: User) => {
       label: "Dashboard",
     },
     {
-      href: "/g/dashboard?tab=creator",
+      href: "/g/dashboard?tab=member",
       label: "Groups",
-      isHidden:
-        !isContentCreator(user.roles) && !isAuthorizedUserAdmin(user.roles),
+      // isHidden:
+      //   !isContentCreator(user.roles) && !isAuthorizedUserAdmin(user.roles),
     },
     {
       href: "/my-content",

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/globals";
 import { JSONContent } from "@tiptap/react";
 import type { BlockNode, TextNode } from "@/types/strapi";
+import { AuthorizedUser, Group } from "@/types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/frontend/tests/components/group/group-management-dashboard.test.tsx
+++ b/frontend/tests/components/group/group-management-dashboard.test.tsx
@@ -86,6 +86,7 @@ describe("GroupDashboard", () => {
         canEdit={true}
         authUser={mockAuthUser}
         dueDates={mockDueDates}
+        statuses={{}}
       />,
     );
 
@@ -97,6 +98,7 @@ describe("GroupDashboard", () => {
         canEdit={false}
         authUser={mockAuthUser}
         dueDates={mockDueDates}
+        statuses={{}}
       />,
     );
 
@@ -117,6 +119,7 @@ describe("GroupDashboard", () => {
         canEdit={true}
         authUser={mockAuthUser}
         dueDates={[]}
+        statuses={{}}
       />,
     );
 
@@ -137,6 +140,7 @@ describe("GroupDashboard", () => {
         canEdit={true}
         authUser={mockAuthUser}
         dueDates={[]}
+        statuses={{}}
       />,
     );
 
@@ -158,6 +162,7 @@ describe("GroupDashboard", () => {
         canEdit={true}
         authUser={mockAuthUser}
         dueDates={[]}
+        statuses={{}}
       />,
     );
 
@@ -171,6 +176,7 @@ describe("GroupDashboard", () => {
     canEdit: true,
     authUser: { id: "1", timeZone: "UTC" } as any,
     dueDates: [],
+    statuses: {},
   };
 
   test("empty state renders correctly", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the role permissions for groups so that all group admin can see the progress tab and can export progress in excel form even if they don't have Content Creator / Admin permissions.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This allows CS1200 TAs to export progress as a CSV without having to give them admin access to the website.


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x ] My code follows the code style of this project.
- [ x] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Progress tab now visible to group admins, not just editors.
  - Groups navigation defaults to Member tab and is always visible in the menu.
  - Group selector re-enables Member tab and sets it as the default.

- Enhancements
  - Relaxed access checks on Group Dashboard and Management pages to allow broader authenticated access.
  - Due date announcements now include past-due dates.

- Style
  - Increased Content Section title size for improved readability.

- Bug Fixes
  - Next Steps display remains stable when editing label/URL.

- Tests
  - Updated dashboard tests to pass required props.

- Chores
  - Updated documentation timestamp metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->