### PR TITLE
Feature/ody 17 expand playlist tiles to include more information ex tags

### DIFF
--- a/frontend/components/playlists/playlist-card.tsx
+++ b/frontend/components/playlists/playlist-card.tsx
@@ -44,7 +44,12 @@ export function PlaylistCard({
   const [isTextClamped, setIsTextClamped] = useState(false);
   const [isScreenChanged, setIsScreenChanged] = useState(false); // New state variable to track screen size changes
   const textRef = useRef(null);
-
+  const dropletCount = playlist.droplets ? playlist.droplets.length : 0;
+  const lessonCount =
+    playlist.droplets?.reduce(
+      (total, droplet) => total + (droplet.lessons?.length ?? 0),
+      0,
+    ) ?? 0;
   const strippedDescription = playlist.description
     ?.replace(/<\/p>\s*<p>/gi, "\n")
     .replace(/<br\s*\/?>/gi, "\n")
@@ -109,12 +114,8 @@ export function PlaylistCard({
           </CardTitle>
 
           <p className="light:text-slate-600 pt-2 text-sm dark:text-slate-300">
-            Droplets: {playlist.droplets ? playlist.droplets.length : ""}{" "}
-            Lessons:{" "}
-            {playlist.droplets?.reduce(
-              (total, droplet) => total + (droplet.lessons?.length ?? 0),
-              0,
-            ) ?? 0}{" "}
+            Droplets: {dropletCount} &nbsp;&nbsp;&nbsp;&nbsp; Lessons:{" "}
+            {lessonCount}
           </p>
           <div>
             {strippedDescription &&

--- a/frontend/components/playlists/playlist-card.tsx
+++ b/frontend/components/playlists/playlist-card.tsx
@@ -4,6 +4,7 @@ import { getDueDateBadgeColor } from "@/lib/utils";
 import { Clock } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { DateTime } from "luxon";
+import { getDropletById } from "@/lib/requests/droplet";
 
 interface PlaylistCardProps {
   playlist: {
@@ -37,7 +38,6 @@ export function PlaylistCard({
   timeZone,
 }: PlaylistCardProps) {
   const linkTo = toDraft ? `/draft/p/${playlist.slug}` : `/p/${playlist.slug}`;
-
   let daysUntil = 0;
   if (dueDate && dueDate !== "") {
     const dueDateObject = DateTime.fromISO(dueDate);
@@ -88,6 +88,18 @@ export function PlaylistCard({
             {playlist.droplets?.length === 1
               ? "1 droplet"
               : `${playlist.droplets?.length || 0} droplets`}
+          </p>
+          <p className="text-muted-foreground text-sm">
+            {playlist.droplets?.reduce(
+              (total, droplet) => total + (droplet.lessons?.length ?? 0),
+              0,
+            ) ?? 0}{" "}
+            lessons
+          </p>
+          <p className="text-muted-foreground text-sm">
+            {playlist.description
+              ? playlist.description
+              : "No description provided."}
           </p>
         </CardHeader>
       </Card>

--- a/frontend/components/playlists/playlist-card.tsx
+++ b/frontend/components/playlists/playlist-card.tsx
@@ -1,10 +1,13 @@
+"use client";
+
 import Link from "next/link";
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { getDueDateBadgeColor } from "@/lib/utils";
 import { Clock } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { DateTime } from "luxon";
 import { getDropletById } from "@/lib/requests/droplet";
+import { useState, useEffect, useRef } from "react";
 
 interface PlaylistCardProps {
   playlist: {
@@ -37,6 +40,26 @@ export function PlaylistCard({
   dueDate,
   timeZone,
 }: PlaylistCardProps) {
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+  const [isTextClamped, setIsTextClamped] = useState(false);
+  const [isScreenChanged, setIsScreenChanged] = useState(false); // New state variable to track screen size changes
+  const textRef = useRef(null);
+
+  const strippedDescription = playlist.description
+    ?.replace(/<\/p>\s*<p>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/?p>/gi, "")
+    .replace(/<[^>]+>/g, "")
+    .trim();
+
+  useEffect(() => {
+    if (textRef.current && strippedDescription) {
+      const element = textRef.current as HTMLParagraphElement;
+      const isClamped = element.scrollHeight > element.clientHeight;
+      setIsTextClamped(isClamped);
+    }
+  }, [strippedDescription, descriptionExpanded]);
+
   const linkTo = toDraft ? `/draft/p/${playlist.slug}` : `/p/${playlist.slug}`;
   let daysUntil = 0;
   if (dueDate && dueDate !== "") {
@@ -84,23 +107,55 @@ export function PlaylistCard({
           <CardTitle className="block w-full place-self-end text-3xl font-black text-slate-950 dark:text-slate-300">
             {playlist.name}
           </CardTitle>
-          <p className="text-muted-foreground text-sm">
-            {playlist.droplets?.length === 1
-              ? "1 droplet"
-              : `${playlist.droplets?.length || 0} droplets`}
-          </p>
-          <p className="text-muted-foreground text-sm">
+
+          <p className="light:text-slate-600 pt-2 text-sm dark:text-slate-300">
+            Droplets: {playlist.droplets ? playlist.droplets.length : ""}{" "}
+            Lessons:{" "}
             {playlist.droplets?.reduce(
               (total, droplet) => total + (droplet.lessons?.length ?? 0),
               0,
             ) ?? 0}{" "}
-            lessons
           </p>
-          <p className="text-muted-foreground text-sm">
-            {playlist.description
-              ? playlist.description
-              : "No description provided."}
-          </p>
+          <div>
+            {strippedDescription &&
+              strippedDescription.trim() !== "<p></p>" &&
+              strippedDescription.trim() !== "" && (
+                <>
+                  <p
+                    ref={textRef}
+                    className={`${
+                      descriptionExpanded ? "line-clamp-none" : "line-clamp-2"
+                    } text-md text-slate-700 dark:text-slate-300`}
+                  >
+                    {strippedDescription}
+                  </p>
+
+                  {isTextClamped && !descriptionExpanded && (
+                    <button
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setDescriptionExpanded(true);
+                      }}
+                      className="text-left text-sm text-sky-700 dark:text-sky-500"
+                    >
+                      See More
+                    </button>
+                  )}
+
+                  {descriptionExpanded && (
+                    <button
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setDescriptionExpanded(false);
+                      }}
+                      className="text-left text-sm text-sky-700 dark:text-sky-500"
+                    >
+                      See Less
+                    </button>
+                  )}
+                </>
+              )}
+          </div>
         </CardHeader>
       </Card>
     </Link>

--- a/frontend/components/playlists/playlist-form.tsx
+++ b/frontend/components/playlists/playlist-form.tsx
@@ -23,6 +23,7 @@ interface PlaylistFormProps {
   existingPlaylist?: {
     id: number;
     name: string;
+    description?: string;
     slug: string;
     isPublic: boolean;
     droplets?: Droplet[];
@@ -37,6 +38,9 @@ export function PlaylistForm({
 }: PlaylistFormProps) {
   const router = useRouter();
   const [name, setName] = useState(existingPlaylist?.name || "");
+  const [description, setDescription] = useState(
+    existingPlaylist?.description || "",
+  );
   const [isPublic, setIsPublic] = useState(existingPlaylist?.isPublic || false);
   const [selectedDroplets, setSelectedDroplets] = useState(
     existingPlaylist?.droplets || [],
@@ -138,6 +142,7 @@ export function PlaylistForm({
 
     const updatePlaylistData = {
       name,
+      description,
       isPublic,
       droplets: selectedDroplets.map((droplet) => ({ id: droplet.id })),
       author: { id: author.id },
@@ -146,6 +151,7 @@ export function PlaylistForm({
     };
     const playlistData = {
       name,
+      description,
       isPublic,
       droplets: selectedDroplets.map((droplet) => ({ id: droplet.id })),
       author: { id: author.id },
@@ -205,6 +211,17 @@ export function PlaylistForm({
             onCheckedChange={setIsPublic}
           />
           <Label htmlFor="public">Make this playlist public</Label>
+        </div>
+
+        <div>
+          <Label htmlFor="description">Playlist Description</Label>
+          <Input
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Enter playlist description"
+            className="max-w-xl"
+          />
         </div>
       </div>
 

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -45,6 +45,11 @@ export async function getAuthorizedUserByEmail<
         populate: {
           droplets: {
             fields: "*",
+            populate: {
+              lessons: {
+                fields: ["*"], // or just ["id"] if you only need the count
+              },
+            },
           },
         },
       },
@@ -53,6 +58,11 @@ export async function getAuthorizedUserByEmail<
         populate: {
           droplets: {
             fields: "*",
+            populate: {
+              lessons: {
+                fields: ["*"], // or just ["id"] if you only need the count
+              },
+            },
           },
         },
       },

--- a/frontend/lib/requests/playlist.ts
+++ b/frontend/lib/requests/playlist.ts
@@ -135,6 +135,7 @@ export async function updatePlaylist(
   id: number,
   data: {
     name: string;
+    description: string;
     isPublic: boolean;
     droplets?: { id: number }[];
     authors?: { id: number };
@@ -145,6 +146,7 @@ export async function updatePlaylist(
   try {
     const dataToSend = {
       name: data.name,
+      description: data.description,
       isPublic: data.isPublic,
       droplets: {
         set: data.droplets, // 'set' replaces all existing relationships
@@ -193,6 +195,7 @@ export async function updatePlaylist(
 export async function createPlaylist(data: {
   name: string;
   isPublic: boolean;
+  description: string;
   droplets: { id: number }[];
   author: { id: number };
   userId: number;
@@ -201,6 +204,7 @@ export async function createPlaylist(data: {
   try {
     const dataToSend = {
       name: data.name,
+      description: data.description,
       authors: {
         set: [data.author.id],
       },

--- a/frontend/tests/components/explore/playlists-grid.test.tsx
+++ b/frontend/tests/components/explore/playlists-grid.test.tsx
@@ -81,7 +81,9 @@ describe("PlaylistsGrid", () => {
         await PlaylistsGrid({ playlists: mockPlaylists }),
       );
 
-      expect(container).toHaveTextContent("Test Playlist0 droplets");
+      expect(container).toHaveTextContent(
+        "Test PlaylistDroplets: 0 Lessons: 0",
+      );
     });
 
     it("sorts playlists by name correctly", async () => {

--- a/frontend/tests/components/playlists/playlist-card.test.tsx
+++ b/frontend/tests/components/playlists/playlist-card.test.tsx
@@ -15,7 +15,7 @@ describe("PlaylistCard", () => {
   it("renders playlist name and droplet count", () => {
     render(<PlaylistCard playlist={mockPlaylist} />);
     expect(screen.getByText("Test Playlist")).toBeInTheDocument();
-    expect(screen.getByText("0 droplets")).toBeInTheDocument();
+    expect(screen.getByText("Droplets: 0 Lessons: 0")).toBeInTheDocument();
   });
 
   it("shows due date badge when date is provided", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added a lesson count and a description display on the playlist tiles. Also created a box for creators to add descriptions to new or existing playlists in the playlist creator. 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This changes allows more details to be displayed in the playlist tiles and allows playlists to have descriptions assigned on the frontend.

## Screenshots (if appropriate):
<img width="477" height="275" alt="image" src="https://github.com/user-attachments/assets/015e41cc-14fc-43a6-b76e-ebb3b13ca627" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Playlist cards show combined "Droplets" and "Lessons" counts and display a collapsible description with "See More"/"See Less".
  - Playlist form adds a Description field for creating and editing playlist descriptions.
- Bug Fixes / Data
  - Authorized user views now include lesson details so lesson counts are accurate.
- Tests
  - Updated tests to expect the combined counts and description behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->