### PR TITLE
fixed getTags function sort on server side

### DIFF
--- a/frontend/lib/requests/tag.ts
+++ b/frontend/lib/requests/tag.ts
@@ -2,8 +2,9 @@ import { Tag } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
 import { fetchAPI, PopulateValue } from "../utils";
 
+// sort server side by name ascending
 export async function getTags({
-  sort,
+  sort = ["name:asc"],
   filters,
   fields = ["id", "name", "slug"],
   populate,
@@ -24,9 +25,7 @@ export async function getTags({
     },
   };
 
-  return (await fetchAPI<Tag[]>(path, { urlParams })).sort((a, b) =>
-    a.name.localeCompare(b.name),
-  );
+  return await fetchAPI<Tag[]>(path, { urlParams });
 }
 
 export async function getTagBySlug(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactored the getTags function to handle sorting on the server-side instead of client-side. Tags are now sorted alphabetically by name using Strapi's built-in sort functionality, which is more efficient than sorting after the data is fetched.

## Motivation and Context

Previously, tags were being sorted in the browser after fetching from the API, which is inefficient and doesn't follow best practices. By moving the sort logic to the Strapi query parameters, the database handles sorting before returning results.
This improves performance and centralizes the sorting logic on the server where it belongs.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Moved tag sorting to the server with a default A–Z (by name) order.
  * Removed client-side sorting to streamline data handling.

* **User Impact**
  * Tag lists now appear alphabetically by default.
  * Improved consistency of ordering across the app.
  * Slightly faster loading for tag-related views due to reduced client processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->