### PR TITLE
Ody 10 update styling for friend and kudos announcements

### DIFF
--- a/frontend/components/feed/feed-block.tsx
+++ b/frontend/components/feed/feed-block.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { Announcement, AuthorizedUser } from "@/types";
 import Link from "next/link";
 import { KudosButton } from "./kudos-button";
@@ -13,7 +12,6 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { ProfileBlock } from "../friends/profile-block";
-
 export function FeedBlock({
   announcement,
   authUser,
@@ -23,14 +21,11 @@ export function FeedBlock({
 }) {
   const announcementType = announcement.type;
   const [open, setOpen] = useState(false);
-
   function formatDate(dateInput: string | Date | undefined) {
     if (!dateInput) return "";
-
     try {
       const date = dateInput instanceof Date ? dateInput : new Date(dateInput);
       if (isNaN(date.getTime())) return "";
-
       return new Intl.DateTimeFormat("en-US", {
         year: "numeric",
         month: "numeric",
@@ -45,7 +40,6 @@ export function FeedBlock({
     }
   }
   const formattedDate = formatDate(announcement.firstCreated);
-
   const backgroundColor = {
     playlist: "bg-green-200 dark:bg-[#29703B]",
     droplet: "bg-blue-200 dark:bg-[#266697]",
@@ -54,7 +48,6 @@ export function FeedBlock({
     kudos: "bg-orange-200 dark:bg-[#B55E0C]",
     system: "bg-red-200 dark:bg-[#B83028]",
   };
-
   const announcementIcon = {
     playlist: <ListVideo />,
     droplet: <Droplet />,
@@ -63,14 +56,10 @@ export function FeedBlock({
     kudos: <PartyPopper />,
     system: <Info />,
   };
-
   const content = announcement.content;
   const [namePart] = content.split(/has\s+/i);
-  //const [, taskPart] = content.split(/finished\s+/i);
-const dropletName = announcement.droplet || 
-  announcement.content.split(/finished\s+/i)[1] || "";
-
-
+  const [, taskPart] = content.split(/(?:completed|finished)\s+/i); // non-capturing group for "completed" or "finished"
+  const [, kudosTaskPart] = content.split(/for\s+/i);
   return (
     <li
       className={`${backgroundColor[announcementType]} relative flex flex-col items-start gap-2 rounded-lg p-4 pb-3`}
@@ -110,7 +99,10 @@ const dropletName = announcement.droplet ||
                 >
                   {namePart.trim()}
                 </p>
-                {" has given you kudos "}
+                <>
+                  {"\u00A0"}has given you kudos for{"\u00A0"}
+                </>
+                <span>{kudosTaskPart?.trim()}</span>
                 <div>
                   <ProfileBlock
                     user={authUser}
@@ -139,21 +131,17 @@ const dropletName = announcement.droplet ||
                         <>
                           {"\u00A0"}has just finished{"\u00A0"}
                         </>
-                        
-                        <span>{droplet.trim()}</span>
-                        {/*<span>{taskPart?.trim()}</span> */}
-
+                        <span>{taskPart?.trim()}</span>
                         {announcementType === "friend" && (
                           <div className="flex flex-1 justify-end">
                             <KudosButton
                               authUser={authUser}
                               announcement={announcement}
-                              droplet={dropletName.trim()}
-                              /* droplet={
+                              droplet={
                                 announcement.content?.split(
                                   /finished\s+/i,
                                 )[1] || ""
-                              } */ 
+                              }
                             />
                           </div>
                         )}

--- a/frontend/components/feed/feed-block.tsx
+++ b/frontend/components/feed/feed-block.tsx
@@ -66,7 +66,10 @@ export function FeedBlock({
 
   const content = announcement.content;
   const [namePart] = content.split(/has\s+/i);
-  const [, taskPart] = content.split(/completed\s+/i);
+  //const [, taskPart] = content.split(/finished\s+/i);
+const dropletName = announcement.droplet || 
+  announcement.content.split(/finished\s+/i)[1] || "";
+
 
   return (
     <li
@@ -136,18 +139,21 @@ export function FeedBlock({
                         <>
                           {"\u00A0"}has just finished{"\u00A0"}
                         </>
-                        <span>{taskPart?.trim()}</span>
+                        
+                        <span>{droplet.trim()}</span>
+                        {/*<span>{taskPart?.trim()}</span> */}
 
                         {announcementType === "friend" && (
                           <div className="flex flex-1 justify-end">
                             <KudosButton
                               authUser={authUser}
                               announcement={announcement}
-                              droplet={
+                              droplet={dropletName.trim()}
+                              /* droplet={
                                 announcement.content?.split(
                                   /finished\s+/i,
                                 )[1] || ""
-                              }
+                              } */ 
                             />
                           </div>
                         )}

--- a/frontend/components/feed/feed-container.tsx
+++ b/frontend/components/feed/feed-container.tsx
@@ -15,7 +15,6 @@ export function FeedContainer({ authUser }: { authUser: AuthorizedUser }) {
   );
   const [filtersExpanded, setFiltersExpanded] = useState(false);
   const [requestsExpanded, setRequestsExpanded] = useState(false);
-
   return (
     <div className="flex flex-row gap-4">
       <div className="flex flex-col items-end gap-4">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Resolved the issue of friend announcements not showing droplet name after "<Friend_name> has just finished ___". Also solved a very similar issue for kudos announcements in which the droplet name would also be absent. Both should now be working. 

## Motivation and Context

This fix makes the friend and kudos announcements much more clear for users, adding to the refinement and quality of the platform.

## Screenshots (if appropriate):
<img width="806" height="338" alt="Screenshot 2025-09-26 at 3 47 47 PM" src="https://github.com/user-attachments/assets/faeb32e2-757c-4dc3-971e-a6311a044627" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced kudos announcements: now recognize both “completed” and “finished” phrasing.
  * Displays the related task description in the kudos message for clearer context.
  * Improved message readability with refined spacing in the kudos text.

* **Style**
  * Minor formatting/whitespace adjustments; no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->