### PR TITLE
Feature/ody 9 add wrapping for bugs listed in the reports tab

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -47,3 +47,17 @@
 .callout-bullet-list li::marker {
   color: #334155; /* Replace with your desired color (red in this example) */
 }
+
+/* Ensure dark mode compatibility for prose and bg-sky-50 elements */
+.dark .prose,
+.dark .prose *,
+.dark .bg-sky-50,
+.dark .bg-sky-50 * {
+  color: white !important;
+}
+
+/* Dark background for sky-50 elements */
+.dark .bg-sky-50,
+.dark [class*="bg-sky-50"] {
+  background-color: rgb(15 23 42) !important;
+}

--- a/frontend/components/admin/reports/report.tsx
+++ b/frontend/components/admin/reports/report.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { Report } from "./reports";
 import { toast } from "sonner";
 import { deleteReport } from "@/lib/actions";
+import { useState, useEffect, useRef } from "react";
 
 export function ReportBlock({ report }: { report: Report }) {
   const handleDeleteReport = async (reportId: string) => {
@@ -17,6 +18,52 @@ export function ReportBlock({ report }: { report: Report }) {
     }
   };
 
+  // State variables for description expansion and clamping
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+  const [isTextClamped, setIsTextClamped] = useState(false);
+  const [isScreenChanged, setIsScreenChanged] = useState(false); // New state variable to track screen size changes
+  const textRef = useRef(null);
+
+  // Stripping HTML tags and converting <p> and <br> to new lines
+  const strippedDescription = report.description
+    ?.replace(/<\/p>\s*<p>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/?p>/gi, "")
+    .replace(/<[^>]+>/g, "")
+    .trim();
+
+  useEffect(() => {
+    if (textRef.current && strippedDescription) {
+      const element = textRef.current as HTMLParagraphElement;
+      const isClamped = element.scrollHeight > element.clientHeight;
+      setIsTextClamped(isClamped);
+    }
+  }, [strippedDescription, descriptionExpanded]);
+
+  // Effect to handle screen size changes and re-evaluate clamping
+  useEffect(() => {
+    const handleResize = () => {
+      setIsScreenChanged(true);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isScreenChanged) {
+      // Re-evaluate clamping only if the screen size has changed
+      if (textRef.current && strippedDescription) {
+        const element = textRef.current as HTMLParagraphElement;
+        const isClamped = element.scrollHeight > element.clientHeight;
+        setIsTextClamped(isClamped);
+      }
+      setIsScreenChanged(false); // Reset the flag after handling
+    }
+  }, [isScreenChanged, strippedDescription, descriptionExpanded]);
+
   return (
     <li className="py-0 [&:not(:first-child)]:pt-3">
       <div className="flex items-center space-x-4">
@@ -27,15 +74,51 @@ export function ReportBlock({ report }: { report: Report }) {
             </span>
           </p>
 
-          <p className="mt-2 truncate font-medium text-slate-900 dark:text-slate-300">
-            {report.description}
-          </p>
+          {strippedDescription &&
+            strippedDescription.trim() !== "<p></p>" &&
+            strippedDescription.trim() !== "" && (
+              <div className="mt-2">
+                <p
+                  ref={textRef}
+                  className={`${
+                    descriptionExpanded ? "line-clamp-none" : "line-clamp-2"
+                  } text-md text-slate-700 dark:text-slate-300`}
+                >
+                  {strippedDescription}
+                </p>
+
+                {isTextClamped && !descriptionExpanded && (
+                  <button
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setDescriptionExpanded(true);
+                    }}
+                    className="mt-1 text-left text-sm text-sky-700 dark:text-sky-500"
+                  >
+                    See More
+                  </button>
+                )}
+
+                {descriptionExpanded && (
+                  <button
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setDescriptionExpanded(false);
+                    }}
+                    className="mt-1 text-left text-sm text-sky-700 dark:text-sky-500"
+                  >
+                    See Less
+                  </button>
+                )}
+              </div>
+            )}
+
           <p className="mt-2 truncate font-medium text-slate-900 dark:text-slate-300">
             Path: {report.path}
           </p>
         </div>
 
-        <div className="inline-flex items-center gap-2">
+        <div className="flex flex-shrink-0 items-center gap-2">
           <Button
             after={<ArrowRightIcon />}
             className="dark:bg-slate-300"

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -6,7 +6,7 @@ import { Droplet } from "@/types";
 import Link from "next/link";
 
 import { StarRating } from "@/components/ui/rating-stars";
-import { useState, useEffect, useRef, use } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Button } from "../ui/button";
 import { toast } from "sonner";
 import { Archive, ArchiveRestore, Clock } from "lucide-react";

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -368,7 +368,7 @@ function LessonBlockRenderer({
     case "droplets.callout":
       return (
         <div
-          className={`flex flex-col items-center space-y-4 rounded-md border px-6 py-6 dark:border-slate-500 ${block.color || "bg-sky-50 dark:bg-sky-200"}`}
+          className={`flex flex-col items-center space-y-4 rounded-md border px-6 py-6 dark:border-slate-500 ${block.color || "bg-sky-50 dark:bg-sky-800"}`}
         >
           {block?.iconEnabled && (
             <div className="">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I added a see more button to the bugs in the Reports tab under the Admin section. Prior to this change if report descriptions were too long, they would get shortened and cut off. Now, with this implemented, if a report gets cut off, a "see more" button allows you to click and view the entire report description. Once fully opened, you are also able to click "see less" to condense it again. This change is also consistent across different screen sizes, with an effect in place to handle screen size changes and re-evaluate description clamping.

## Motivation and Context

This improves the admin user experience, making it easier and not as frustrating when viewing bug reports. It is now easy to quickly read the description of any bug without having it take up too much screen space by default.


## Screenshots (if appropriate):
<img width="1583" height="912" alt="Screenshot 2025-09-26 at 10 36 23 AM" src="https://github.com/user-attachments/assets/777c7d8e-8ce0-4fcc-a37d-cecbe15a626d" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report descriptions are now auto-truncated with “See More/See Less” for easier reading, responsive to screen size.

* **Style**
  * Improved dark mode readability for prose and sky-themed backgrounds.
  * Updated lesson callout styling in dark mode for better contrast.

* **Chores**
  * Cleaned up unused code import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->