### PR TITLE
feature/ody-49 add statistic to track retention rate on admin page

### DIFF
--- a/frontend/app/(general)/admin/page.tsx
+++ b/frontend/app/(general)/admin/page.tsx
@@ -49,7 +49,6 @@ export default async function Page() {
     getRetentionData(),
   ]);
 
-  
   const { retentionRate, totalEnrollments, completedEnrollments } =
     await getRetentionData();
 

--- a/frontend/app/(general)/admin/page.tsx
+++ b/frontend/app/(general)/admin/page.tsx
@@ -28,6 +28,7 @@ import { UniquePageviewChart } from "@/components/admin/unique-pageview";
 import { NewUsersChart } from "@/components/admin/new-users";
 import { get } from "lodash";
 
+// General Admin Page Component
 export default async function Page() {
   const user = await getCurrentUser();
 
@@ -49,11 +50,13 @@ export default async function Page() {
     getRetentionData(),
   ]);
 
+  // Destructure retention data
   const { retentionRate, totalEnrollments, completedEnrollments } =
     retentionData;
 
   if (!user || !isAuthorizedUserAdmin(user.roles)) return notFound();
 
+  // Content for admin section
   const pageContent = {
     Users: <AuthorizedUsers />,
     Droplets: <Droplets />,
@@ -63,6 +66,7 @@ export default async function Page() {
     Reports: <Reports />,
   };
 
+  // Content for statistics section
   const statisticsContent = {
     "General Statistics": (
       <GeneralStatistics
@@ -78,6 +82,7 @@ export default async function Page() {
     // "Weekly New Users": <NewUsersChart data={newUsers} />,
   };
 
+  // Main render
   return (
     <div className="mx-auto w-full max-w-5xl">
       <div className="mx-auto my-4 w-full max-w-7xl p-8 text-center">
@@ -112,6 +117,7 @@ export default async function Page() {
   );
 }
 
+// General Statistics Component
 function GeneralStatistics({
   authorizedUsersLength,
   droplets,

--- a/frontend/app/(general)/admin/page.tsx
+++ b/frontend/app/(general)/admin/page.tsx
@@ -50,7 +50,7 @@ export default async function Page() {
   ]);
 
   const { retentionRate, totalEnrollments, completedEnrollments } =
-    await getRetentionData();
+    retentionData;
 
   if (!user || !isAuthorizedUserAdmin(user.roles)) return notFound();
 

--- a/frontend/app/(general)/admin/page.tsx
+++ b/frontend/app/(general)/admin/page.tsx
@@ -13,6 +13,7 @@ import { Droplets } from "@/components/admin/droplets/droplets";
 import { Groups } from "@/components/admin/groups/groups";
 import { Playlists } from "@/components/admin/playlists/playlists";
 import { ComponentDropdown } from "@/components/shared/component-dropdown";
+import { getRetentionData } from "@/lib/requests/analytics";
 import {
   fetchDailyActiveUsers,
   fetchUniquePageview,
@@ -25,10 +26,10 @@ import { StatisticsSelector } from "@/components/admin/statistics-selector";
 import { WeeklyActiveUsersChart } from "@/components/admin/weekly-active-users-chart";
 import { UniquePageviewChart } from "@/components/admin/unique-pageview";
 import { NewUsersChart } from "@/components/admin/new-users";
+import { get } from "lodash";
 
 export default async function Page() {
   const user = await getCurrentUser();
-  let totalEnrollments = 0;
 
   const [
     authorizedUsers,
@@ -37,7 +38,7 @@ export default async function Page() {
     weeklyActiveUsers,
     pageviewCount,
     newUsers,
-    enrollments,
+    retentionData,
   ] = await Promise.all([
     fetchAuthorizedUsersMetadata(),
     fetchDroplets(),
@@ -45,10 +46,12 @@ export default async function Page() {
     fetchWeeklyActiveUsers(),
     fetchUniquePageview(),
     fetchWeeklyNewUsers(),
-    fetchEnrollmentMetadata(),
+    getRetentionData(),
   ]);
 
-  totalEnrollments = enrollments?.meta.pagination.total || 0;
+  
+  const { retentionRate, totalEnrollments, completedEnrollments } =
+    await getRetentionData();
 
   if (!user || !isAuthorizedUserAdmin(user.roles)) return notFound();
 
@@ -67,6 +70,7 @@ export default async function Page() {
         droplets={droplets}
         authorizedUsersLength={authorizedUsers.meta.pagination.total}
         totalEnrollments={totalEnrollments}
+        retentionRate={retentionRate}
       />
     ),
     "Daily Active Users": <DailyActiveUsersChart data={dailyActiveUsers} />,
@@ -113,10 +117,12 @@ function GeneralStatistics({
   authorizedUsersLength,
   droplets,
   totalEnrollments,
+  retentionRate,
 }: {
   authorizedUsersLength: number;
   droplets: Droplet[];
   totalEnrollments: number;
+  retentionRate: number;
 }) {
   return (
     <div className="flex items-center justify-center gap-x-8 gap-y-6 text-center sm:flex-row">
@@ -148,6 +154,16 @@ function GeneralStatistics({
             </div>
             <div className="text-sm text-slate-500 dark:text-slate-400">
               {totalEnrollments}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center space-x-3">
+          <div>
+            <div className="font-medium dark:text-slate-300">
+              Retention Rate
+            </div>
+            <div className="text-sm text-slate-500 dark:text-slate-400">
+              {retentionRate}%
             </div>
           </div>
         </div>

--- a/frontend/lib/requests/analytics.ts
+++ b/frontend/lib/requests/analytics.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { fetchDroplets } from "./data";
+import { fetchEnrollmentMetadata } from "./enrollment";
+import { fetchAPI } from "../utils";
+import { Droplet, Enrollment } from "@/types";
+import { StrapiRequestParams } from "@/types/strapi";
+
+// Function to get all enrollments
+async function getCompletedEnrollmentsCount(): Promise<number> {
+  const response = await fetchEnrollmentMetadata({
+    filters: { isComplete: { $eq: true } },
+    pagination: { pageSize: 1, page: 1 },
+  });
+
+  return response?.meta?.pagination?.total || 0;
+}
+
+export async function getRetentionData() {
+  const [enrollmentMetadata, completedCount] = await Promise.all([
+    fetchEnrollmentMetadata(),
+    getCompletedEnrollmentsCount(),
+  ]);
+
+  const totalEnrollments = enrollmentMetadata?.meta?.pagination?.total || 0;
+  const completedEnrollments = completedCount;
+
+  console.log("Debug - Total enrollments:", totalEnrollments);
+  console.log("Debug - Completed enrollments:", completedEnrollments);
+
+  const retentionRate =
+    totalEnrollments === 0
+      ? 0
+      : Math.round((completedEnrollments / totalEnrollments) * 10000) / 100;
+
+  return {
+    retentionRate,
+    totalEnrollments,
+    completedEnrollments,
+  };
+}

--- a/frontend/lib/requests/analytics.ts
+++ b/frontend/lib/requests/analytics.ts
@@ -16,6 +16,7 @@ async function getCompletedEnrollmentsCount(): Promise<number> {
   return response?.meta?.pagination?.total || 0;
 }
 
+// Function to get retention data
 export async function getRetentionData() {
   const [enrollmentMetadata, completedCount] = await Promise.all([
     fetchEnrollmentMetadata(),
@@ -25,9 +26,7 @@ export async function getRetentionData() {
   const totalEnrollments = enrollmentMetadata?.meta?.pagination?.total || 0;
   const completedEnrollments = completedCount;
 
-  console.log("Debug - Total enrollments:", totalEnrollments);
-  console.log("Debug - Completed enrollments:", completedEnrollments);
-
+  // Calculate retention rate
   const retentionRate =
     totalEnrollments === 0
       ? 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a "Retention Rate" metric to the Admin -> General Statistics tab. This is calculated by dividing the total # of completed droplets by the total # of enrollments, showcasing what percentage of droplets that were started were actually finished. Right now the database only contains 16 completed droplets to my knowledge, so the percentage is pretty low. 

## Motivation and Context

This allows admin to view the success of the site and get a general glimpse into how effective and engaging the droplets are. It would also be a good metric to use when promoting the site, if the % is high. 

## Screenshots (if appropriate):
<img width="760" height="137" alt="Screenshot 2025-09-29 at 1 58 35 PM" src="https://github.com/user-attachments/assets/33f28018-4f48-4a68-bd2e-6ce576dcf91e" />


## Checklist:



<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Retention Rate tile to the Admin General Statistics panel.
  - Dashboard now displays retention rate alongside total and completed enrollments.

- **Refactor**
  - Statistics data flow now uses a unified analytics data source to compute and supply retention metrics to the dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->