### PR TITLE
ODY 114-fixed special text in darkmode highlight

### DIFF
--- a/frontend/components/droplets/lessons/GenericBlockRenderer.tsx
+++ b/frontend/components/droplets/lessons/GenericBlockRenderer.tsx
@@ -150,6 +150,7 @@ const GenericBlockRenderer: React.FC<GenericBlockRendererProps> = ({
 
       span.style.backgroundColor = color;
       span.style.borderRadius = "8px";
+      span.style.setProperty("color", "black", "important");
 
       const contents = nodeRange.extractContents();
       span.appendChild(contents);
@@ -289,7 +290,7 @@ const GenericBlockRenderer: React.FC<GenericBlockRendererProps> = ({
           const span = document.createElement("span");
           span.style.borderRadius = "8px";
           span.style.backgroundColor = highlight.color;
-          span.style.color = "black";
+          span.style.setProperty("color", "black", "important");
           range.surroundContents(span);
         } catch {
           highlightRange(
@@ -416,7 +417,7 @@ const GenericBlockRenderer: React.FC<GenericBlockRendererProps> = ({
         const span = document.createElement("span");
         span.style.borderRadius = "8px";
         span.style.backgroundColor = selectedColor;
-        span.style.color = "black";
+        span.style.setProperty("color", "black", "important");
 
         const textNode = document.createTextNode(text);
         span.appendChild(textNode);
@@ -541,6 +542,7 @@ const GenericBlockRenderer: React.FC<GenericBlockRendererProps> = ({
       const span = document.createElement("span");
       span.style.borderRadius = "8px";
       span.style.backgroundColor = selectedColor;
+      span.style.setProperty("color", "black", "important");
 
       const textNode = document.createTextNode(text);
       span.appendChild(textNode);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Highlighting sections with bold, italicized or code text in dark mode should make the text black now
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text color rendering in lesson highlights to ensure consistent visual styling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->