### PR TITLE
made quiz answers save when navigating through lessons

### DIFF
--- a/frontend/components/droplets/footer.tsx
+++ b/frontend/components/droplets/footer.tsx
@@ -5,6 +5,10 @@ import { ArrowLeftIcon, ArrowRightIcon, LockIcon } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { updateViewedLessons } from "@/lib/requests/enrollment";
+import {
+  isLessonQuizCompleted,
+  markLessonQuizCompleted,
+} from "@/lib/quiz-storage";
 
 type PaginationProps = {
   link: string;
@@ -38,9 +42,14 @@ export default function DropletFooter({
   };
 
   useEffect(() => {
+    if (currentLessonId && isLessonQuizCompleted(currentLessonId)) {
+      setCanProceed(true);
+      return;
+    }
+
     const checkQuizAnswers = () => {
       const questions = document.querySelectorAll('[role="question"]');
-      if (!questions) {
+      if (!questions || questions.length === 0) {
         setCanProceed(true);
         return;
       }
@@ -50,13 +59,16 @@ export default function DropletFooter({
         setCanProceed(false);
         return;
       }
-
       const allAnsweredCorrectly = Array.from(completedQuizQuestions).every(
         (question) => {
           const resultBadge = question.textContent;
           return resultBadge?.toLowerCase().includes("right");
         },
       );
+
+      if (allAnsweredCorrectly && currentLessonId) {
+        markLessonQuizCompleted(currentLessonId);
+      }
 
       setCanProceed(allAnsweredCorrectly);
     };
@@ -71,7 +83,7 @@ export default function DropletFooter({
     });
 
     return () => observer.disconnect();
-  }, []);
+  }, [currentLessonId]);
 
   if (!droplet.droplet_lessons || droplet.droplet_lessons.length === 0)
     return null;

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -288,6 +288,7 @@ export function LessonRenderer({
             <LessonBlockRenderer
               key={i}
               block={b}
+              lessonId={lesson.id}
               highlights={highlights}
               onHighlight={handleHighlight}
               onDeleteHighlight={handleDeleteHighlight}
@@ -325,6 +326,7 @@ export function LessonRenderer({
 
 function LessonBlockRenderer({
   block,
+  lessonId,
   highlights,
   onHighlight,
   onDeleteHighlight,
@@ -336,6 +338,7 @@ function LessonBlockRenderer({
   setActiveBlock,
 }: {
   block: any;
+  lessonId: number;
   highlights: Highlight[];
   onHighlight: (highlight: Highlight, isWithNote?: boolean) => void;
   onDeleteHighlight: (id: number) => void;
@@ -379,7 +382,7 @@ function LessonBlockRenderer({
       );
 
     case "droplets.quiz":
-      return <QuizBlock data={block} />;
+      return <QuizBlock data={block} lessonId={lessonId} />;
 
     case "droplets.open-ended-quiz":
       return <OpenEndedQuizBlock data={block} />;

--- a/frontend/components/droplets/lessons/quiz-question.tsx
+++ b/frontend/components/droplets/lessons/quiz-question.tsx
@@ -13,7 +13,7 @@ import {
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { QuizQuestion } from "@/types";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
+import { ArrowLeftIcon, ArrowRightIcon, RotateCcwIcon } from "lucide-react";
 import { useMemo, useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -46,11 +46,19 @@ export function QuizQuestionBlock({
   // Load saved answer on mount
   useEffect(() => {
     const saved = getQuizAnswer(lessonId, question.id);
-    if (saved) {
-      form.setValue("answerIds", saved.answerIds);
-      setShowResult(saved.showResult);
+    if (saved && saved.answerIds.length > 0) {
+      // Set form values
+      form.reset({ answerIds: saved.answerIds });
+
+      // Set showResult after ensuring form is populated
+      if (saved.showResult) {
+        // Use a microtask to ensure React has processed the form reset
+        Promise.resolve().then(() => {
+          setShowResult(true);
+        });
+      }
     }
-  }, [lessonId, question.id, form]);
+  }, [lessonId, question.id]);
 
   // Save answers whenever they change
   useEffect(() => {
@@ -106,14 +114,23 @@ export function QuizQuestionBlock({
       {showResult ? (
         <div className="mt-4 rounded-md border border-slate-200 px-8 py-12 text-center">
           {areAnswersCorrect(form.getValues("answerIds")) ? (
-            <>
+            <div className="flex flex-col items-center">
               <Badge
                 className="bg-green-100 text-lg text-green-700 hover:bg-green-200"
                 role="status"
               >
                 That&rsquo;s Right!
               </Badge>
-            </>
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowResult(false)}
+                className="mt-2"
+              >
+                <RotateCcwIcon className="h-4 w-4" />
+              </Button>
+            </div>
           ) : (
             <>
               <Badge

--- a/frontend/components/droplets/lessons/quiz-question.tsx
+++ b/frontend/components/droplets/lessons/quiz-question.tsx
@@ -14,15 +14,22 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { QuizQuestion } from "@/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { saveQuizAnswer, getQuizAnswer } from "@/lib/quiz-storage";
 
 const formSchema = z.object({
   answerIds: z.array(z.string()),
 });
 
-export function QuizQuestionBlock({ question }: { question: QuizQuestion }) {
+export function QuizQuestionBlock({
+  question,
+  lessonId,
+}: {
+  question: QuizQuestion;
+  lessonId: number;
+}) {
   const [showResult, setShowResult] = useState(false);
   const correctAnswers = useMemo(
     () => question.answerOptions.filter((option) => option.isCorrect),
@@ -35,6 +42,38 @@ export function QuizQuestionBlock({ question }: { question: QuizQuestion }) {
       answerIds: [],
     },
   });
+
+  // Load saved answer on mount
+  useEffect(() => {
+    const saved = getQuizAnswer(lessonId, question.id);
+    if (saved) {
+      form.setValue("answerIds", saved.answerIds);
+      setShowResult(saved.showResult);
+    }
+  }, [lessonId, question.id, form]);
+
+  // Save answers whenever they change
+  useEffect(() => {
+    const subscription = form.watch((value) => {
+      if (value.answerIds && value.answerIds.length > 0) {
+        const answerIds = value.answerIds.filter(
+          (id): id is string => id !== undefined,
+        );
+        if (answerIds.length > 0) {
+          saveQuizAnswer(lessonId, question.id, answerIds, showResult);
+        }
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [lessonId, question.id, showResult, form]);
+
+  // Save showResult state changes
+  useEffect(() => {
+    const answerIds = form.getValues("answerIds");
+    if (answerIds.length > 0) {
+      saveQuizAnswer(lessonId, question.id, answerIds, showResult);
+    }
+  }, [showResult, lessonId, question.id, form]);
 
   function onSubmit(values: z.infer<typeof formSchema>) {
     if (values.answerIds.length > 0) {

--- a/frontend/components/droplets/lessons/quiz-question.tsx
+++ b/frontend/components/droplets/lessons/quiz-question.tsx
@@ -123,12 +123,13 @@ export function QuizQuestionBlock({
               </Badge>
 
               <Button
+                before={<ArrowLeftIcon />}
                 variant="outline"
                 size="sm"
                 onClick={() => setShowResult(false)}
                 className="mt-2"
               >
-                <ArrowLeftIcon className="h-4 w-4" />
+                View Answer
               </Button>
             </div>
           ) : (

--- a/frontend/components/droplets/lessons/quiz-question.tsx
+++ b/frontend/components/droplets/lessons/quiz-question.tsx
@@ -13,7 +13,7 @@ import {
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { QuizQuestion } from "@/types";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ArrowLeftIcon, ArrowRightIcon, RotateCcwIcon } from "lucide-react";
+import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
 import { useMemo, useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -128,7 +128,7 @@ export function QuizQuestionBlock({
                 onClick={() => setShowResult(false)}
                 className="mt-2"
               >
-                <RotateCcwIcon className="h-4 w-4" />
+                <ArrowLeftIcon className="h-4 w-4" />
               </Button>
             </div>
           ) : (

--- a/frontend/components/droplets/lessons/quiz.tsx
+++ b/frontend/components/droplets/lessons/quiz.tsx
@@ -1,7 +1,13 @@
 import { Quiz } from "@/types";
 import { QuizQuestionBlock } from "./quiz-question";
 
-export function QuizBlock({ data }: { data: Quiz }) {
+export function QuizBlock({
+  data,
+  lessonId,
+}: {
+  data: Quiz;
+  lessonId: number;
+}) {
   return (
     <div className="-mx-6 my-12 rounded-md border border-slate-200 bg-slate-50 px-6 py-12 dark:border-slate-500 dark:bg-slate-800">
       <div className="text-center">
@@ -10,7 +16,6 @@ export function QuizBlock({ data }: { data: Quiz }) {
           Test your knowledge and see what you just learned.
         </p>
       </div>
-
       <div>
         {data.questions.map((question) => {
           return (
@@ -19,7 +24,7 @@ export function QuizBlock({ data }: { data: Quiz }) {
               id="quiz-question"
               className="mx-auto mt-8 w-full max-w-lg divide-slate-200 rounded-md border border-slate-200 bg-white p-6 dark:border-slate-500 dark:bg-slate-900"
             >
-              <QuizQuestionBlock question={question} />
+              <QuizQuestionBlock question={question} lessonId={lessonId} />
             </div>
           );
         })}

--- a/frontend/lib/quiz-storage.ts
+++ b/frontend/lib/quiz-storage.ts
@@ -1,0 +1,37 @@
+interface QuizAnswer {
+  answerIds: string[];
+  showResult: boolean;
+  timestamp: number;
+}
+
+export const saveQuizAnswer = (
+  lessonId: number,
+  questionId: number,
+  answerIds: string[],
+  showResult: boolean,
+) => {
+  const key = `quiz-${lessonId}-${questionId}`;
+  const data: QuizAnswer = {
+    answerIds,
+    showResult,
+    timestamp: Date.now(),
+  };
+  sessionStorage.setItem(key, JSON.stringify(data));
+};
+
+export const getQuizAnswer = (
+  lessonId: number,
+  questionId: number,
+): QuizAnswer | null => {
+  const key = `quiz-${lessonId}-${questionId}`;
+  const stored = sessionStorage.getItem(key);
+  return stored ? JSON.parse(stored) : null;
+};
+
+export const clearQuizAnswers = (lessonId: number) => {
+  Object.keys(sessionStorage).forEach((key) => {
+    if (key.startsWith(`quiz-${lessonId}-`)) {
+      sessionStorage.removeItem(key);
+    }
+  });
+};

--- a/frontend/lib/quiz-storage.ts
+++ b/frontend/lib/quiz-storage.ts
@@ -35,3 +35,17 @@ export const clearQuizAnswers = (lessonId: number) => {
     }
   });
 };
+
+export const markLessonQuizCompleted = (lessonId: number) => {
+  const key = `quiz-completed-${lessonId}`;
+  sessionStorage.setItem(
+    key,
+    JSON.stringify({ completed: true, timestamp: Date.now() }),
+  );
+};
+
+export const isLessonQuizCompleted = (lessonId: number): boolean => {
+  const key = `quiz-completed-${lessonId}`;
+  const stored = sessionStorage.getItem(key);
+  return stored ? JSON.parse(stored).completed : false;
+};

--- a/frontend/tests/components/droplets/quiz-question.test.tsx
+++ b/frontend/tests/components/droplets/quiz-question.test.tsx
@@ -2,7 +2,30 @@ import { QuizQuestionBlock } from "@/components/droplets/lessons/quiz-question";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+// Mock sessionStorage for testing since it's not available in Node/Jest environment
+const mockSessionStorage = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+// Override window.sessionStorage with our mock
+Object.defineProperty(window, "sessionStorage", {
+  value: mockSessionStorage,
+});
+
 describe("QuizQuestionBlock", () => {
+  // Standard quiz question with one correct answer
   const mockQuestion = {
     id: 1,
     content: "What is 2 + 2?",
@@ -13,41 +36,65 @@ describe("QuizQuestionBlock", () => {
     ],
   };
 
+  const mockLessonId = 1;
+
+  // Clear storage before each test to avoid state pollution
+  beforeEach(() => {
+    mockSessionStorage.clear();
+  });
+
   it("renders question content", () => {
-    render(<QuizQuestionBlock question={mockQuestion} />);
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
+
+    // Verify the question text is displayed
     expect(screen.getByText("What is 2 + 2?")).toBeInTheDocument();
   });
 
   it("renders all answer options", () => {
-    render(<QuizQuestionBlock question={mockQuestion} />);
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
+
+    // Verify all three answer options are visible
     expect(screen.getByText("3")).toBeInTheDocument();
     expect(screen.getByText("4")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
   });
 
   it("shows feedback when answer is submitted", async () => {
-    render(<QuizQuestionBlock question={mockQuestion} />);
-
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
     const user = userEvent.setup();
 
+    // Select the correct answer
     const answer = await screen.findByText("4");
     expect(answer).toBeInTheDocument();
-
     await user.click(answer);
+
+    // Submit the quiz
     await user.click(screen.getByText("Check Answer"));
 
+    // Verify success feedback is shown
     expect(screen.getByText(/right/i)).toBeInTheDocument();
   });
 
   it("validates correct answers", async () => {
-    render(<QuizQuestionBlock question={mockQuestion} />);
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
 
+    // Select the correct answer (id: 2, content: "4")
     const correctAnswer = screen.getByRole("radio", { name: "4" });
     await userEvent.click(correctAnswer);
 
+    // Submit the answer
     const submitButton = screen.getByRole("button", { name: /check answer/i });
     await userEvent.click(submitButton);
 
+    // Wait for and verify the success badge appears
     await waitFor(() => {
       const badge = screen.getByRole("status");
       expect(badge).toHaveTextContent(/right/i);
@@ -55,28 +102,36 @@ describe("QuizQuestionBlock", () => {
   });
 
   it("handles incorrect answers and allows retry", async () => {
-    render(<QuizQuestionBlock question={mockQuestion} />);
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
 
+    // Select an incorrect answer
     const wrongAnswer = screen.getByRole("radio", { name: "3" });
     await userEvent.click(wrongAnswer);
 
+    // Submit the answer
     const submitButton = screen.getByRole("button", { name: /check answer/i });
     await userEvent.click(submitButton);
 
+    // Verify "Not Quite" feedback is shown
     await waitFor(() => {
       const badge = screen.getByRole("status");
       expect(badge).toHaveTextContent(/not quite/i);
     });
 
+    // Click "Try Again" button
     const tryAgainButton = screen.getByRole("button", { name: /try again/i });
     await userEvent.click(tryAgainButton);
 
+    // Verify the form reappears for another attempt
     expect(
       screen.getByRole("button", { name: /check answer/i }),
     ).toBeInTheDocument();
   });
 
   it("handles multiple correct answers", async () => {
+    // Create a question with multiple correct answers (checkbox style)
     const multipleAnswerQuestion = {
       ...mockQuestion,
       answerOptions: [
@@ -86,19 +141,301 @@ describe("QuizQuestionBlock", () => {
       ],
     };
 
-    render(<QuizQuestionBlock question={multipleAnswerQuestion} />);
+    render(
+      <QuizQuestionBlock
+        question={multipleAnswerQuestion}
+        lessonId={mockLessonId}
+      />,
+    );
 
+    // Select both correct answers
     const answer1 = screen.getByRole("checkbox", { name: "A" });
     const answer2 = screen.getByRole("checkbox", { name: "B" });
     await userEvent.click(answer1);
     await userEvent.click(answer2);
 
+    // Submit the answers
     const submitButton = screen.getByRole("button", { name: /check answer/i });
     await userEvent.click(submitButton);
 
+    // Verify success feedback for multiple correct answers
     await waitFor(() => {
       const badge = screen.getByRole("status");
       expect(badge).toHaveTextContent(/right/i);
     });
+  });
+});
+
+describe("QuizQuestionBlock - Session Storage", () => {
+  // Standard quiz question for storage tests
+  const mockQuestion = {
+    id: 1,
+    content: "What is 2 + 2?",
+    answerOptions: [
+      { id: 1, content: "3", isCorrect: false },
+      { id: 2, content: "4", isCorrect: true },
+      { id: 3, content: "5", isCorrect: false },
+    ],
+  };
+
+  const mockLessonId = 1;
+
+  // Clear storage before each test to ensure isolation
+  beforeEach(() => {
+    mockSessionStorage.clear();
+  });
+
+  it("saves selected answer to session storage", async () => {
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
+
+    // Select an answer
+    const answer = screen.getByRole("radio", { name: "4" });
+    await userEvent.click(answer);
+
+    // Verify the answer was saved to sessionStorage
+    await waitFor(() => {
+      const stored = sessionStorage.getItem("quiz-1-1");
+      expect(stored).toBeTruthy();
+      const parsed = JSON.parse(stored!);
+      expect(parsed.answerIds).toEqual(["2"]); // Answer id 2 corresponds to "4"
+      expect(parsed.showResult).toBe(false); // Not yet submitted
+    });
+  });
+
+  it("restores selected answer from session storage on mount", async () => {
+    // Pre-populate sessionStorage with a saved answer
+    sessionStorage.setItem(
+      "quiz-1-1",
+      JSON.stringify({
+        answerIds: ["2"],
+        showResult: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    // Render the component
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
+
+    // Verify the saved answer is restored and checked
+    await waitFor(() => {
+      const correctAnswer = screen.getByRole("radio", {
+        name: "4",
+      });
+      // Check aria-checked attribute for Radix UI radio buttons
+      expect(correctAnswer).toHaveAttribute("aria-checked", "true");
+    });
+  });
+
+  it("saves submission state to session storage", async () => {
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
+
+    // Select and submit an answer
+    const answer = screen.getByRole("radio", { name: "4" });
+    await userEvent.click(answer);
+
+    const submitButton = screen.getByRole("button", { name: /check answer/i });
+    await userEvent.click(submitButton);
+
+    // Verify that showResult is saved as true after submission
+    await waitFor(() => {
+      const stored = sessionStorage.getItem("quiz-1-1");
+      expect(stored).toBeTruthy();
+      const parsed = JSON.parse(stored!);
+      expect(parsed.showResult).toBe(true);
+    });
+  });
+
+  it("restores submission result from session storage", async () => {
+    // Pre-populate with a submitted correct answer
+    sessionStorage.setItem(
+      "quiz-1-1",
+      JSON.stringify({
+        answerIds: ["2"],
+        showResult: true,
+        timestamp: Date.now(),
+      }),
+    );
+
+    // Render the component
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
+
+    // Verify the result screen is shown immediately (not the form)
+    await waitFor(() => {
+      const badge = screen.getByRole("status");
+      expect(badge).toHaveTextContent(/right/i);
+    });
+  });
+
+  it("restores incorrect answer result from session storage", async () => {
+    // Pre-populate with a submitted incorrect answer
+    sessionStorage.setItem(
+      "quiz-1-1",
+      JSON.stringify({
+        answerIds: ["1"],
+        showResult: true,
+        timestamp: Date.now(),
+      }),
+    );
+
+    // Render the component
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
+
+    // Verify the "Not Quite" result is shown immediately
+    await waitFor(() => {
+      const badge = screen.getByRole("status");
+      expect(badge).toHaveTextContent(/not quite/i);
+    });
+  });
+
+  it("persists answers across multiple question instances with different lessonIds", async () => {
+    // Render quiz for lesson 1
+    const { unmount } = render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={1} />,
+    );
+
+    // Select an answer and verify it's stored
+    const answer1 = screen.getByRole("radio", { name: "4" });
+    await userEvent.click(answer1);
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem("quiz-1-1")).toBeTruthy();
+    });
+
+    // Unmount and render the same question for lesson 2
+    unmount();
+    render(<QuizQuestionBlock question={mockQuestion} lessonId={2} />);
+
+    // Verify the answer is NOT restored (different lesson)
+    await waitFor(() => {
+      const answer = screen.getByRole("radio", {
+        name: "4",
+      });
+      // Check aria-checked attribute for Radix UI radio buttons
+      expect(answer).toHaveAttribute("aria-checked", "false");
+    });
+  });
+  it("handles multiple correct answers in session storage", async () => {
+    // Create a question with multiple correct answers
+    const multipleAnswerQuestion = {
+      id: 2,
+      content: "Select all that apply",
+      answerOptions: [
+        { id: 4, content: "A", isCorrect: true },
+        { id: 5, content: "B", isCorrect: true },
+        { id: 6, content: "C", isCorrect: false },
+      ],
+    };
+
+    render(
+      <QuizQuestionBlock
+        question={multipleAnswerQuestion}
+        lessonId={mockLessonId}
+      />,
+    );
+
+    // Select multiple answers
+    const answer1 = screen.getByRole("checkbox", { name: "A" });
+    const answer2 = screen.getByRole("checkbox", { name: "B" });
+    await userEvent.click(answer1);
+    await userEvent.click(answer2);
+
+    // Verify both answers are saved in storage
+    await waitFor(() => {
+      const stored = sessionStorage.getItem("quiz-1-2");
+      expect(stored).toBeTruthy();
+      const parsed = JSON.parse(stored!);
+      expect(parsed.answerIds).toEqual(expect.arrayContaining(["4", "5"]));
+      expect(parsed.answerIds).toHaveLength(2);
+    });
+  });
+
+  it("updates storage when changing answer before submission", async () => {
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
+
+    // Select first answer
+    const firstAnswer = screen.getByRole("radio", { name: "3" });
+    await userEvent.click(firstAnswer);
+
+    // Verify first answer is saved
+    await waitFor(() => {
+      const stored = sessionStorage.getItem("quiz-1-1");
+      const parsed = JSON.parse(stored!);
+      expect(parsed.answerIds).toEqual(["1"]);
+    });
+
+    // Change to a different answer
+    const secondAnswer = screen.getByRole("radio", { name: "4" });
+    await userEvent.click(secondAnswer);
+
+    // Verify storage is updated with the new answer
+    await waitFor(() => {
+      const stored = sessionStorage.getItem("quiz-1-1");
+      const parsed = JSON.parse(stored!);
+      expect(parsed.answerIds).toEqual(["2"]);
+    });
+  });
+
+  it("resets showResult state when trying again", async () => {
+    // Start with a submitted wrong answer in storage
+    sessionStorage.setItem(
+      "quiz-1-1",
+      JSON.stringify({
+        answerIds: ["1"],
+        showResult: true,
+        timestamp: Date.now(),
+      }),
+    );
+
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
+
+    // Verify the result is shown initially
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    // Click "Try Again" button
+    const tryAgainButton = screen.getByRole("button", { name: /try again/i });
+    await userEvent.click(tryAgainButton);
+
+    // Verify the form reappears and result is hidden
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /check answer/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not restore data when storage is empty", () => {
+    // Render with no data in storage
+    render(
+      <QuizQuestionBlock question={mockQuestion} lessonId={mockLessonId} />,
+    );
+
+    // Verify all radio buttons are unchecked using aria-checked
+    const radios = screen.getAllByRole("radio");
+    radios.forEach((radio) => {
+      expect(radio).toHaveAttribute("aria-checked", "false");
+    });
+
+    // Verify the form is shown (not the result screen)
+    expect(
+      screen.getByRole("button", { name: /check answer/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implemented session storage to hold quiz answers when users navigate between lessons within a droplet, eliminating the need to re-enter answers when returning to a previously viewed lesson.

## Motivation and Context

Users do not have to remember their previously entered quiz answers when they return to a lesson during droplet completion. The answers will be saved, improving the overall features of the platform.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quiz answers are auto-saved per lesson and restored across navigation/refresh.
  * Lesson-level quiz progress is persisted so completed quizzes allow immediate progression.
  * Quiz UI now passes lesson context to questions enabling per-lesson persistence and behavior.
  * Replay/back control labeled “View Answer” added to correct-answer feedback.

* **Tests**
  * Expanded coverage for persistence, restoration, submission states, multi-question scenarios and cross-lesson isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->