### PR TITLE
fixed italics visibility in dark mode

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -44,16 +44,28 @@
   animation: slideInFromRight 300ms ease-out; /* ease-out for smooth animation */
 }
 
+/* Ensure dark mode compatibility for prose and bg-sky-50 elements */
 .callout-bullet-list li::marker {
-  color: #334155; /* Replace with your desired color (red in this example) */
+  color: #334155;
 }
 
-/* Ensure dark mode compatibility for prose and bg-sky-50 elements */
+/* Fix for invisible text in dark mode */
 .dark .prose,
 .dark .prose *,
 .dark .bg-sky-50,
-.dark .bg-sky-50 * {
+.dark .bg-sky-50 *,
+.dark pre,
+.dark pre *,
+.dark code,
+.dark code *,
+.dark .hljs,
+.dark .hljs * {
   color: white !important;
+}
+
+/* Specific fix for callout bullet list items in dark mode */
+.dark .pt-3.pl-3 * {
+  color: #334155 !important;
 }
 
 /* Dark background for sky-50 elements */

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -47,3 +47,17 @@
 .callout-bullet-list li::marker {
   color: #334155; /* Replace with your desired color (red in this example) */
 }
+
+/* Ensure dark mode compatibility for prose and bg-sky-50 elements */
+.dark .prose,
+.dark .prose *,
+.dark .bg-sky-50,
+.dark .bg-sky-50 * {
+  color: white !important;
+}
+
+/* Dark background for sky-50 elements */
+.dark .bg-sky-50,
+.dark [class*="bg-sky-50"] {
+  background-color: rgb(15 23 42) !important;
+}

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -368,7 +368,7 @@ function LessonBlockRenderer({
     case "droplets.callout":
       return (
         <div
-          className={`flex flex-col items-center space-y-4 rounded-md border px-6 py-6 dark:border-slate-500 ${block.color || "bg-sky-50 dark:bg-sky-200"}`}
+          className={`flex flex-col items-center space-y-4 rounded-md border px-6 py-6 dark:border-slate-500 ${block.color || "bg-sky-50 dark:bg-sky-800"}`}
         >
           {block?.iconEnabled && (
             <div className="">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed invisible italic text and callout content in dark mode by adding targeted CSS overrides to globals.css. The fix ensures proper text visibility in prose content areas and light-colored background elements when dark mode is active.

## Motivation and Context

Prior to this, when in dark mode, there were certain text elements that were completely invisible to users. In order to strengthen and clean up the user experience, this was a necessary bug to fix.


## Screenshots (if appropriate):
<img width="1859" height="1217" alt="Screenshot 2025-09-25 at 5 24 20 PM" src="https://github.com/user-attachments/assets/7643c254-5428-4f97-b586-d8cece211eda" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved dark-mode readability: forces white text for prose, code blocks, highlighted content, and elements using Sky-50 backgrounds.
  * Darkened Sky-50 surfaces: Sky-50 variants now use a deep blue-black background in dark mode for better contrast.
  * Updated lesson callouts: callouts without an explicit color now default to a darker Sky tone in dark mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->