### PR TITLE
fixed "see more" button to only appear when necessary

### DIFF
--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -6,7 +6,7 @@ import { Droplet } from "@/types";
 import Link from "next/link";
 
 import { StarRating } from "@/components/ui/rating-stars";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, use } from "react";
 import { Button } from "../ui/button";
 import { toast } from "sonner";
 import { Archive, ArchiveRestore, Clock } from "lucide-react";
@@ -35,6 +35,7 @@ export function DropletTile({
 }: DropletTileProps) {
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const [isTextClamped, setIsTextClamped] = useState(false);
+  const [isScreenChanged, setIsScreenChanged] = useState(false); // New state variable to track screen size changes
   const textRef = useRef(null);
 
   const strippedDescription = droplet.description
@@ -51,6 +52,30 @@ export function DropletTile({
       setIsTextClamped(isClamped);
     }
   }, [strippedDescription, descriptionExpanded]);
+
+  // Effect to handle screen size changes and re-evaluate clamping
+  useEffect(() => {
+    const handleResize = () => {
+      setIsScreenChanged(true);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isScreenChanged) {
+      // Re-evaluate clamping only if the screen size has changed
+      if (textRef.current && strippedDescription) {
+        const element = textRef.current as HTMLParagraphElement;
+        const isClamped = element.scrollHeight > element.clientHeight;
+        setIsTextClamped(isClamped);
+      }
+      setIsScreenChanged(false); // Reset the flag after handling
+    }
+  }, [isScreenChanged, strippedDescription, descriptionExpanded]);
 
   const dropletLessonIds = droplet.lessons?.map((l) => l.id) || [];
   const completedLessonsInDroplet = completedLessonIds.filter((id) =>

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -34,11 +34,9 @@ export function DropletTile({
   dueDate,
 }: DropletTileProps) {
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
-  const [isTextClamped, setIsTextClamped] = useState(false);  
-  const textRef = useRef(null);  
+  const [isTextClamped, setIsTextClamped] = useState(false);
+  const textRef = useRef(null);
 
-
-   
   const strippedDescription = droplet.description
     ?.replace(/<\/p>\s*<p>/gi, "\n")
     .replace(/<br\s*\/?>/gi, "\n")
@@ -46,14 +44,13 @@ export function DropletTile({
     .replace(/<[^>]+>/g, "")
     .trim();
 
-    useEffect(() => {
-  if (textRef.current && strippedDescription) {
-     const element = textRef.current as HTMLParagraphElement;
+  useEffect(() => {
+    if (textRef.current && strippedDescription) {
+      const element = textRef.current as HTMLParagraphElement;
       const isClamped = element.scrollHeight > element.clientHeight;
       setIsTextClamped(isClamped);
-      }
-    }, [strippedDescription, descriptionExpanded]);
-  
+    }
+  }, [strippedDescription, descriptionExpanded]);
 
   const dropletLessonIds = droplet.lessons?.map((l) => l.id) || [];
   const completedLessonsInDroplet = completedLessonIds.filter((id) =>
@@ -218,46 +215,44 @@ export function DropletTile({
                 {droplet.name}
               </span>
 
-
-
-              {strippedDescription && 
-              strippedDescription.trim() !== "<p></p>" &&
-              strippedDescription.trim() !== "" && (
-                <>
-                  <p
-                    ref={textRef}
-                    className={`${
-                      descriptionExpanded ? "line-clamp-none" : "line-clamp-2"
-                    } text-md text-slate-700 dark:text-slate-300`}
-                  >
-                    {strippedDescription}
-                  </p>
-                  
-                  {isTextClamped && !descriptionExpanded && (
-                    <button
-                      onClick={(e) => {
-                        e.preventDefault();
-                        setDescriptionExpanded(true);
-                      }}
-                      className="text-sm text-sky-700 dark:text-sky-500 text-left"
+              {strippedDescription &&
+                strippedDescription.trim() !== "<p></p>" &&
+                strippedDescription.trim() !== "" && (
+                  <>
+                    <p
+                      ref={textRef}
+                      className={`${
+                        descriptionExpanded ? "line-clamp-none" : "line-clamp-2"
+                      } text-md text-slate-700 dark:text-slate-300`}
                     >
-                      See More
-                    </button>
-                  )}
-                  
-                  {descriptionExpanded && (
-                    <button
-                      onClick={(e) => {
-                        e.preventDefault();
-                        setDescriptionExpanded(false);
-                      }}
-                      className="text-sm text-sky-700 dark:text-sky-500 text-left"
-                    >
-                      See Less
-                    </button>
-                  )}
-                </>
-            )}       
+                      {strippedDescription}
+                    </p>
+
+                    {isTextClamped && !descriptionExpanded && (
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setDescriptionExpanded(true);
+                        }}
+                        className="text-left text-sm text-sky-700 dark:text-sky-500"
+                      >
+                        See More
+                      </button>
+                    )}
+
+                    {descriptionExpanded && (
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setDescriptionExpanded(false);
+                        }}
+                        className="text-left text-sm text-sky-700 dark:text-sky-500"
+                      >
+                        See Less
+                      </button>
+                    )}
+                  </>
+                )}
             </div>
           </div>
 

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -6,7 +6,7 @@ import { Droplet } from "@/types";
 import Link from "next/link";
 
 import { StarRating } from "@/components/ui/rating-stars";
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Button } from "../ui/button";
 import { toast } from "sonner";
 import { Archive, ArchiveRestore, Clock } from "lucide-react";
@@ -34,13 +34,27 @@ export function DropletTile({
   dueDate,
 }: DropletTileProps) {
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+  const [isTextClamped, setIsTextClamped] = useState(false);  
+  const textRef = useRef(null);  
 
+
+   
   const strippedDescription = droplet.description
     ?.replace(/<\/p>\s*<p>/gi, "\n")
     .replace(/<br\s*\/?>/gi, "\n")
     .replace(/<\/?p>/gi, "")
     .replace(/<[^>]+>/g, "")
     .trim();
+
+    useEffect(() => {
+  if (textRef.current && strippedDescription) {
+     const element = textRef.current as HTMLParagraphElement;
+      const isClamped = element.scrollHeight > element.clientHeight;
+      setIsTextClamped(isClamped);
+      }
+    }, [strippedDescription, descriptionExpanded]);
+  
+
   const dropletLessonIds = droplet.lessons?.map((l) => l.id) || [];
   const completedLessonsInDroplet = completedLessonIds.filter((id) =>
     dropletLessonIds.includes(id),
@@ -204,42 +218,46 @@ export function DropletTile({
                 {droplet.name}
               </span>
 
-              {strippedDescription &&
-                strippedDescription.trim() !== "<p></p>" &&
-                strippedDescription.trim() !== "" && (
-                  <>
-                    <p
-                      className={`${
-                        descriptionExpanded ? "line-clamp-none" : "line-clamp-2"
-                      } text-md text-slate-700 dark:text-slate-300`}
+
+
+              {strippedDescription && 
+              strippedDescription.trim() !== "<p></p>" &&
+              strippedDescription.trim() !== "" && (
+                <>
+                  <p
+                    ref={textRef}
+                    className={`${
+                      descriptionExpanded ? "line-clamp-none" : "line-clamp-2"
+                    } text-md text-slate-700 dark:text-slate-300`}
+                  >
+                    {strippedDescription}
+                  </p>
+                  
+                  {isTextClamped && !descriptionExpanded && (
+                    <button
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setDescriptionExpanded(true);
+                      }}
+                      className="text-sm text-sky-700 dark:text-sky-500 text-left"
                     >
-                      {strippedDescription}
-                    </p>
-                    <p>
-                      {descriptionExpanded ? (
-                        <button
-                          onClick={(e) => {
-                            e.preventDefault();
-                            setDescriptionExpanded(false);
-                          }}
-                          className="text-sm text-sky-700 dark:text-sky-500"
-                        >
-                          See Less
-                        </button>
-                      ) : (
-                        <button
-                          onClick={(e) => {
-                            e.preventDefault();
-                            setDescriptionExpanded(true);
-                          }}
-                          className="text-sm text-sky-700 dark:text-sky-500"
-                        >
-                          See More
-                        </button>
-                      )}
-                    </p>
-                  </>
-                )}
+                      See More
+                    </button>
+                  )}
+                  
+                  {descriptionExpanded && (
+                    <button
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setDescriptionExpanded(false);
+                      }}
+                      className="text-sm text-sky-700 dark:text-sky-500 text-left"
+                    >
+                      See Less
+                    </button>
+                  )}
+                </>
+            )}       
             </div>
           </div>
 


### PR DESCRIPTION
## Description

When on the dashboard or explore page, droplet card descriptions are condensed for a cleaner look with a "See More" option to view the full description. However, some descriptions are short enough to be fully visible by default, yet the "See More" button would still appear, serving no purpose. 

I fixed this by implementing a function that compares the paragraph's scroll height to its client height. If the scroll height is larger than the client height, it indicates that the text is being visually clamped, and the button remains present. Otherwise, the button is hidden.

This approach works dynamically across all screen sizes and layouts, unlike a fixed character count threshold.

## Motivation and Context

This change improved the overall flow of the platform. Although it didn't affect functionality, it was a good step towards higher professionalism and will definitely make the site feel better as a user.

## Screenshots:
<img width="1375" height="973" alt="Screenshot 2025-09-24 at 3 34 35 PM" src="https://github.com/user-attachments/assets/26c19fc8-9f77-4ffe-88b6-af9a9e0444df" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x ] My code follows the code style of this project.
- [x ] I have moved the ticket to "In Review"
- [x ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * “See More” only appears when a description is actually truncated; “See Less” appears when expanded.
  * Prevents unnecessary expand/collapse controls for short descriptions.
* **New Features**
  * Description clamping now re-evaluates on window resize for correct truncation.
  * Buttons aligned left with text for improved readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->