### PR TITLE
Filter Authorized Users from Access Requests

### DIFF
--- a/frontend/components/shared/access-manager/access-requests/access-requests.tsx
+++ b/frontend/components/shared/access-manager/access-requests/access-requests.tsx
@@ -12,23 +12,26 @@ export type AccessRequest = {
   college: string;
 };
 
-export function accessFilter(requests: AccessRequest[], users: AuthorizedUser[]) {
-  return (
-    requests.filter((req) => 
-      !users.some((user) => 
-        (user.firstName?.toLowerCase() === req.givenName?.toLowerCase() &&
-        user.lastName?.toLowerCase() === req.familyName?.toLowerCase() &&
-        user.email?.toLowerCase() === req.email)
-      )
-    )
-  )
+export function accessFilter(
+  requests: AccessRequest[],
+  users: AuthorizedUser[],
+) {
+  return requests.filter(
+    (req) =>
+      !users.some(
+        (user) =>
+          user.firstName?.toLowerCase() === req.givenName?.toLowerCase() &&
+          user.lastName?.toLowerCase() === req.familyName?.toLowerCase() &&
+          user.email?.toLowerCase() === req.email,
+      ),
+  );
 }
 
 export async function AccessRequests() {
   const accessRequests = await fetchAccessRequests();
   const authorizedUsers = await fetchAuthorizedUsers();
 
-  const filteredRequests = accessFilter(accessRequests, authorizedUsers); 
+  const filteredRequests = accessFilter(accessRequests, authorizedUsers);
 
   return (
     <section>
@@ -40,9 +43,8 @@ export async function AccessRequests() {
       <div className="mt-4 rounded-md bg-slate-100 p-4 dark:bg-slate-800">
         {filteredRequests.length > 0 ? (
           <ul className="divide-y divide-slate-200 md:space-y-4 dark:divide-slate-700">
-            {filteredRequests.map(
-              (request: AccessRequest) => {
-              return <AccessRequestBlock request={request} key={request.id} />
+            {filteredRequests.map((request: AccessRequest) => {
+              return <AccessRequestBlock request={request} key={request.id} />;
             })}
           </ul>
         ) : (

--- a/frontend/components/shared/access-manager/access-requests/access-requests.tsx
+++ b/frontend/components/shared/access-manager/access-requests/access-requests.tsx
@@ -27,7 +27,9 @@ export function accessFilter(requests: AccessRequest[], users: AuthorizedUser[])
 export async function AccessRequests() {
   const accessRequests = await fetchAccessRequests();
   const authorizedUsers = await fetchAuthorizedUsers();
-  
+
+  const filteredRequests = accessFilter(accessRequests, authorizedUsers); 
+
   return (
     <section>
       <h1 className="font-bold dark:text-slate-300">Access Requests</h1>
@@ -36,9 +38,9 @@ export async function AccessRequests() {
       </p>
 
       <div className="mt-4 rounded-md bg-slate-100 p-4 dark:bg-slate-800">
-        {accessRequests.length > 0 ? (
+        {filteredRequests.length > 0 ? (
           <ul className="divide-y divide-slate-200 md:space-y-4 dark:divide-slate-700">
-            {accessFilter(accessRequests, authorizedUsers).map(
+            {filteredRequests.map(
               (request: AccessRequest) => {
               return <AccessRequestBlock request={request} key={request.id} />
             })}

--- a/frontend/components/shared/access-manager/access-requests/access-requests.tsx
+++ b/frontend/components/shared/access-manager/access-requests/access-requests.tsx
@@ -14,14 +14,13 @@ export type AccessRequest = {
 
 export function accessFilter(requests: AccessRequest[], users: AuthorizedUser[]) {
   return (
-    requests.filter( (request: AccessRequest) => {
-              return users.filter((user: AuthorizedUser) => {
-                return (user.firstName?.toLowerCase() === request.givenName?.toLowerCase()
-                    && user.lastName?.toLowerCase() === request.familyName?.toLowerCase()
-                    && user.email?.toLowerCase() === request.email?.toLowerCase()
-                    )
-              }).length === 0;
-            })
+    requests.filter((req) => 
+      !users.some((user) => 
+        (user.firstName?.toLowerCase() === req.givenName?.toLowerCase() &&
+        user.lastName?.toLowerCase() === req.familyName?.toLowerCase() &&
+        user.email?.toLowerCase() === req.email)
+      )
+    )
   )
 }
 

--- a/frontend/components/shared/access-manager/access-requests/access-requests.tsx
+++ b/frontend/components/shared/access-manager/access-requests/access-requests.tsx
@@ -1,5 +1,7 @@
 import { fetchAccessRequests } from "@/lib/requests/data";
 import { AccessRequestBlock } from "./access-request";
+import { fetchAuthorizedUsers } from "@/lib/requests/authorized-user";
+import { AuthorizedUser } from "@/types";
 
 export type AccessRequest = {
   id: string;
@@ -10,9 +12,23 @@ export type AccessRequest = {
   college: string;
 };
 
+export function accessFilter(requests: AccessRequest[], users: AuthorizedUser[]) {
+  return (
+    requests.filter( (request: AccessRequest) => {
+              return users.filter((user: AuthorizedUser) => {
+                return (user.firstName.toLowerCase() === request.givenName.toLowerCase()
+                    && user.lastName.toLowerCase() === request.familyName.toLowerCase()
+                    && user.email.toLowerCase() === request.email.toLowerCase()
+                    )
+              }).length === 0;
+            })
+  )
+}
+
 export async function AccessRequests() {
   const accessRequests = await fetchAccessRequests();
-
+  const authorizedUsers = await fetchAuthorizedUsers();
+  
   return (
     <section>
       <h1 className="font-bold dark:text-slate-300">Access Requests</h1>
@@ -23,9 +39,10 @@ export async function AccessRequests() {
       <div className="mt-4 rounded-md bg-slate-100 p-4 dark:bg-slate-800">
         {accessRequests.length > 0 ? (
           <ul className="divide-y divide-slate-200 md:space-y-4 dark:divide-slate-700">
-            {accessRequests.map((request: AccessRequest) => (
-              <AccessRequestBlock request={request} key={request.id} />
-            ))}
+            {accessFilter(accessRequests, authorizedUsers).map(
+              (request: AccessRequest) => {
+              return <AccessRequestBlock request={request} key={request.id} />
+            })}
           </ul>
         ) : (
           <p>There are no access requests at this time.</p>

--- a/frontend/components/shared/access-manager/access-requests/access-requests.tsx
+++ b/frontend/components/shared/access-manager/access-requests/access-requests.tsx
@@ -16,9 +16,9 @@ export function accessFilter(requests: AccessRequest[], users: AuthorizedUser[])
   return (
     requests.filter( (request: AccessRequest) => {
               return users.filter((user: AuthorizedUser) => {
-                return (user.firstName.toLowerCase() === request.givenName.toLowerCase()
-                    && user.lastName.toLowerCase() === request.familyName.toLowerCase()
-                    && user.email.toLowerCase() === request.email.toLowerCase()
+                return (user.firstName?.toLowerCase() === request.givenName?.toLowerCase()
+                    && user.lastName?.toLowerCase() === request.familyName?.toLowerCase()
+                    && user.email?.toLowerCase() === request.email?.toLowerCase()
                     )
               }).length === 0;
             })

--- a/frontend/tests/components/shared/access-requests.test.tsx
+++ b/frontend/tests/components/shared/access-requests.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import { AccessRequests } from "@/components/shared/access-manager/access-requests/access-requests";
 import { fetchAccessRequests } from "@/lib/requests/data";
+import { fetchAuthorizedUsers } from "@/lib/requests/authorized-user";
 
 jest.mock("@/lib/requests/data", () => ({
   fetchAccessRequests: jest.fn(),
+}));
+
+jest.mock("@/lib/requests/authorized-user", () => ({
+  fetchAuthorizedUsers: jest.fn(),
 }));
 
 describe("AccessRequests", () => {
@@ -13,6 +18,7 @@ describe("AccessRequests", () => {
 
   it("renders empty state when no requests", async () => {
     (fetchAccessRequests as jest.Mock).mockResolvedValue([]);
+    (fetchAuthorizedUsers as jest.Mock).mockResolvedValue([]);
     render(await AccessRequests());
     expect(
       screen.getByText("There are no access requests at this time."),
@@ -32,7 +38,66 @@ describe("AccessRequests", () => {
     ];
 
     (fetchAccessRequests as jest.Mock).mockResolvedValue(mockRequests);
+    (fetchAuthorizedUsers as jest.Mock).mockResolvedValue([]);
+
     render(await AccessRequests());
     expect(screen.getByText("John Doe")).toBeInTheDocument();
+  });
+
+  it("filters out authorized users from access requests", async () => {
+    const mockRequests = [
+      {
+        id: "1",
+        givenName: "John",
+        familyName: "Doe",
+        email: "john@example.com",
+        affiliation: "Student",
+        college: "Engineering",
+      },
+      {
+        id: "2",
+        givenName: "Jane",
+        familyName: "Smith",
+        email: "jane@example.com",
+        affiliation: "Faculty",
+        college: "Computer Science",
+      },
+    ];
+
+    const mockAuthorizedUsers = [
+      {
+        groups: [],
+        id: 1,
+        email: "jane@example.com",
+        roles: [],
+        isEnabled: true,
+        enrollments: [],
+        playlists: [],
+        linkedin: "",
+        github: "",
+        firstTime: false,
+        firstName: "Jane",
+        lastName: "Smith",
+        bio: "",
+        friendships: [],
+        sent_requests: [],
+        received_requests: [],
+        profilePhoto: "",
+        blocked: [],
+        was_blocked: [],
+        timeZone: { id: 1, name: "UTC", offset: 0 },
+        droplets: [],
+        created_playlists: [],
+      },
+    ];
+
+    (fetchAccessRequests as jest.Mock).mockResolvedValue(mockRequests);
+    (fetchAuthorizedUsers as jest.Mock).mockResolvedValue(mockAuthorizedUsers);
+
+    render(await AccessRequests());
+    
+    // John should be visible, Jane should be filtered out
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.queryByText("Jane Smith")).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/shared/access-requests.test.tsx
+++ b/frontend/tests/components/shared/access-requests.test.tsx
@@ -95,7 +95,7 @@ describe("AccessRequests", () => {
     (fetchAuthorizedUsers as jest.Mock).mockResolvedValue(mockAuthorizedUsers);
 
     render(await AccessRequests());
-    
+
     // John should be visible, Jane should be filtered out
     expect(screen.getByText("John Doe")).toBeInTheDocument();
     expect(screen.queryByText("Jane Smith")).not.toBeInTheDocument();


### PR DESCRIPTION
## Description
Added filtering logic to the AccessRequests component to prevent displaying users who are already authorized. The component now fetches authorized users and filters them out from the access requests list before rendering.

**Key Changes:**
- Import `fetchAuthorizedUsers` from authorized-user requests library
- Filter access requests by comparing email, firstName/givenName, and lastName/familyName fields
- Updated Jest tests to mock the new fetch function and added test case for filtering behavior

## Motivation and Context
**Problem:** The AccessRequests component was displaying users who already have authorized access, creating confusion and redundant information in the UI.

**Solution:** By cross-referencing AccessRequest and AuthorizedUser data types and filtering based on matching user identifiers (email, first name, last name), we ensure only genuinely pending requests are displayed to administrators.


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Access Requests now automatically hide entries for users already authorized, reducing noise and duplicate requests in the UI; filtering is applied before rendering.

* **Tests**
  * Added and updated tests to validate authorized-user filtering, initial render, and empty-state behaviors.

* **Documentation**
  * Updated generated documentation metadata timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->