### PR TITLE
fixed profile url bug and test file

### DIFF
--- a/frontend/app/(general)/[username]/profile-content.tsx
+++ b/frontend/app/(general)/[username]/profile-content.tsx
@@ -349,7 +349,7 @@ export function ProfileContent({
               {friends.map((friend) => (
                 <a
                   key={friend.id}
-                  href={`/profile/${friend.email.replace("@northeastern.edu", "")}`}
+                  href={`/${friend.email.replace("@northeastern.edu", "")}`}
                   className="flex cursor-pointer items-center gap-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
                 >
                   <Avatar

--- a/frontend/tests/components/profile/profile-content.test.tsx
+++ b/frontend/tests/components/profile/profile-content.test.tsx
@@ -530,7 +530,7 @@ describe("ProfileContent", () => {
 
       fireEvent.click(screen.getByText("Friends"));
 
-      const friendLink = container.querySelector('a[href="/profile/friend"]');
+      const friendLink = container.querySelector('a[href="/friend"]');
       expect(friendLink).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Quick fix - tweaked url endpoint for friend profiles to be /username, instead of the former /profile/username.

## Motivation and Context

Resolved bug where clicking on a friends profile would take you to a 404 error

## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated friend profile links to use shorter root-level URLs (e.g., /friend) instead of /profile/{id}, improving URL consistency and readability. Navigation behavior and styling remain unchanged.
- Tests
  - Updated profile content tests to match the new friend link paths and corresponding DOM queries and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->