### PR TITLE
resolved profile url path issue

### DIFF
--- a/frontend/app/(general)/settings/social-forms.tsx
+++ b/frontend/app/(general)/settings/social-forms.tsx
@@ -379,7 +379,7 @@ export function SocialForms({
             .{" "}
             <ContentCopyIcon
               onClick={() => {
-                const profileLink = `khouryodyssey.com/${authorizedUser.email.substring(
+                const profileLink = `khouryodyssey.com/prof/${authorizedUser.email.substring(
                   0,
                   authorizedUser.email.indexOf("@"),
                 )}`;

--- a/frontend/components/header/user-dropdown.tsx
+++ b/frontend/components/header/user-dropdown.tsx
@@ -67,7 +67,9 @@ export function UserDropdown({
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild data-testid="profile-link">
-          <Link href={`/${user.email?.replace("@northeastern.edu", "") || ""}`}>
+          <Link
+            href={`/prof/${user.email?.replace("@northeastern.edu", "") || ""}`}
+          >
             <User2Icon className="mr-2 h-4 w-4" />
             <span>Profile</span>
           </Link>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There were two places where the profile url path was incorrect. When clicking the Profile button in the dropdown menu, it would direct users to a url without the new '/prof' addition. This was the same case when copying the profile url to clipboard on the setting page. 

## Motivation and Context

Necessary resolutions to maintain a fluid user flow on the platform.

## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated profile links in the user menu to route to /prof/{local-part}.
  * Adjusted the displayed profile URL in settings to show the /prof/ prefixed path.
  * Updated copy-to-clipboard behavior in settings so the copied profile URL includes the /prof/ prefix, aligning the copied text with the visible link and the destination users visit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->