### PR TITLE
Ody 15 sort by due date and see droplet due date on explore and

### DIFF
--- a/frontend/app/(general)/admin/page.tsx
+++ b/frontend/app/(general)/admin/page.tsx
@@ -49,7 +49,6 @@ export default async function Page() {
     getRetentionData(),
   ]);
 
-  
   const { retentionRate, totalEnrollments, completedEnrollments } =
     await getRetentionData();
 

--- a/frontend/app/(general)/admin/page.tsx
+++ b/frontend/app/(general)/admin/page.tsx
@@ -13,6 +13,7 @@ import { Droplets } from "@/components/admin/droplets/droplets";
 import { Groups } from "@/components/admin/groups/groups";
 import { Playlists } from "@/components/admin/playlists/playlists";
 import { ComponentDropdown } from "@/components/shared/component-dropdown";
+import { getRetentionData } from "@/lib/requests/analytics";
 import {
   fetchDailyActiveUsers,
   fetchUniquePageview,
@@ -25,10 +26,10 @@ import { StatisticsSelector } from "@/components/admin/statistics-selector";
 import { WeeklyActiveUsersChart } from "@/components/admin/weekly-active-users-chart";
 import { UniquePageviewChart } from "@/components/admin/unique-pageview";
 import { NewUsersChart } from "@/components/admin/new-users";
+import { get } from "lodash";
 
 export default async function Page() {
   const user = await getCurrentUser();
-  let totalEnrollments = 0;
 
   const [
     authorizedUsers,
@@ -37,7 +38,7 @@ export default async function Page() {
     weeklyActiveUsers,
     pageviewCount,
     newUsers,
-    enrollments,
+    retentionData,
   ] = await Promise.all([
     fetchAuthorizedUsersMetadata(),
     fetchDroplets(),
@@ -45,10 +46,12 @@ export default async function Page() {
     fetchWeeklyActiveUsers(),
     fetchUniquePageview(),
     fetchWeeklyNewUsers(),
-    fetchEnrollmentMetadata(),
+    getRetentionData(),
   ]);
 
-  totalEnrollments = enrollments?.meta.pagination.total || 0;
+  
+  const { retentionRate, totalEnrollments, completedEnrollments } =
+    await getRetentionData();
 
   if (!user || !isAuthorizedUserAdmin(user.roles)) return notFound();
 
@@ -67,6 +70,7 @@ export default async function Page() {
         droplets={droplets}
         authorizedUsersLength={authorizedUsers.meta.pagination.total}
         totalEnrollments={totalEnrollments}
+        retentionRate={retentionRate}
       />
     ),
     "Daily Active Users": <DailyActiveUsersChart data={dailyActiveUsers} />,
@@ -113,10 +117,12 @@ function GeneralStatistics({
   authorizedUsersLength,
   droplets,
   totalEnrollments,
+  retentionRate,
 }: {
   authorizedUsersLength: number;
   droplets: Droplet[];
   totalEnrollments: number;
+  retentionRate: number;
 }) {
   return (
     <div className="flex items-center justify-center gap-x-8 gap-y-6 text-center sm:flex-row">
@@ -148,6 +154,16 @@ function GeneralStatistics({
             </div>
             <div className="text-sm text-slate-500 dark:text-slate-400">
               {totalEnrollments}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center space-x-3">
+          <div>
+            <div className="font-medium dark:text-slate-300">
+              Retention Rate
+            </div>
+            <div className="text-sm text-slate-500 dark:text-slate-400">
+              {retentionRate}%
             </div>
           </div>
         </div>

--- a/frontend/components/dashboard/enrolled-droplets-grid-client.tsx
+++ b/frontend/components/dashboard/enrolled-droplets-grid-client.tsx
@@ -54,6 +54,24 @@ export function EnrolledDropletsGridClient({
             : b.completionPercentage - a.completionPercentage;
         } else if (field === "rating") {
           return direction === "asc" ? ratingA - ratingB : ratingB - ratingA;
+        } else if (field === "duedate") {
+          const dueDateA = dueDates?.find(
+            (dueDate) => dueDate.droplet?.id === a.id,
+          )?.dueDate;
+          const dueDateB = dueDates?.find(
+            (dueDate) => dueDate.droplet?.id === b.id,
+          )?.dueDate;
+          if (dueDateA && dueDateB) {
+            return direction === "asc"
+              ? new Date(dueDateA).getTime() - new Date(dueDateB).getTime()
+              : new Date(dueDateB).getTime() - new Date(dueDateA).getTime();
+          } else if (dueDateA) {
+            return -1; // a comes first
+          } else if (dueDateB) {
+            return 1; // b comes first
+          } else {
+            return 0; // no change in order
+          }
         }
         return 0;
       });

--- a/frontend/components/explore/sorted-droplets-grid.tsx
+++ b/frontend/components/explore/sorted-droplets-grid.tsx
@@ -56,6 +56,24 @@ export function SortedDropletsGrid({
             : b.completionPercentage - a.completionPercentage;
         } else if (field === "rating") {
           return direction === "asc" ? ratingA - ratingB : ratingB - ratingA;
+        } else if (field === "duedate") {
+          const dueDateA = dueDates?.find(
+            (dueDate) => dueDate.droplet?.id === a.id,
+          )?.dueDate;
+          const dueDateB = dueDates?.find(
+            (dueDate) => dueDate.droplet?.id === b.id,
+          )?.dueDate;
+          if (dueDateA && dueDateB) {
+            return direction === "asc"
+              ? new Date(dueDateA).getTime() - new Date(dueDateB).getTime()
+              : new Date(dueDateB).getTime() - new Date(dueDateA).getTime();
+          } else if (dueDateA) {
+            return -1; // a comes first
+          } else if (dueDateB) {
+            return 1; // b comes first
+          } else {
+            return 0; // no change in order
+          }
         }
         return 0;
       });

--- a/frontend/lib/globals.ts
+++ b/frontend/lib/globals.ts
@@ -99,7 +99,9 @@ export type SortFilterItem = {
     | "completion:asc"
     | "completion:desc"
     | "rating:asc"
-    | "rating:desc";
+    | "rating:desc"
+    | "duedate:asc"
+    | "duedate:desc";
 };
 
 export const sorting: SortFilterItem[] = [
@@ -124,6 +126,16 @@ export const sorting: SortFilterItem[] = [
     label: "Worst Rating",
     slug: "rating:asc",
     sortKey: "rating:asc",
+  },
+  {
+    label: "Due Date (Soonest)",
+    slug: "duedate:asc",
+    sortKey: "duedate:asc",
+  },
+  {
+    label: "Due Date (Latest)",
+    slug: "duedate:desc",
+    sortKey: "duedate:desc",
   },
 ];
 

--- a/frontend/lib/requests/analytics.ts
+++ b/frontend/lib/requests/analytics.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { fetchDroplets } from "./data";
+import { fetchEnrollmentMetadata } from "./enrollment";
+import { fetchAPI } from "../utils";
+import { Droplet, Enrollment } from "@/types";
+import { StrapiRequestParams } from "@/types/strapi";
+
+// Function to get all enrollments
+async function getCompletedEnrollmentsCount(): Promise<number> {
+  const response = await fetchEnrollmentMetadata({
+    filters: { isComplete: { $eq: true } },
+    pagination: { pageSize: 1, page: 1 },
+  });
+
+  return response?.meta?.pagination?.total || 0;
+}
+
+export async function getRetentionData() {
+  const [enrollmentMetadata, completedCount] = await Promise.all([
+    fetchEnrollmentMetadata(),
+    getCompletedEnrollmentsCount(),
+  ]);
+
+  const totalEnrollments = enrollmentMetadata?.meta?.pagination?.total || 0;
+  const completedEnrollments = completedCount;
+
+  console.log("Debug - Total enrollments:", totalEnrollments);
+  console.log("Debug - Completed enrollments:", completedEnrollments);
+
+  const retentionRate =
+    totalEnrollments === 0
+      ? 0
+      : Math.round((completedEnrollments / totalEnrollments) * 10000) / 100;
+
+  return {
+    retentionRate,
+    totalEnrollments,
+    completedEnrollments,
+  };
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Allows users to sort droplets in explore and in the dashboard by their due date, with droplets with no due date appearing at the end
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This allows students to quickly find their assigned droplets and complete them in order of urgency

## Screenshots (if appropriate):
<img width="1909" height="1022" alt="image" src="https://github.com/user-attachments/assets/60bbc33d-dd8d-4d7c-9b53-9fc0488adf7e" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added gallery subtitles across backend and frontend; subtitles now display in galleries.
  - Introduced Retention Rate metric on the Admin dashboard.
  - Added sorting by Due Date (Soonest/Latest) in droplets grids.

- Bug Fixes
  - Access Requests now hide users who are already authorized.
  - Improved due-date badge logic and clearer “Late” messaging.

- Style
  - Expanded dark mode text coverage and readability.
  - Enhanced feed kudos parsing and layout.

- Documentation
  - Updated generated API documentation to include gallery subtitles.

- Tests
  - Added tests for Access Requests filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->