### PR TITLE
ODY-14 Fix Droplet Due Date Display Logic for Completed and Overdue Items

### DIFF
--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -208,9 +208,9 @@ export function DropletTile({
                     } else if (daysUntil > 0) {
                       return `Due in ${daysUntil} days`;
                     } else {
-                      return daysUntil === -1?
-                      `One Day Late!`: 
-                      `${Math.abs(daysUntil)} Days Late!`;
+                      return daysUntil === -1
+                        ? `One Day Late!`
+                        : `${Math.abs(daysUntil)} Days Late!`;
                     }
                   })()}
                 </Badge>

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -190,7 +190,7 @@ export function DropletTile({
                 <Badge variant="destructive">Draft</Badge>
               ) : null}
 
-              {completionPercentage != 100 && dueDate && dueDate !== "" && daysUntil > -2 && (
+              {completionPercentage != 100 && dueDate && dueDate !== "" /*&& daysUntil > -2*/ && (
                 <Badge
                   className={getDueDateBadgeColor(daysUntil, true)}
                   variant="outline"

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -190,7 +190,7 @@ export function DropletTile({
                 <Badge variant="destructive">Draft</Badge>
               ) : null}
 
-              {dueDate && dueDate !== "" && daysUntil > -2 && (
+              {completionPercentage != 100 && dueDate && dueDate !== "" && daysUntil > -2 && (
                 <Badge
                   className={getDueDateBadgeColor(daysUntil, true)}
                   variant="outline"

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -208,7 +208,7 @@ export function DropletTile({
                     } else if (daysUntil > 0) {
                       return `Due in ${daysUntil} days`;
                     } else {
-                      return "Late!";
+                      return `${Math.abs(daysUntil)} Days Late!`;
                     }
                   })()}
                 </Badge>

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -190,7 +190,7 @@ export function DropletTile({
                 <Badge variant="destructive">Draft</Badge>
               ) : null}
 
-              {completionPercentage != 100 && dueDate && dueDate !== "" /*&& daysUntil > -2*/ && (
+              {completionPercentage != 100 && dueDate && dueDate !== "" && (
                 <Badge
                   className={getDueDateBadgeColor(daysUntil, true)}
                   variant="outline"
@@ -208,7 +208,9 @@ export function DropletTile({
                     } else if (daysUntil > 0) {
                       return `Due in ${daysUntil} days`;
                     } else {
-                      return `${Math.abs(daysUntil)} Days Late!`;
+                      return daysUntil === -1?
+                      `One Day Late!`: 
+                      `${Math.abs(daysUntil)} Days Late!`;
                     }
                   })()}
                 </Badge>


### PR DESCRIPTION
## Description
Fixed droplet due date badge rendering logic to properly handle completed droplets and overdue indicators. Completed droplets no longer show due date badges, and overdue droplets now correctly display late indicators.

**Key Changes:**
- Modified due date badge conditional rendering in DropletTile to hide when `completionPercentage === 100`
- Removed restrictive `daysUntil > -2` condition that prevented overdue badges from displaying
- Updated badge logic to properly show late indicators for overdue droplets

## Motivation and Context
**Problem:** The Explore page was showing due date badges for already completed droplets and failing to indicate when droplets were overdue, creating confusion for students about their assignment status.

**Solution:** By adding completion percentage checks and removing overly restrictive date conditions, students now see accurate droplet status - completed items show no due date, and overdue items are properly flagged as late.


## Screenshots (if appropriate):
### Problem 1: due date tag being shown even after completion
<img width="796" height="539" alt="Screenshot From 2025-09-26 16-13-36" src="https://github.com/user-attachments/assets/8adfc854-ed27-4f24-b86e-0644cf3d2f71" />

### Problem 2: due date not showing late droplet
<img width="796" height="539" alt="Screenshot From 2025-09-26 16-39-00" src="https://github.com/user-attachments/assets/ab03f395-326a-490e-8d36-222ff6d3a0cd" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Due-date badge now appears only when a due date exists and the item isn’t 100% complete; overdue label now indicates exact days late (e.g., "One Day Late!" or "X Days Late!") instead of a generic "Late!".

* **Documentation**
  * Refreshed generated documentation metadata with an updated generation timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->