### PR TITLE
ODY 72-Allow progress to show with just playlists and fixed arrow logic

### DIFF
--- a/frontend/components/group/group-management-dashboard.tsx
+++ b/frontend/components/group/group-management-dashboard.tsx
@@ -141,8 +141,8 @@ export function GroupDashboard({
             title=""
             emptyMessage="No students are enrolled in any droplets or playlists."
           >
-            {group.droplets &&
-            group.droplets.length > 0 &&
+            {((group.droplets && group.droplets.length > 0) ||
+              (group.playlists && group.playlists.length > 0)) &&
             group.members &&
             group.members.length > 0 ? (
               <div className="flex flex-row items-start overflow-x-auto">

--- a/frontend/components/group/group-progress-grid.tsx
+++ b/frontend/components/group/group-progress-grid.tsx
@@ -18,17 +18,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-interface Option {
-  value: string;
-  label: string;
-}
-
-const options: Option[] = [
-  { value: "option1", label: "Option 1" },
-  { value: "option2", label: "Option 2" },
-  { value: "option3", label: "Option 3" },
-];
-
 interface GroupProgressGridProps {
   group: {
     id: number;
@@ -57,10 +46,9 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
   const paginate = (lessons: Droplet[]) => {
     return lessons.slice(startIndex, endIndex);
   };
-  const totalPages = Math.ceil((group.droplets?.length || 0) / lessonsPerPage);
 
   const handleNextPage = () => {
-    if (currentPage < totalPages - 1) setCurrentPage(currentPage + 1);
+    setCurrentPage(currentPage + 1);
   };
 
   const handlePrevPage = () => {
@@ -294,7 +282,8 @@ export function GroupProgressGrid({ group, statuses }: GroupProgressGridProps) {
           <button
             onClick={handleNextPage}
             disabled={
-              currentPage === totalPages - 1 ||
+              (currentPage + 1) * lessonsPerPage >=
+                getDisplayedDroplets().length ||
               getDisplayedDroplets().length <= lessonsPerPage
             }
             aria-label="Next page"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The progress tab now shows and is accessible if there are droplets or playlists in the group and the arrow logic should now allow full access to all droplets in playlists
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This resolves the issues Claire brought up to allow groups to be made up of just playlists for better organization

## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Group Progress section now appears when a group has either droplets or playlists, not just droplets.
  * Improved pagination behavior in the Progress grid: the Next button now enables/disables based on currently displayed items and maintains correct visibility, preventing dead-ends.
  * Minor UI consistency tweaks to button states and visibility for a smoother navigation experience within the Progress section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->