### PR TITLE
Ody 76 add date to reports display

### DIFF
--- a/backend/src/api/report/content-types/report/schema.json
+++ b/backend/src/api/report/content-types/report/schema.json
@@ -34,6 +34,9 @@
         "bug"
       ],
       "required": true
+    },
+    "time": {
+      "type": "datetime"
     }
   }
 }

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -1459,6 +1459,7 @@ export interface ApiReportReport extends Schema.CollectionType {
     email: Attribute.Email & Attribute.Required;
     fullName: Attribute.String & Attribute.Required;
     path: Attribute.String & Attribute.Required;
+    time: Attribute.DateTime;
     type: Attribute.Enumeration<['bug']> & Attribute.Required;
     updatedAt: Attribute.DateTime;
     updatedBy: Attribute.Relation<

--- a/frontend/components/admin/reports/report.tsx
+++ b/frontend/components/admin/reports/report.tsx
@@ -7,6 +7,7 @@ import { Report } from "./reports";
 import { toast } from "sonner";
 import { deleteReport } from "@/lib/actions";
 import { useState, useEffect, useRef } from "react";
+import { DateTime } from "luxon";
 
 export function ReportBlock({ report }: { report: Report }) {
   const handleDeleteReport = async (reportId: string) => {
@@ -116,6 +117,11 @@ export function ReportBlock({ report }: { report: Report }) {
           <p className="mt-2 truncate font-medium text-slate-900 dark:text-slate-300">
             Path: {report.path}
           </p>
+          {report.time && (
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              Reported on: {report.time.toLocaleString(DateTime.DATETIME_FULL)}
+            </p>
+          )}
         </div>
 
         <div className="flex flex-shrink-0 items-center gap-2">

--- a/frontend/components/admin/reports/reports.tsx
+++ b/frontend/components/admin/reports/reports.tsx
@@ -1,5 +1,6 @@
 import { fetchReports } from "@/lib/requests/data";
 import { ReportBlock } from "./report";
+import { DateTime } from "luxon";
 
 export type Report = {
   id: string;
@@ -8,6 +9,7 @@ export type Report = {
   email: string;
   path: string;
   description: string;
+  time: DateTime;
 };
 
 export async function Reports() {

--- a/frontend/lib/actions.ts
+++ b/frontend/lib/actions.ts
@@ -139,7 +139,7 @@ export async function createBugReport(formData: z.infer<typeof reportSchema>) {
   try {
     const response = await fetch(STRAPI_API_URL + "/api/reports", {
       method: "POST",
-      body: JSON.stringify({ data: { ...formData, type: "bug" } }),
+      body: JSON.stringify({ data: { ...formData, type: "bug", time: new Date().toISOString() } }),
       headers: {
         "Content-Type": "application/json",
         Authorization: "Bearer " + STRAPI_ACCESS_TOKEN,

--- a/frontend/lib/actions.ts
+++ b/frontend/lib/actions.ts
@@ -139,7 +139,9 @@ export async function createBugReport(formData: z.infer<typeof reportSchema>) {
   try {
     const response = await fetch(STRAPI_API_URL + "/api/reports", {
       method: "POST",
-      body: JSON.stringify({ data: { ...formData, type: "bug", time: new Date().toISOString() } }),
+      body: JSON.stringify({
+        data: { ...formData, type: "bug", time: new Date().toISOString() },
+      }),
       headers: {
         "Content-Type": "application/json",
         Authorization: "Bearer " + STRAPI_ACCESS_TOKEN,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a timestamp in bug reports that is tracked in the strapi. It only changes new bug reports so old reports will work but just not show times
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):
<img width="1483" height="261" alt="image" src="https://github.com/user-attachments/assets/fdfc7846-b373-4f6e-96b2-8230e6cf2cd4" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports now include a timestamp, enabling clearer tracking of when a report was submitted.
  * The admin report detail view displays a “Reported on” date/time when available.
  * New reports automatically capture and store the submission time.

* **Documentation**
  * API documentation updated to describe the new report timestamp field, including its date-time format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->