### PR TITLE
fix scrolling when dropdown open

### DIFF
--- a/frontend/components/header/user-dropdown.tsx
+++ b/frontend/components/header/user-dropdown.tsx
@@ -19,7 +19,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
-import { useEffect } from "react";
 
 export function UserDropdown({
   user,

--- a/frontend/components/header/user-dropdown.tsx
+++ b/frontend/components/header/user-dropdown.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
+import { useEffect } from "react";
 
 export function UserDropdown({
   user,
@@ -28,7 +29,7 @@ export function UserDropdown({
   authorizedUser: AuthorizedUser | null;
 }) {
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <div className="group light:text-slate-600 wg-antialiased flex w-full shrink cursor-pointer items-center justify-between gap-1 rounded-lg p-1.5 px-1 text-sm transition-colors duration-100 select-none hover:bg-slate-100 dark:hover:bg-white/5">
           <div className="inline-flex flex-row items-center justify-between">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows users to scroll in background when popup dropdown menu is open. This improves fluidity of platform, reduces potential confusion or frustration for users.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * User dropdown menu now operates in non-blocking mode, allowing seamless interaction with other page elements while the menu remains open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->