### PR TITLE
Make author blocks clickable

### DIFF
--- a/frontend/app/(droplets)/d/[slug]/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/page.tsx
@@ -19,6 +19,7 @@ import { getCurrentUser } from "@/lib/auth/session";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { StarRating } from "@/components/ui/rating-stars";
+import { AuthorCard } from "@/components/droplets/author-block";
 
 type Props = {
   params: Promise<params>;
@@ -221,35 +222,7 @@ export default async function DropletRoute({ params }: Props) {
 
             <ul className="mt-4 flex flex-col divide-y divide-slate-200 rounded-md border border-slate-200 bg-slate-50 dark:divide-slate-500 dark:border-slate-500 dark:bg-slate-800">
               {droplet.authorized_users?.map((author) => (
-                <li
-                  key={`author-${author.id}`}
-                  className="inline-flex gap-4 p-4"
-                >
-                  <Avatar variant="round" className="border border-sky-800">
-                    <AvatarImage src={author?.profilePhoto || undefined} />
-                    <AvatarFallback>
-                      {author?.firstName && author?.lastName ? (
-                        author.firstName[0] + author.lastName[0]
-                      ) : (
-                        <User2Icon className="h-4 w-4" />
-                      )}
-                    </AvatarFallback>
-                  </Avatar>
-
-                  <div
-                    className={!author.bio ? "flex flex-row items-center" : ""}
-                  >
-                    <span className="leading-relaxed font-bold">
-                      {author.firstName + " " + author.lastName}
-                    </span>
-
-                    {author.bio ? (
-                      <p className="text-sm text-slate-600 dark:text-slate-300">
-                        {author.bio}
-                      </p>
-                    ) : null}
-                  </div>
-                </li>
+                <AuthorCard key={author.id} {...author} />
               ))}
             </ul>
           </section>

--- a/frontend/components/droplets/author-block.tsx
+++ b/frontend/components/droplets/author-block.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { User2Icon } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+import { AuthorizedUser } from "@/types";
+
+export function AuthorCard(author: AuthorizedUser) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    console.log(author.email);
+    router.push(
+      `/prof/${author.email?.slice(0, author.email.indexOf("@")) || ""}`,
+    );
+  };
+
+  return (
+    <li
+      onClick={handleClick}
+      className="inline-flex cursor-pointer gap-4 p-4 transition-colors hover:bg-slate-100 dark:hover:bg-slate-700"
+    >
+      <Avatar variant="round" className="border border-sky-800">
+        <AvatarImage src={author?.profilePhoto || undefined} />
+        <AvatarFallback>
+          {author?.firstName && author?.lastName ? (
+            author.firstName[0] + author.lastName[0]
+          ) : (
+            <User2Icon className="h-4 w-4" />
+          )}
+        </AvatarFallback>
+      </Avatar>
+
+      <div className={!author.bio ? "flex flex-row items-center" : ""}>
+        <span className="leading-relaxed font-bold">
+          {author.firstName + " " + author.lastName}
+        </span>
+
+        {author.bio ? (
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            {author.bio}
+          </p>
+        ) : null}
+      </div>
+    </li>
+  );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
At the bottom of the droplet overview, there is a box with the author's details, it now takes you to their profile
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authors are now displayed as individual interactive cards in the authors section, replacing the previous inline layout
  * Each author card showcases their avatar, name, and biographical information in an improved card format
  * Users can click on any author card to navigate directly to that author's profile page
  * Enhanced visual design and user experience when browsing and accessing author information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->