### PR TITLE
restrict lesson access to enrolled users only

### DIFF
--- a/frontend/app/(droplets)/d/[slug]/layout.tsx
+++ b/frontend/app/(droplets)/d/[slug]/layout.tsx
@@ -38,23 +38,20 @@ export default async function RootLayout({ params, children }: Props) {
   const { slug } = await params;
   const session = await getServerSession();
   const user = await getCurrentUser();
+
+  if (!user) return notFound();
+
   let completedLessonIds: number[] = [];
   let authorizedUser: AuthorizedUser | null = null;
+  let enrollmentId: string | undefined;
+
   if (user?.email) {
     authorizedUser = (await getAuthorizedUserByEmail(
       user.email,
     )) as AuthorizedUser;
   }
 
-  if (session?.user?.email) {
-    const user = await getAuthorizedUserByEmail(session.user.email);
-    const enrollments = await getEnrollmentsByAuthorizedUser(user.id);
-    completedLessonIds = enrollments.flatMap(
-      (enrollment) =>
-        enrollment.viewedLessons?.map((lesson) => lesson.id) || [],
-    );
-  }
-
+  // Fetch droplet first
   const droplet = await getDropletBySlug<Droplet>(slug, {
     fields: ["*"],
     populate: {
@@ -67,7 +64,21 @@ export default async function RootLayout({ params, children }: Props) {
     },
   });
 
-  if (!droplet || !user) return notFound();
+  if (!droplet) return notFound();
+
+  if (session?.user?.email) {
+    const sessionUser = await getAuthorizedUserByEmail(session.user.email);
+    const enrollments = await getEnrollmentsByAuthorizedUser(sessionUser.id);
+
+    const currentEnrollment = enrollments.find(
+      (enrollment) => enrollment.droplet?.id === droplet.id,
+    );
+
+    enrollmentId = currentEnrollment?.id.toString();
+
+    completedLessonIds =
+      currentEnrollment?.viewedLessons?.map((lesson) => lesson.id) || [];
+  }
 
   const isAuthor =
     droplet.authorized_users &&
@@ -82,6 +93,7 @@ export default async function RootLayout({ params, children }: Props) {
         user={user}
         droplet={droplet}
         completedLessonIds={completedLessonIds}
+        enrollmentId={enrollmentId}
       />
       <main className="w-full flex-1">{children}</main>
     </div>

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -73,6 +73,25 @@ export function LessonRenderer({
   const router = useRouter();
   const [highlights, setHighlights] = useState<Highlight[]>([]);
 
+  const isAdmin = user && isAuthorizedUserAdmin(user.roles);
+  const isNotEnrolled = !enrollmentId && !author && !isAdmin;
+
+  if (isNotEnrolled) {
+    return (
+      <div className="mx-auto w-full max-w-prose xl:py-8">
+        <div className="rounded-md border border-slate-200 bg-slate-50 p-6 text-center dark:border-slate-700 dark:bg-slate-800">
+          <LockIcon className="mx-auto mb-4 h-12 w-12 text-slate-400" />
+          <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+            Enrollment Required
+          </h2>
+          <p className="mt-2 text-slate-600 dark:text-slate-400">
+            You must enroll in this droplet to access lessons.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   useEffect(() => {
     const fetchHighlights = async () => {
       const response = await getHighlightsForLesson(lesson.id);

--- a/frontend/components/droplets/sidebar.tsx
+++ b/frontend/components/droplets/sidebar.tsx
@@ -27,15 +27,19 @@ export default function Sidebar({
   author = false,
   droplet,
   completedLessonIds = [],
+  enrollmentId,
 }: {
   user?: User | null;
   author: boolean;
   droplet: Pick<Droplet, "name" | "slug" | "droplet_lessons">;
   completedLessonIds: number[];
+  enrollmentId?: string | undefined;
 }) {
   const [expanded, setExpanded] = useState(false);
   const pathname = usePathname();
   const isAdmin = user && isAuthorizedUserAdmin(user.roles);
+
+  const isEnrolled = !!enrollmentId || author || isAdmin;
 
   const activeLinkClasses =
     "w-full flex font-bold items-center p-2 bg-slate-200 dark:bg-slate-700 [&>svg]:text-sky-700 rounded-lg dark:text-white dark:hover:bg-slate-700 group text-sky-700 transition-colors";
@@ -165,11 +169,15 @@ export default function Sidebar({
                     index > 0
                       ? droplet.droplet_lessons[index - 1].lesson
                       : null;
-                  const isLocked =
+
+                  // Check sequential unlock separately from enrollment
+                  const isPreviousLessonIncomplete =
                     previousLesson &&
                     !completedLessonIds.includes(previousLesson.id) &&
                     !author &&
                     !isAdmin;
+
+                  const isLocked = !isEnrolled || isPreviousLessonIncomplete;
 
                   return (
                     <li key={lesson.id} className="w-full">
@@ -179,9 +187,17 @@ export default function Sidebar({
                           pathname == `/d/${droplet.slug}/${lesson.slug}`
                             ? activeLinkClasses
                             : inactiveLinkClasses,
-                          isLocked && "opacity-50",
+                          isLocked &&
+                            "pointer-events-none cursor-not-allowed opacity-50",
                         )}
-                        onClick={() => setExpanded(false)}
+                        onClick={(e) => {
+                          if (isLocked) {
+                            e.preventDefault();
+                            return;
+                          }
+                          setExpanded(false);
+                        }}
+                        aria-disabled={!!isLocked}
                       >
                         {lesson.type === "activity" ? (
                           <HammerIcon className="shrink-0" />
@@ -197,12 +213,13 @@ export default function Sidebar({
                             data-testid="lock-icon"
                           />
                         )}
-                        {completedLessonIds.includes(lesson.id) && (
-                          <CheckCircle2
-                            className="ml-auto h-4 w-4 shrink-0 text-green-500"
-                            data-testid="check-circle-icon"
-                          />
-                        )}
+                        {completedLessonIds.includes(lesson.id) &&
+                          !isLocked && (
+                            <CheckCircle2
+                              className="ml-auto h-4 w-4 shrink-0 text-green-500"
+                              data-testid="check-circle-icon"
+                            />
+                          )}
                       </Link>
                     </li>
                   );

--- a/frontend/tests/components/droplets/sidebar.test.tsx
+++ b/frontend/tests/components/droplets/sidebar.test.tsx
@@ -219,6 +219,7 @@ describe("Sidebar", () => {
         author={false}
         droplet={mockProps.droplet}
         completedLessonIds={[1]}
+        enrollmentId="123"
       />,
     );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Restricts lesson access to enrolled users only. Unenrolled users now see locked lessons with visual indicators in the sidebar and an enrollment requirement message when attempting to access content. Authors and admins can still preview lessons without enrollment. Before, users could still access the first lesson without being enrolled. Now no lessons are available prior to enrollment.

## Motivation and Context

This will mitigate any confusion with enrollment, since users clearly cannot move onto lessons without enrolling.

## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added enrollment-required gating for lessons with a clear lock message.
  * Introduced sequential lesson unlocking; locked lessons show disabled navigation and reduced opacity.
  * Completion checkmarks now appear only for accessible lessons.

* Refactor
  * Streamlined enrollment and completion detection to improve accuracy and access handling.
  * Enhanced unauthenticated access behavior for clearer outcomes.

* Tests
  * Updated Sidebar tests to account for enrollment context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->