### PR TITLE
Improvement/ody 115 add a button under feed friend requests to go straight to friends page

### DIFF
--- a/frontend/components/feed/feed-container.tsx
+++ b/frontend/components/feed/feed-container.tsx
@@ -8,6 +8,9 @@ import { AnnouncementType, AuthorizedUser } from "@/types";
 import { BellRing, SlidersHorizontal } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FriendRequests } from "../friends/friend-requests";
+import { Button } from "../ui/button";
+import Link from "next/link";
+import { Users } from "lucide-react";
 
 export function FeedContainer({ authUser }: { authUser: AuthorizedUser }) {
   const [selectedRoles, setSelectedRoles] = useState<AnnouncementTypeTitle[]>(
@@ -25,6 +28,15 @@ export function FeedContainer({ authUser }: { authUser: AuthorizedUser }) {
               friendsPerPage={3}
               authUser={authUser}
             ></FriendRequests>
+            <Link href="/settings/friends" className="mt-3 block">
+              <Button
+                size="sm"
+                className="w-full bg-sky-300 text-black hover:bg-sky-400 dark:bg-sky-300 dark:hover:bg-sky-400"
+              >
+                <Users className="mr-2 h-4 w-4" />
+                Manage Friends
+              </Button>
+            </Link>
           </div>
           <FeedFilter onFilterChange={setSelectedRoles} />
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Manage Friends” button in the feed’s left sidebar, placed alongside Friend Requests. The button includes an icon and opens the Friends settings page for quicker access to manage your friend list.
  * Existing Friend Requests and feed filters remain unchanged; this addition provides a clearer, more accessible entry point for managing friendships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->