### PR TITLE
added completing to kudos announcements

### DIFF
--- a/frontend/components/feed/feed-block.tsx
+++ b/frontend/components/feed/feed-block.tsx
@@ -60,7 +60,8 @@ export function FeedBlock({
   const content = announcement.content;
   const [namePart] = content.split(/has\s+/i);
   const [, taskPart] = content.split(/(?:completed|finished)\s+/i); // non-capturing group for "completed" or "finished"
-  const [, kudosTaskPart] = content.split(/for\s+/i);
+  const [, kudosTaskPart] = content.split(/for\s+(?:completing\s+)?/i); // non-capturing group for "completing"
+
   return (
     <li
       className={`${backgroundColor[announcementType]} relative flex flex-col items-start gap-2 rounded-lg p-4 pb-3`}
@@ -101,7 +102,7 @@ export function FeedBlock({
                   {namePart.trim()}
                 </p>
                 <>
-                  {"\u00A0"}has given you kudos for{"\u00A0"}
+                  {"\u00A0"}has given you kudos for completing{"\u00A0"}
                 </>
                 <span>{kudosTaskPart?.trim()}</span>
                 <div>

--- a/frontend/lib/requests/feed.ts
+++ b/frontend/lib/requests/feed.ts
@@ -240,7 +240,7 @@ export async function createKudosAnnouncement(
         body: JSON.stringify({
           data: {
             authorized_user: user.id,
-            content: `${user.firstName ? user.firstName + " " + user.lastName : user.email} has given you kudos for ${droplet}`,
+            content: `${user.firstName ? user.firstName + " " + user.lastName : user.email} has given you kudos for completing ${droplet}`,
             firstCreated: curDate,
             type: "kudos",
           },

--- a/frontend/tests/components/feed/feed-block.test.tsx
+++ b/frontend/tests/components/feed/feed-block.test.tsx
@@ -330,7 +330,24 @@ describe("FeedBlock", () => {
 
       expect(screen.getByText("Jane Smith")).toBeInTheDocument();
       expect(screen.getByText(/has given you kudos for/)).toBeInTheDocument();
-      expect(screen.getByText("completing React Basics")).toBeInTheDocument();
+      expect(screen.getByText("React Basics")).toBeInTheDocument();
+    });
+
+    it("handles old format kudos content without 'completing' keyword", () => {
+      const kudosAnnouncement = {
+        ...mockDropletAnnouncement,
+        type: "kudos" as const,
+        content: "Jane Smith has given you kudos for React Basics", // Old format
+      };
+      render(
+        <FeedBlock announcement={kudosAnnouncement} authUser={mockUser} />,
+      );
+
+      expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+      expect(
+        screen.getByText(/has given you kudos for completing/),
+      ).toBeInTheDocument();
+      expect(screen.getByText("React Basics")).toBeInTheDocument();
     });
 
     it("opens profile dialog when clicking on name in kudos", async () => {
@@ -637,7 +654,7 @@ describe("FeedBlock", () => {
         <FeedBlock announcement={kudosAnnouncement} authUser={mockUser} />,
       );
 
-      expect(screen.getByText("completing Advanced React")).toBeInTheDocument();
+      expect(screen.getByText("Advanced React")).toBeInTheDocument();
     });
 
     it("handles kudos content with multiple 'has' words", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the word "completing" to kudos announcement content in the backend. When a user gives kudos to a friend for finishing a droplet, the announcement now reads "[Name] has given you kudos for completing [Droplet Name]" instead of "[Name] has given you kudos for [Droplet Name]".

Updated the FeedBlock component parsing logic to handle both the new format (with completing) and legacy format (without completing) for backward compatibility with existing announcements in the database.

**Test by triggering a new kudos announcement in strapi, then check to make sure it looks correct, with "completing".

## Motivation and Context

This addition of the word "completing" makes kudos announcements more clear.

## Screenshots (if appropriate):
<img width="775" height="107" alt="Screenshot 2025-10-22 at 11 27 15 AM" src="https://github.com/user-attachments/assets/743a7cfe-5b24-4d87-b382-706d9269019e" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated kudos messaging to display "has given you kudos for completing [task]" format.
  * Improved parsing logic to support both current and legacy kudos content formats.
  * Ensured task names render correctly without text duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->