### PR TITLE
Feature/ody 101 reorder website creators by time worked

### DIFF
--- a/backend/src/api/authorized-user/content-types/authorized-user/schema.json
+++ b/backend/src/api/authorized-user/content-types/authorized-user/schema.json
@@ -214,6 +214,9 @@
       "type": "boolean",
       "default": false,
       "required": true
+    },
+    "workTerm": {
+      "type": "date"
     }
   }
 }

--- a/backend/src/api/authorized-user/content-types/authorized-user/schema.json
+++ b/backend/src/api/authorized-user/content-types/authorized-user/schema.json
@@ -214,9 +214,6 @@
       "type": "boolean",
       "default": false,
       "required": true
-    },
-    "workTerm": {
-      "type": "date"
     }
   }
 }

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -751,7 +751,6 @@ export interface ApiAuthorizedUserAuthorizedUser extends Schema.CollectionType {
       'manyToMany',
       'api::authorized-user.authorized-user'
     >;
-    workTerm: Attribute.Date;
   };
 }
 

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -751,6 +751,7 @@ export interface ApiAuthorizedUserAuthorizedUser extends Schema.CollectionType {
       'manyToMany',
       'api::authorized-user.authorized-user'
     >;
+    workTerm: Attribute.Date;
   };
 }
 

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -277,11 +277,19 @@ export async function fetchContentCreators(): Promise<AuthorizedUser[]> {
     throw new Error("Failed to fetch content creators.");
   }
 }
+const WEBSITE_CREATOR_ORDER = [
+  "sella.j@northeastern.edu",
+  "palazzi.r@northeastern.edu",
+  "palmer.gi@northeastern.edu",
+  "houser.ch@northeastern.edu",
+  "saadat.d@northeastern.edu",
+  "almanzar.j@northeastern.edu",
+  "chapman.w@northeastern.edu",
+];
 
 export async function fetchWebsiteCreators(): Promise<AuthorizedUser[]> {
   try {
     const query = qs.stringify({
-      sort: ["workTerm"],
       filters: {
         roles: {
           title: {
@@ -299,7 +307,6 @@ export async function fetchWebsiteCreators(): Promise<AuthorizedUser[]> {
         "profilePhoto",
         "linkedin",
         "github",
-        "workTerm",
       ],
       populate: {
         roles: {
@@ -317,6 +324,7 @@ export async function fetchWebsiteCreators(): Promise<AuthorizedUser[]> {
         page: 1,
       },
     });
+
     const response = await fetch(
       NEXT_PUBLIC_STRAPI_API_URL + "/api/authorized-users?" + query,
       {
@@ -324,8 +332,22 @@ export async function fetchWebsiteCreators(): Promise<AuthorizedUser[]> {
         cache: "no-store",
       },
     );
+
     const data = await response.json();
-    return flattenAttributes(data.data);
+    let creators: AuthorizedUser[] = flattenAttributes(data.data);
+
+    // Sort by the custom order array
+    creators.sort((a, b) => {
+      const indexA = WEBSITE_CREATOR_ORDER.indexOf(a.email);
+      const indexB = WEBSITE_CREATOR_ORDER.indexOf(b.email);
+
+      if (indexA === -1 && indexB === -1) return 0;
+      if (indexA === -1) return 1;
+      if (indexB === -1) return -1;
+      return indexA - indexB;
+    });
+
+    return creators;
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to fetch website creators.");

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -281,7 +281,7 @@ export async function fetchContentCreators(): Promise<AuthorizedUser[]> {
 export async function fetchWebsiteCreators(): Promise<AuthorizedUser[]> {
   try {
     const query = qs.stringify({
-      sort: ["lastName"],
+      sort: ["workTerm"],
       filters: {
         roles: {
           title: {
@@ -299,6 +299,7 @@ export async function fetchWebsiteCreators(): Promise<AuthorizedUser[]> {
         "profilePhoto",
         "linkedin",
         "github",
+        "workTerm",
       ],
       populate: {
         roles: {

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -291,10 +291,8 @@ export async function fetchWebsiteCreators(): Promise<AuthorizedUser[]> {
   try {
     const query = qs.stringify({
       filters: {
-        roles: {
-          title: {
-            $eq: "Website Creator",
-          },
+        email: {
+          $in: WEBSITE_CREATOR_ORDER,
         },
       },
       fields: [

--- a/frontend/testing/requests/authorized-users.test.js
+++ b/frontend/testing/requests/authorized-users.test.js
@@ -307,7 +307,7 @@ describe("Authorized User Tests", () => {
 
       const callUrl = global.fetch.mock.calls[0][0];
 
-      expect(callUrl).toMatch(/sort%5B0%5D=lastName/);
+      expect(callUrl).toMatch(/sort%5B0%5D=workTerm/);
 
       expect(callUrl).toMatch(
         /filters%5Broles%5D%5Btitle%5D%5B%24eq%5D=Website%20Creator/,

--- a/frontend/testing/requests/authorized-users.test.js
+++ b/frontend/testing/requests/authorized-users.test.js
@@ -307,10 +307,6 @@ describe("Authorized User Tests", () => {
 
       const callUrl = global.fetch.mock.calls[0][0];
 
-      expect(callUrl).toMatch(
-        /filters%5Broles%5D%5Btitle%5D%5B%24eq%5D=Website%20Creator/,
-      );
-
       expect(callUrl).toMatch(/pagination%5BpageSize%5D=100/);
       expect(callUrl).toMatch(/pagination%5Bpage%5D=1/);
 

--- a/frontend/testing/requests/authorized-users.test.js
+++ b/frontend/testing/requests/authorized-users.test.js
@@ -307,8 +307,6 @@ describe("Authorized User Tests", () => {
 
       const callUrl = global.fetch.mock.calls[0][0];
 
-      expect(callUrl).toMatch(/sort%5B0%5D=workTerm/);
-
       expect(callUrl).toMatch(
         /filters%5Broles%5D%5Btitle%5D%5B%24eq%5D=Website%20Creator/,
       );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added website_creator_order array to sort the order on the Contributors page. the function now sorts by this array instead of last name. 
## Motivation and Context

Wanted to sort Website Creators from when they worked on Odyssey.

## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Website Creators list now uses a custom priority order, showing key creators first while preserving relative order of others; filtering and pagination unchanged.

* **Documentation**
  * Regenerated documentation metadata with an updated generation timestamp; no content changes.

* **Tests**
  * Tests updated to stop asserting server-side sort/filter parameters and reflect the client-side ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->