### PR TITLE
Feature/group changes

### DIFF
--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -145,11 +145,11 @@ export default async function GroupDetailPage({ params }: Props) {
                 members={group.admins || []}
                 variant="admin"
               />
-              <MemberList
+              {/* <MemberList
                 title="Managers"
                 members={group.managers || []}
                 variant="manager"
-              />
+              /> */}
             </div>
           </div>
 

--- a/frontend/app/(groups)/g/dashboard/group-selector.tsx
+++ b/frontend/app/(groups)/g/dashboard/group-selector.tsx
@@ -20,7 +20,7 @@ import { Badge } from "@/components/ui/badge";
 const baseTabs = [
   { name: "Member", value: "member", icon: UserIcon },
   { name: "Admin", value: "admin", icon: ShieldIcon },
-  { name: "Manager", value: "manager", icon: CircleUserIcon },
+  // { name: "Manager", value: "manager", icon: CircleUserIcon },
   // { name: "Favs", value: "favorites", icon: StarIcon },
 ];
 

--- a/frontend/components/group/group-management-form.tsx
+++ b/frontend/components/group/group-management-form.tsx
@@ -440,7 +440,7 @@ export function GroupManagementForm({
               )}
             />
 
-            <FormField
+            {/* <FormField
               control={form.control}
               name="managers"
               render={({ field }) => (
@@ -455,7 +455,7 @@ export function GroupManagementForm({
                   <FormMessage />
                 </FormItem>
               )}
-            />
+            /> */}
           </div>
         </ContentSection>
 

--- a/frontend/components/ui/user-multi-select.tsx
+++ b/frontend/components/ui/user-multi-select.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/popover";
 import { Checkbox } from "@/components/ui/checkbox";
 import { AuthorizedUser } from "@/types";
-import { fetchAllContentCreators } from "@/lib/requests/users";
+import { fetchAuthorizedUsers } from "@/lib/requests/authorized-user";
 
 interface UserMultiSelectProps {
   selectedIds: number[];
@@ -34,7 +34,7 @@ export function UserMultiSelect({
 
   useEffect(() => {
     const fetchUsers = async () => {
-      const fetchedUsers = await fetchAllContentCreators();
+      const fetchedUsers = await fetchAuthorizedUsers();
       setUsers(fetchedUsers);
     };
     fetchUsers();

--- a/frontend/lib/requests/users.ts
+++ b/frontend/lib/requests/users.ts
@@ -1,8 +1,0 @@
-"use server";
-
-import { fetchContentCreators } from "@/lib/requests/authorized-user";
-import { AuthorizedUser } from "@/types";
-
-export async function fetchAllContentCreators(): Promise<AuthorizedUser[]> {
-  return fetchContentCreators();
-}

--- a/frontend/tests/components/ui/user-multi-select.test.tsx
+++ b/frontend/tests/components/ui/user-multi-select.test.tsx
@@ -1,7 +1,15 @@
 import { render, fireEvent, waitFor, screen } from "@testing-library/react";
 import { UserMultiSelect } from "@/components/ui/user-multi-select";
+import { fetchAuthorizedUsers } from "@/lib/requests/authorized-user";
+
+jest.mock("@/lib/requests/authorized-user", () => ({
+  fetchAuthorizedUsers: jest.fn(),
+}));
 
 describe("UserMultiSelect", () => {
+  beforeEach(() => {
+    (fetchAuthorizedUsers as jest.Mock).mockResolvedValue(mockUsers);
+  });
   const mockUsers = [
     {
       id: 1,

--- a/frontend/tests/components/ui/user-multi-select.test.tsx
+++ b/frontend/tests/components/ui/user-multi-select.test.tsx
@@ -1,10 +1,5 @@
 import { render, fireEvent, waitFor, screen } from "@testing-library/react";
 import { UserMultiSelect } from "@/components/ui/user-multi-select";
-import { fetchAllContentCreators } from "@/lib/requests/users";
-
-jest.mock("@/lib/requests/users", () => ({
-  fetchAllContentCreators: jest.fn(),
-}));
 
 describe("UserMultiSelect", () => {
   const mockUsers = [
@@ -21,10 +16,6 @@ describe("UserMultiSelect", () => {
       email: "jane.smith@example.com",
     },
   ];
-
-  beforeEach(() => {
-    (fetchAllContentCreators as jest.Mock).mockResolvedValue(mockUsers);
-  });
 
   it("renders select button with placeholder", () => {
     const { getByRole } = render(
@@ -73,10 +64,6 @@ describe("UserMultiSelect", () => {
     });
   });
 
-  jest.mock("@/lib/requests/users", () => ({
-    fetchAllContentCreators: jest.fn(),
-  }));
-
   describe("UserMultiSelect", () => {
     const mockUsers = [
       {
@@ -92,10 +79,6 @@ describe("UserMultiSelect", () => {
         email: "jane.smith@example.com",
       },
     ];
-
-    beforeEach(() => {
-      (fetchAllContentCreators as jest.Mock).mockResolvedValue(mockUsers);
-    });
 
     it("handles user selection and deselection", async () => {
       const mockOnChange = jest.fn();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Removed the manager field for groups because it had the same functionality as group admin. Also fixed the API call for setting admin for groups so that any user can be set as an admin, instead of only content creators being allowed to be admin.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This allows TAs for CS1200 to be set as admin for groups.


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x ] My code follows the code style of this project.
- [ x] I have moved the ticket to "In Review"
- [ x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Simplified group management and dashboards by removing the Managers functionality: the Managers list no longer appears in Group Leadership, the Managers tab is hidden in the group selector, and the Managers field is removed from the group management form. Creator and Administrators sections remain unchanged.

- Documentation
  - Updated autogenerated documentation metadata timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->