### PR TITLE
Feature/ody 59 due date fixes

### DIFF
--- a/frontend/components/first-time/first-visit-popup.tsx
+++ b/frontend/components/first-time/first-visit-popup.tsx
@@ -17,12 +17,56 @@ import { useRouter } from "next/navigation";
 import { Logo } from "../header/logo";
 import { createSystemAnnouncement } from "@/lib/requests/feed";
 import { updateUserInfo } from "@/lib/requests/authorized-user";
+import { setTimeZone } from "@/lib/actions";
+
+const timeZones = [
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Phoenix",
+  "America/Los_Angeles",
+  "America/Anchorage",
+  "America/Honolulu",
+  "America/Bogota",
+  "America/Lima",
+  "America/Caracas",
+  "America/Santiago",
+  "America/Argentina/Buenos_Aires",
+  "America/Sao_Paulo",
+  "Europe/London",
+  "Europe/Berlin",
+  "Europe/Paris",
+  "Europe/Madrid",
+  "Europe/Rome",
+  "Europe/Athens",
+  "Europe/Istanbul",
+  "Europe/Moscow",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Shanghai",
+  "Asia/Tokyo",
+  "Asia/Seoul",
+  "Asia/Bangkok",
+  "Asia/Singapore",
+  "Asia/Jakarta",
+  "Asia/Hong_Kong",
+  "Australia/Sydney",
+  "Australia/Melbourne",
+  "Australia/Brisbane",
+  "Pacific/Auckland",
+  "Pacific/Fiji",
+  "Africa/Cairo",
+  "Africa/Johannesburg",
+  "Africa/Lagos",
+  "Africa/Nairobi",
+];
 
 export function FirstVisitPopup({ user }: { user: AuthorizedUser | null }) {
   const [isOpen, setIsOpen] = useState(false);
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [bio, setBio] = useState("");
+  const [timeZone, setThisTimeZone] = useState("");
   const router = useRouter();
 
   useEffect(() => {
@@ -40,6 +84,10 @@ export function FirstVisitPopup({ user }: { user: AuthorizedUser | null }) {
       toast.error("Please enter your last name before continuing");
       return;
     }
+    if (!timeZone.trim()) {
+      toast.error("Please select your time zone before continuing");
+      return;
+    }
     try {
       if (user) {
         await updateUserInfo(user.id, { firstTime: false });
@@ -48,6 +96,7 @@ export function FirstVisitPopup({ user }: { user: AuthorizedUser | null }) {
           last: lastName,
           bio: bio,
         });
+        await setTimeZone(timeZone + "  ", user.id);
         await createSystemAnnouncement(
           "Want to see what your friends are up to? Their activity will appear here on your feed — just head to your profile to follow them!",
           user,
@@ -127,6 +176,25 @@ export function FirstVisitPopup({ user }: { user: AuthorizedUser | null }) {
             aria-label="Bio"
             className="focus:ring-0"
           />
+        </div>
+        <div className="mt-4 flex flex-col gap-4">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            Choose your time zone: <span className="text-red-500">*</span>
+          </p>
+          <select
+            className="w-[50%] rounded-md border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-slate-800 dark:bg-black dark:text-white"
+            value={timeZone}
+            onChange={(e) => setThisTimeZone(e.target.value)}
+          >
+            <option value="" disabled>
+              Choose a time zone...
+            </option>
+            {timeZones.map((tz) => (
+              <option key={tz} value={tz}>
+                {tz}
+              </option>
+            ))}
+          </select>
         </div>
         <div className="mt-4 flex flex-col gap-4">
           <p className="text-sm text-slate-600 dark:text-slate-400">

--- a/frontend/components/first-time/first-visit-popup.tsx
+++ b/frontend/components/first-time/first-visit-popup.tsx
@@ -182,6 +182,7 @@ export function FirstVisitPopup({ user }: { user: AuthorizedUser | null }) {
             Choose your time zone: <span className="text-red-500">*</span>
           </p>
           <select
+            aria-label="Choose a time zone..."
             className="w-[50%] rounded-md border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-slate-800 dark:bg-black dark:text-white"
             value={timeZone}
             onChange={(e) => setThisTimeZone(e.target.value)}

--- a/frontend/components/group/group-droplet-tile.tsx
+++ b/frontend/components/group/group-droplet-tile.tsx
@@ -38,7 +38,7 @@ export function GroupDropletTile({
     daysUntil = Math.ceil(diffDays);
 
     finalDate = DateTime.fromISO(dueDate)
-      .setZone(authUser?.timeZone || "America/New_York")
+      .setZone(authUser?.timeZone?.trim() || "America/New_York")
       .toFormat("MM/dd hh:mm a");
   }
 

--- a/frontend/components/group/group-management-dashboard.tsx
+++ b/frontend/components/group/group-management-dashboard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
-import "react-tabs/style/react-tabs.css";
 
 import { ContentSection } from "@/components/group/content-section";
 import { GroupDropletTile } from "@/components/group/group-droplet-tile";

--- a/frontend/components/group/group-management-dashboard.tsx
+++ b/frontend/components/group/group-management-dashboard.tsx
@@ -124,7 +124,7 @@ export function GroupDashboard({
                       (dueDate) => dueDate.playlist?.id === playlist.id,
                     )?.dueDate || ""
                   }
-                  timeZone={authUser.timeZone}
+                  timeZone={authUser.timeZone?.trim()}
                 />
               ))}
             </div>

--- a/frontend/components/settings/time-zone-selector.tsx
+++ b/frontend/components/settings/time-zone-selector.tsx
@@ -2,6 +2,7 @@
 
 import { setTimeZone } from "@/lib/actions";
 import { useState } from "react";
+import { toast } from "sonner";
 
 const timeZones = [
   "America/New_York",
@@ -58,6 +59,7 @@ export default function TimeZoneSelector({
   const handleChange = async (zone: string) => {
     await setTimeZone(zone + "  ", userId);
     setSelectedTimeZone(zone);
+    toast.success("Time zone updated successfully!");
   };
 
   return (

--- a/frontend/tests/components/first-time/first-visit-popup.test.tsx
+++ b/frontend/tests/components/first-time/first-visit-popup.test.tsx
@@ -109,12 +109,16 @@ describe("FirstVisitPopup", () => {
 
       const firstNameInput = getByLabelText("First name");
       const lastNameInput = getByLabelText("Last name");
+      const timeZoneInput = getByLabelText("Choose a time zone...");
 
       fireEvent.change(firstNameInput, {
         target: { value: "John" },
       });
       fireEvent.change(lastNameInput, {
         target: { value: "Doe" },
+      });
+      fireEvent.change(timeZoneInput, {
+        target: { value: "America/New_York" },
       });
 
       const dialog = await getByRole("dialog", { hidden: true });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
On the onboarding page, there is a section to add your timezone that is required and in the settings page, when the timezone is changed, there is a toast notification. 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change ensures new accounts have timezones and people know when the timezone is changed

## Screenshots (if appropriate):
<img width="843" height="161" alt="image" src="https://github.com/user-attachments/assets/f839e3bb-6f79-48ba-9fcc-b3a3a9e26a37" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added time zone selection on first visit and success toast when updating time zone.
  * Introduced retention rate in admin statistics.
  * Enabled sorting droplets by due date across grids.
  * Added playlist filter to group progress with updated pagination and exports.
  * Display gallery subtitles in the staggered gallery.
  * Improved kudos announcements to include “for …” task context.
  * Filter out already-authorized users from access requests.

* UX Improvements
  * Hide due-date badge for completed droplets; clearer “One Day Late/Days Late” labels.
  * Better dark-mode text visibility across code blocks and callouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->