### PR TITLE
Feature/ody 52 playlist progress on group page

### DIFF
--- a/frontend/components/group/group-droplet-tile.tsx
+++ b/frontend/components/group/group-droplet-tile.tsx
@@ -38,7 +38,7 @@ export function GroupDropletTile({
     daysUntil = Math.ceil(diffDays);
 
     finalDate = DateTime.fromISO(dueDate)
-      .setZone(authUser?.timeZone.trim() || "America/New_York")
+      .setZone(authUser?.timeZone || "America/New_York")
       .toFormat("MM/dd hh:mm a");
   }
 

--- a/frontend/components/group/group-progress-grid.tsx
+++ b/frontend/components/group/group-progress-grid.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-//import "react-tabs/style/react-tabs.css";
 import { ContentSection } from "@/components/group/content-section";
 import { Droplet } from "@/types";
 import { Playlist } from "@/types";
@@ -54,7 +53,6 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
 
   const startIndex = currentPage * lessonsPerPage;
   const endIndex = startIndex + lessonsPerPage;
-  const paginatedLessons = group.droplets?.slice(startIndex, endIndex);
 
   const paginate = (lessons: Droplet[]) => {
     return lessons.slice(startIndex, endIndex);
@@ -123,7 +121,6 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
         // Create headers with completion date columns
         const headers: string[] = [];
         getDisplayedDroplets().forEach((droplet) => {
-          // headers.push(`${droplet.name} (${droplet.id})`);
           headers.push(`${droplet.name}`);
           headers.push("Completion Date");
         });
@@ -266,14 +263,6 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
             <FileSpreadsheet />
             Download as Excel
           </Button>
-          {/* <select className="ml-2 border px-4 py-2 border-gray-300 rounded !h-[40px]" value={selectedValue} onChange={handleChange}>
-              <option value="">All Droplets</option>
-              {group.playlists?.map((option) => (
-                <option key={option.name} value={option.name}>
-                  {option.name}
-                </option>
-              ))}
-            </select> */}
           <Select
             value={selectedValue}
             onValueChange={(value) => {

--- a/frontend/components/group/group-progress-grid.tsx
+++ b/frontend/components/group/group-progress-grid.tsx
@@ -48,7 +48,7 @@ interface GroupProgressGridProps {
 }
 
 export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
-  const [selectedValue, setSelectedValue] = useState<string>("");
+  const [selectedValue, setSelectedValue] = useState<string>("all");
   const [currentPage, setCurrentPage] = useState(0);
   const lessonsPerPage = 4;
 

--- a/frontend/components/group/group-progress-grid.tsx
+++ b/frontend/components/group/group-progress-grid.tsx
@@ -309,7 +309,7 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
               getDisplayedDroplets().length <= lessonsPerPage
             }
             aria-label="Next page"
-            className={`px-4 py-2 ${currentPage >= totalPages - 1 || getDisplayedDroplets().length <= lessonsPerPage ? "visibility: hidden" : "visibility: visible"}`}
+            className={`px-4 py-2 ${(currentPage + 1) * lessonsPerPage >= getDisplayedDroplets().length || getDisplayedDroplets().length <= lessonsPerPage ? "visibility: hidden" : "visibility: visible"}`}
           >
             <MoveRight />
           </button>

--- a/frontend/components/group/group-progress-grid.tsx
+++ b/frontend/components/group/group-progress-grid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import "react-tabs/style/react-tabs.css";
+//import "react-tabs/style/react-tabs.css";
 import { ContentSection } from "@/components/group/content-section";
 import { Droplet } from "@/types";
 import { Playlist } from "@/types";
@@ -11,6 +11,30 @@ import { useState } from "react";
 import { Button } from "../ui/button";
 import * as XLSX from "xlsx-js-style";
 import { toast } from "sonner";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+
+
+
+
+const options: Option[] = [
+  { value: 'option1', label: 'Option 1' },
+  { value: 'option2', label: 'Option 2' },
+  { value: 'option3', label: 'Option 3' },
+  ];
+
 
 interface GroupProgressGridProps {
   group: {
@@ -30,6 +54,7 @@ interface GroupProgressGridProps {
 }
 
 export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
+  const [selectedValue, setSelectedValue] = useState<string>('');
   const [currentPage, setCurrentPage] = useState(0);
   const lessonsPerPage = 4;
 
@@ -37,6 +62,9 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
   const endIndex = startIndex + lessonsPerPage;
   const paginatedLessons = group.droplets?.slice(startIndex, endIndex);
 
+  const paginate = (lessons: Droplet[]) => {
+    return lessons.slice(startIndex, endIndex);
+  };
   const totalPages = Math.ceil((group.droplets?.length || 0) / lessonsPerPage);
 
   const handleNextPage = () => {
@@ -45,6 +73,10 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
 
   const handlePrevPage = () => {
     if (currentPage > 0) setCurrentPage(currentPage - 1);
+  };
+
+      const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedValue(event.target.value);
   };
 
   let sortedMembers: AuthorizedUser[] = [];
@@ -80,13 +112,21 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
       return "#e4e5e9";
     }
   };
+  const getDisplayedDroplets = () => {
+    if (selectedValue === "all") {
+      return group.droplets || [];
+    }
+    else {
+      return group.playlists?.find((playlist) => playlist.name === selectedValue)?.droplets || [];
+    }
+  }
 
   const exportGridToExcel = () => {
     try {
-      if (group.droplets && sortedMembers) {
+      if (getDisplayedDroplets() && sortedMembers) {
         // Create headers with completion date columns
         const headers: string[] = [];
-        group.droplets.forEach((droplet) => {
+        getDisplayedDroplets().forEach((droplet) => {
           // headers.push(`${droplet.name} (${droplet.id})`);
           headers.push(`${droplet.name}`);
           headers.push("Completion Date");
@@ -104,7 +144,7 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
           row.push(member.email, memberName);
 
           // Add completion percentage and completion date for each droplet
-          group.droplets!.forEach((droplet) => {
+          getDisplayedDroplets()!.forEach((droplet) => {
             const key = `${member.id}-${droplet.id}`;
             const status = statuses[key];
 
@@ -222,13 +262,39 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
   return (
     <div className="flex flex-col items-end">
       <div className="flex w-full flex-row justify-between">
-        <Button
-          className="border dark:border-slate-500 dark:bg-slate-800 dark:text-white dark:hover:text-slate-800"
-          onClick={exportGridToExcel}
-        >
-          <FileSpreadsheet />
-          Download as Excel
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            className="border dark:border-slate-500 dark:bg-slate-800 dark:text-white dark:hover:text-slate-800"
+            onClick={exportGridToExcel}
+          >
+            <FileSpreadsheet />
+            Download as Excel
+          </Button>
+            {/* <select className="ml-2 border px-4 py-2 border-gray-300 rounded !h-[40px]" value={selectedValue} onChange={handleChange}>
+              <option value="">All Droplets</option>
+              {group.playlists?.map((option) => (
+                <option key={option.name} value={option.name}>
+                  {option.name}
+                </option>
+              ))}
+            </select> */}
+            <Select value={selectedValue} onValueChange={(value) => {
+                setSelectedValue(value);
+                setCurrentPage(0);
+              }}>
+              <SelectTrigger className="ml-2 w-auto focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0">
+                <SelectValue placeholder="All Droplets" />
+              </SelectTrigger>
+              <SelectContent className="border-none">
+                <SelectItem value="all">All Droplets</SelectItem>
+                {group.playlists?.map((option) => (
+                  <SelectItem key={option.name} value={option.name}>
+                    {option.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         <div className="">
           <button
             onClick={handlePrevPage}
@@ -239,16 +305,16 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
           </button>
           <button
             onClick={handleNextPage}
-            disabled={currentPage === totalPages - 1}
+            disabled={currentPage === totalPages - 1 || getDisplayedDroplets().length <= lessonsPerPage}
             aria-label="Next page"
-            className={`px-4 py-2 ${currentPage >= totalPages - 1 ? "visibility: hidden" : "visibility: visible"}`}
+            className={`px-4 py-2 ${(currentPage >= totalPages - 1 || getDisplayedDroplets().length <= lessonsPerPage) ? "visibility: hidden" : "visibility: visible"}`}
           >
             <MoveRight />
           </button>
         </div>
       </div>
       <ContentSection title="">
-        {group.droplets && group.droplets.length > 0 ? (
+        {getDisplayedDroplets() && getDisplayedDroplets().length > 0 ? (
           <div className="flex flex-row justify-start">
             <div className="flex flex-col justify-self-start">
               <div className="bg-white-50 flex h-24 w-55 items-center justify-center border-slate-200 p-4 transition-colors hover:border-slate-300">
@@ -276,7 +342,7 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
 
             <div>
               <div className="flex flex-row">
-                {paginatedLessons?.map((droplet) => (
+                {paginate(getDisplayedDroplets())?.map((droplet) => (
                   <div
                     key={droplet.id}
                     className="bg-white-50 flex h-24 w-36 items-center justify-center border-slate-200 p-4 transition-colors hover:border-slate-300"
@@ -294,10 +360,10 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
               <div
                 className="grid grid-flow-row gap-0"
                 style={{
-                  gridTemplateColumns: `repeat(${paginatedLessons?.length || 1}, minmax(0, 1fr))`,
+                  gridTemplateColumns: `repeat(${paginate(getDisplayedDroplets())?.length || 1}, minmax(0, 1fr))`,
                 }}
               >
-                {paginatedLessons?.map((droplet) => (
+                {paginate(getDisplayedDroplets())?.map((droplet) => (
                   <div
                     className=""
                     key={`group-${group.id}-droplet-${droplet.id}`}

--- a/frontend/components/group/group-progress-grid.tsx
+++ b/frontend/components/group/group-progress-grid.tsx
@@ -17,24 +17,18 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select"
-
+} from "@/components/ui/select";
 
 interface Option {
   value: string;
   label: string;
 }
 
-
-
-
-
 const options: Option[] = [
-  { value: 'option1', label: 'Option 1' },
-  { value: 'option2', label: 'Option 2' },
-  { value: 'option3', label: 'Option 3' },
-  ];
-
+  { value: "option1", label: "Option 1" },
+  { value: "option2", label: "Option 2" },
+  { value: "option3", label: "Option 3" },
+];
 
 interface GroupProgressGridProps {
   group: {
@@ -54,7 +48,7 @@ interface GroupProgressGridProps {
 }
 
 export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
-  const [selectedValue, setSelectedValue] = useState<string>('');
+  const [selectedValue, setSelectedValue] = useState<string>("");
   const [currentPage, setCurrentPage] = useState(0);
   const lessonsPerPage = 4;
 
@@ -75,7 +69,7 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
     if (currentPage > 0) setCurrentPage(currentPage - 1);
   };
 
-      const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectedValue(event.target.value);
   };
 
@@ -115,11 +109,13 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
   const getDisplayedDroplets = () => {
     if (selectedValue === "all") {
       return group.droplets || [];
+    } else {
+      return (
+        group.playlists?.find((playlist) => playlist.name === selectedValue)
+          ?.droplets || []
+      );
     }
-    else {
-      return group.playlists?.find((playlist) => playlist.name === selectedValue)?.droplets || [];
-    }
-  }
+  };
 
   const exportGridToExcel = () => {
     try {
@@ -270,7 +266,7 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
             <FileSpreadsheet />
             Download as Excel
           </Button>
-            {/* <select className="ml-2 border px-4 py-2 border-gray-300 rounded !h-[40px]" value={selectedValue} onChange={handleChange}>
+          {/* <select className="ml-2 border px-4 py-2 border-gray-300 rounded !h-[40px]" value={selectedValue} onChange={handleChange}>
               <option value="">All Droplets</option>
               {group.playlists?.map((option) => (
                 <option key={option.name} value={option.name}>
@@ -278,23 +274,26 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
                 </option>
               ))}
             </select> */}
-            <Select value={selectedValue} onValueChange={(value) => {
-                setSelectedValue(value);
-                setCurrentPage(0);
-              }}>
-              <SelectTrigger className="ml-2 w-auto focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0">
-                <SelectValue placeholder="All Droplets" />
-              </SelectTrigger>
-              <SelectContent className="border-none">
-                <SelectItem value="all">All Droplets</SelectItem>
-                {group.playlists?.map((option) => (
-                  <SelectItem key={option.name} value={option.name}>
-                    {option.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+          <Select
+            value={selectedValue}
+            onValueChange={(value) => {
+              setSelectedValue(value);
+              setCurrentPage(0);
+            }}
+          >
+            <SelectTrigger className="ml-2 w-auto focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0">
+              <SelectValue placeholder="All Droplets" />
+            </SelectTrigger>
+            <SelectContent className="border-none">
+              <SelectItem value="all">All Droplets</SelectItem>
+              {group.playlists?.map((option) => (
+                <SelectItem key={option.name} value={option.name}>
+                  {option.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
         <div className="">
           <button
             onClick={handlePrevPage}
@@ -305,9 +304,12 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
           </button>
           <button
             onClick={handleNextPage}
-            disabled={currentPage === totalPages - 1 || getDisplayedDroplets().length <= lessonsPerPage}
+            disabled={
+              currentPage === totalPages - 1 ||
+              getDisplayedDroplets().length <= lessonsPerPage
+            }
             aria-label="Next page"
-            className={`px-4 py-2 ${(currentPage >= totalPages - 1 || getDisplayedDroplets().length <= lessonsPerPage) ? "visibility: hidden" : "visibility: visible"}`}
+            className={`px-4 py-2 ${currentPage >= totalPages - 1 || getDisplayedDroplets().length <= lessonsPerPage ? "visibility: hidden" : "visibility: visible"}`}
           >
             <MoveRight />
           </button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added a dropdown menu in the groups progress page to select group playlists and see the progress of the droplets in those playlists and download just the data for those droplets
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
I added this to allow teachers to assign a certain amount of droplets in a playlist and use this to determine if the students have met the quota

## Screenshots (if appropriate):
<img width="951" height="778" alt="image" src="https://github.com/user-attachments/assets/9600be74-6fee-4372-a94d-675692af5829" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a playlist filter dropdown to choose which droplets are shown.
  - Export to Excel now exports only the currently visible/filtered droplets.

- **Refactor**
  - Grid headers, cells, column layout, pagination, Next button behavior, rendering, and empty states now follow the filtered/visible droplet set for consistent display and interactions.

- **Bug Fixes**
  - Timezone handling updated to avoid trimming user timezone values, reducing unexpected timestamp changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->