### PR TITLE
ODY 150-remove arrows for no droplets found screen

### DIFF
--- a/frontend/components/ui/page-nav.tsx
+++ b/frontend/components/ui/page-nav.tsx
@@ -33,7 +33,7 @@ export function PageNav({ currentPage, updatePage, totalPages }: PageNavProps) {
           onClick={handlePrevPage}
           disabled={currentPage === 1}
           aria-label="chevron-left"
-          className={`${currentPage === 1 ? "text-slate-400 dark:text-slate-600" : ""}`}
+          className={`${currentPage === 1 ? "text-slate-400 dark:text-slate-600" : ""} ${totalPages === 0 ? "visibility: hidden" : "visibility: visible"}`}
         >
           <ChevronLeft />
         </button>
@@ -64,7 +64,7 @@ export function PageNav({ currentPage, updatePage, totalPages }: PageNavProps) {
           onClick={handleNextPage}
           disabled={currentPage === totalPages}
           aria-label="chevron-right"
-          className={`${currentPage === totalPages ? "text-slate-400 dark:text-slate-600" : ""}`}
+          className={`${currentPage === totalPages ? "text-slate-400 dark:text-slate-600" : ""} ${totalPages === 0 ? "visibility: hidden" : "visibility: visible"}`}
         >
           <ChevronRight />
         </button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the filters have no matching droplet, the arrows do not appear in the bottom right
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination navigation buttons now properly hide when no pages are available, providing a cleaner interface and eliminating unnecessary navigation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->