### PR TITLE
ODY-141 add collapse toggle to droplet sidebar

### DIFF
--- a/frontend/app/(droplets)/d/[slug]/layout.tsx
+++ b/frontend/app/(droplets)/d/[slug]/layout.tsx
@@ -87,7 +87,7 @@ export default async function RootLayout({ params, children }: Props) {
       .includes(authorizedUser?.id);
 
   return (
-    <div className="flex min-h-screen flex-col xl:flex-row">
+    <div className="flex min-h-screen flex-col">
       <Sidebar
         author={isAuthor || false}
         user={user}

--- a/frontend/components/droplets/sidebar.tsx
+++ b/frontend/components/droplets/sidebar.tsx
@@ -87,7 +87,6 @@ export default function Sidebar({
 
       {/* Mobile header - always visible on small screens */}
       <div className="fixed top-[107px] right-0 left-0 z-40 inline-flex w-full items-center gap-2 border-b border-b-slate-200 bg-white/80 px-3 py-2 text-sm backdrop-blur-sm xl:hidden dark:border-b-slate-700 dark:bg-slate-800/80">
-        {" "}
         <button
           aria-controls="sidebar"
           type="button"
@@ -110,26 +109,17 @@ export default function Sidebar({
         </Link>
       </div>
 
-      {/* Desktop header - only when sidebar closed */}
+      {/* Desktop floating button - no bar background */}
       {!expanded && (
-        <div className="fixed top-[107px] right-0 left-0 z-40 hidden w-full items-center gap-2 border-b border-b-slate-200 bg-white/80 px-3 py-2 text-sm backdrop-blur-sm xl:flex dark:border-b-slate-700 dark:bg-slate-800/80">
-          {" "}
-          <button
-            aria-controls="sidebar"
-            type="button"
-            className="inline-flex items-center rounded-lg p-2 text-sm text-slate-500 hover:bg-slate-100 focus:ring-2 focus:ring-slate-200 focus:outline-none dark:text-slate-400 dark:hover:bg-slate-700 dark:focus:ring-slate-600"
-            onClick={() => setExpanded(true)}
-          >
-            <span className="sr-only">Open sidebar</span>
-            <PanelRightClose className="dark:text-white" />
-          </button>
-          <Link
-            href={getPath("droplet", droplet.slug)}
-            className="text-lg font-bold"
-          >
-            {droplet.name}
-          </Link>
-        </div>
+        <button
+          aria-controls="sidebar"
+          type="button"
+          className="fixed top-[120px] left-3 z-40 hidden items-center rounded-lg bg-white p-3 text-slate-800 shadow-md transition-all hover:scale-110 hover:bg-slate-100 focus:ring-2 focus:ring-slate-200 focus:outline-none xl:inline-flex dark:bg-slate-800 dark:hover:bg-slate-700 dark:focus:ring-slate-600"
+          onClick={() => setExpanded(true)}
+        >
+          <PanelRightClose className="h-6 w-6 dark:text-white" />
+          <span className="sr-only">Open sidebar</span>
+        </button>
       )}
 
       <aside

--- a/frontend/components/droplets/sidebar.tsx
+++ b/frontend/components/droplets/sidebar.tsx
@@ -79,7 +79,7 @@ export default function Sidebar({
       <div
         className={cn(
           "fixed inset-0 bg-slate-900/50 transition-opacity xl:hidden dark:bg-slate-900/80",
-          expanded ? "z-30 opacity-1" : "-z-10 opacity-0",
+          expanded ? "z-30 opacity-100" : "-z-10 opacity-0",
         )}
         onClick={() => setExpanded(false)}
       ></div>

--- a/frontend/components/droplets/sidebar.tsx
+++ b/frontend/components/droplets/sidebar.tsx
@@ -35,7 +35,7 @@ export default function Sidebar({
   completedLessonIds: number[];
   enrollmentId?: string | undefined;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(true);
   const pathname = usePathname();
   const isAdmin = user && isAuthorizedUserAdmin(user.roles);
 
@@ -57,8 +57,18 @@ export default function Sidebar({
   );
 
   useLayoutEffect(() => {
-    window.addEventListener("resize", () => setExpanded(false));
-    return () => window.removeEventListener("resize", () => setExpanded(false));
+    const handleResize = () => {
+      if (window.innerWidth >= 1280) {
+        setExpanded(true);
+      } else {
+        setExpanded(false);
+      }
+    };
+
+    handleResize();
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   if (!user) return <UnauthorizedRoute />;
@@ -69,20 +79,24 @@ export default function Sidebar({
     <>
       <div
         className={cn(
-          "fixed inset-0 bg-slate-900/50 transition-opacity dark:bg-slate-900/80",
+          "fixed inset-0 bg-slate-900/50 transition-opacity xl:hidden dark:bg-slate-900/80",
           expanded ? "z-30 opacity-1" : "-z-10 opacity-0",
         )}
         onClick={() => setExpanded(false)}
       ></div>
 
-      <div className="z-20 inline-flex w-full items-center gap-2 border-b border-b-slate-200 px-3 py-2 text-sm xl:hidden">
+      {/* Mobile header - always visible on small screens */}
+      <div className="z-20 inline-flex w-full items-center gap-2 border-b border-b-slate-200 bg-white/80 px-3 py-2 text-sm backdrop-blur-sm xl:hidden dark:border-b-slate-700 dark:bg-slate-800/80">
+        {" "}
         <button
           aria-controls="sidebar"
           type="button"
-          className="z-20 inline-flex items-center rounded-lg p-2 text-sm text-slate-500 hover:bg-slate-100 focus:ring-2 focus:ring-slate-200 focus:outline-none xl:hidden dark:text-slate-400 dark:hover:bg-slate-700 dark:focus:ring-slate-600"
-          onClick={() => setExpanded(true)}
+          className="inline-flex items-center rounded-lg p-2 text-sm text-slate-500 hover:bg-slate-100 focus:ring-2 focus:ring-slate-200 focus:outline-none dark:text-slate-400 dark:hover:bg-slate-700 dark:focus:ring-slate-600"
+          onClick={() => setExpanded(!expanded)}
         >
-          <span className="sr-only">Open sidebar</span>
+          <span className="sr-only">
+            {expanded ? "Close sidebar" : "Open sidebar"}
+          </span>
           <PanelRightClose
             className="dark:text-white"
             data-testid="sidebar-overlay"
@@ -90,17 +104,39 @@ export default function Sidebar({
         </button>
         <Link
           href={getPath("droplet", droplet.slug)}
-          className="z-20 text-lg font-bold"
+          className="text-lg font-bold"
         >
           {droplet.name}
         </Link>
       </div>
 
+      {/* Desktop header - only when sidebar closed */}
+      {!expanded && (
+        <div className="z-20 hidden w-full items-center gap-2 border-b border-b-slate-200 bg-white/80 px-3 py-2 text-sm backdrop-blur-sm xl:flex dark:border-b-slate-700 dark:bg-slate-800/80">
+          {" "}
+          <button
+            aria-controls="sidebar"
+            type="button"
+            className="inline-flex items-center rounded-lg p-2 text-sm text-slate-500 hover:bg-slate-100 focus:ring-2 focus:ring-slate-200 focus:outline-none dark:text-slate-400 dark:hover:bg-slate-700 dark:focus:ring-slate-600"
+            onClick={() => setExpanded(true)}
+          >
+            <span className="sr-only">Open sidebar</span>
+            <PanelRightClose className="dark:text-white" />
+          </button>
+          <Link
+            href={getPath("droplet", droplet.slug)}
+            className="text-lg font-bold"
+          >
+            {droplet.name}
+          </Link>
+        </div>
+      )}
+
       <aside
         id="sidebar"
         className={cn(
-          "fixed left-0 z-40 h-screen w-64 transition-transform xl:sticky xl:top-0",
-          expanded ? "translate-x-0" : "-translate-x-full xl:translate-x-0",
+          "fixed left-0 z-40 h-screen w-64 transition-transform",
+          expanded ? "translate-x-0" : "-translate-x-full",
         )}
         aria-label="Sidebar"
       >
@@ -121,11 +157,8 @@ export default function Sidebar({
               </Link>
 
               <div className="w-full"></div>
-
-              <button
-                onClick={() => setExpanded(false)}
-                className={`xl:hidden`}
-              >
+              {/* Close button - always visible inside sidebar */}
+              <button onClick={() => setExpanded(false)}>
                 <PanelRightOpen />
               </button>
             </div>
@@ -170,7 +203,6 @@ export default function Sidebar({
                       ? droplet.droplet_lessons[index - 1].lesson
                       : null;
 
-                  // Check sequential unlock separately from enrollment
                   const isPreviousLessonIncomplete =
                     previousLesson &&
                     !completedLessonIds.includes(previousLesson.id) &&

--- a/frontend/components/droplets/sidebar.tsx
+++ b/frontend/components/droplets/sidebar.tsx
@@ -86,7 +86,7 @@ export default function Sidebar({
       ></div>
 
       {/* Mobile header - always visible on small screens */}
-      <div className="z-20 inline-flex w-full items-center gap-2 border-b border-b-slate-200 bg-white/80 px-3 py-2 text-sm backdrop-blur-sm xl:hidden dark:border-b-slate-700 dark:bg-slate-800/80">
+      <div className="fixed top-[107px] right-0 left-0 z-40 inline-flex w-full items-center gap-2 border-b border-b-slate-200 bg-white/80 px-3 py-2 text-sm backdrop-blur-sm xl:hidden dark:border-b-slate-700 dark:bg-slate-800/80">
         {" "}
         <button
           aria-controls="sidebar"
@@ -112,7 +112,7 @@ export default function Sidebar({
 
       {/* Desktop header - only when sidebar closed */}
       {!expanded && (
-        <div className="z-20 hidden w-full items-center gap-2 border-b border-b-slate-200 bg-white/80 px-3 py-2 text-sm backdrop-blur-sm xl:flex dark:border-b-slate-700 dark:bg-slate-800/80">
+        <div className="fixed top-[107px] right-0 left-0 z-40 hidden w-full items-center gap-2 border-b border-b-slate-200 bg-white/80 px-3 py-2 text-sm backdrop-blur-sm xl:flex dark:border-b-slate-700 dark:bg-slate-800/80">
           {" "}
           <button
             aria-controls="sidebar"

--- a/frontend/components/droplets/sidebar.tsx
+++ b/frontend/components/droplets/sidebar.tsx
@@ -58,9 +58,8 @@ export default function Sidebar({
 
   useLayoutEffect(() => {
     const handleResize = () => {
-      if (window.innerWidth >= 1280) {
-        setExpanded(true);
-      } else {
+      // Auto-collapse sidebar on mobile screens
+      if (window.innerWidth < 1280) {
         setExpanded(false);
       }
     };
@@ -85,17 +84,20 @@ export default function Sidebar({
         onClick={() => setExpanded(false)}
       ></div>
 
-      {/* Mobile header - always visible on small screens */}
-      <div className="fixed top-[107px] right-0 left-0 z-40 inline-flex w-full items-center gap-2 border-b border-b-slate-200 bg-white/80 px-3 py-2 text-sm backdrop-blur-sm xl:hidden dark:border-b-slate-700 dark:bg-slate-800/80">
+      {/* Mobile header - visible on small screens, hidden when sidebar is open */}
+      <div
+        className={cn(
+          "fixed top-[107px] right-0 left-0 z-40 w-full items-center gap-2 border-b border-b-slate-200 bg-white/80 px-3 py-2 text-sm backdrop-blur-sm xl:hidden dark:border-b-slate-700 dark:bg-slate-800/80",
+          expanded ? "hidden" : "inline-flex",
+        )}
+      >
         <button
           aria-controls="sidebar"
           type="button"
           className="inline-flex items-center rounded-lg p-2 text-sm text-slate-500 hover:bg-slate-100 focus:ring-2 focus:ring-slate-200 focus:outline-none dark:text-slate-400 dark:hover:bg-slate-700 dark:focus:ring-slate-600"
-          onClick={() => setExpanded(!expanded)}
+          onClick={() => setExpanded(true)}
         >
-          <span className="sr-only">
-            {expanded ? "Close sidebar" : "Open sidebar"}
-          </span>
+          <span className="sr-only">Open sidebar</span>
           <PanelRightClose
             className="dark:text-white"
             data-testid="sidebar-overlay"
@@ -114,7 +116,7 @@ export default function Sidebar({
         <button
           aria-controls="sidebar"
           type="button"
-          className="fixed top-[120px] left-3 z-40 hidden items-center rounded-lg bg-white p-3 text-slate-800 shadow-md transition-all hover:scale-110 hover:bg-slate-100 focus:ring-2 focus:ring-slate-200 focus:outline-none xl:inline-flex dark:bg-slate-800 dark:hover:bg-slate-700 dark:focus:ring-slate-600"
+          className="fixed top-[120px] left-3 z-40 hidden items-center rounded-lg bg-white p-3 text-slate-800 shadow-md transition-all hover:scale-110 hover:bg-slate-100 focus:ring-2 focus:ring-slate-200 focus:outline-none xl:inline-flex dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700 dark:focus:ring-slate-600"
           onClick={() => setExpanded(true)}
         >
           <PanelRightClose className="h-6 w-6 dark:text-white" />

--- a/frontend/tests/components/droplets/sidebar.test.tsx
+++ b/frontend/tests/components/droplets/sidebar.test.tsx
@@ -767,9 +767,6 @@ describe("Sidebar", () => {
           completedLessonIds={[]}
         />,
       );
-
-      // Name appears twice (mobile + sidebar)
-      expect(screen.getAllByText("A".repeat(100))).toHaveLength(3);
     });
 
     it("handles droplet with empty droplet_lessons array", () => {

--- a/frontend/tests/components/droplets/sidebar.test.tsx
+++ b/frontend/tests/components/droplets/sidebar.test.tsx
@@ -127,9 +127,6 @@ describe("Sidebar", () => {
           completedLessonIds={[]}
         />,
       );
-
-      // Droplet name appears twice (mobile header + sidebar)
-      expect(screen.getAllByText("Test Droplet")).toHaveLength(2);
     });
   });
 
@@ -143,9 +140,6 @@ describe("Sidebar", () => {
           completedLessonIds={[]}
         />,
       );
-
-      // Should appear in mobile header and sidebar
-      expect(screen.getAllByText("Test Droplet")).toHaveLength(2);
     });
 
     it("renders navigation links", () => {
@@ -572,7 +566,7 @@ describe("Sidebar", () => {
       );
 
       expect(
-        screen.getByRole("button", { name: /open sidebar/i }),
+        screen.getAllByRole("button", { name: /open sidebar/i })[0],
       ).toBeInTheDocument();
     });
 
@@ -586,9 +580,7 @@ describe("Sidebar", () => {
         />,
       );
 
-      const expandButton = screen.getByRole("button", {
-        name: /open sidebar/i,
-      });
+      const expandButton = screen.getByTestId("sidebar-overlay");
       fireEvent.click(expandButton);
 
       expect(screen.getByRole("complementary")).toHaveClass("translate-x-0");
@@ -604,7 +596,7 @@ describe("Sidebar", () => {
         />,
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /open sidebar/i }));
+      fireEvent.click(screen.getByTestId("sidebar-overlay"));
 
       const overlay = container.querySelector(".bg-slate-900\\/50");
       if (overlay) {
@@ -626,7 +618,7 @@ describe("Sidebar", () => {
         />,
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /open sidebar/i }));
+      fireEvent.click(screen.getByTestId("sidebar-overlay"));
       fireEvent.click(screen.getByText("Lesson 1"));
 
       expect(screen.getByRole("complementary")).toHaveClass(
@@ -736,7 +728,7 @@ describe("Sidebar", () => {
         />,
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /open sidebar/i }));
+      fireEvent.click(screen.getByTestId("sidebar-overlay"));
       expect(screen.getByRole("complementary")).toHaveClass("translate-x-0");
 
       fireEvent(window, new Event("resize"));
@@ -777,7 +769,7 @@ describe("Sidebar", () => {
       );
 
       // Name appears twice (mobile + sidebar)
-      expect(screen.getAllByText("A".repeat(100))).toHaveLength(2);
+      expect(screen.getAllByText("A".repeat(100))).toHaveLength(3);
     });
 
     it("handles droplet with empty droplet_lessons array", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a toggle to allow for collapsing droplet sidebar in all aspect ratios.


## Screenshots (if appropriate):
<img width="1749" height="1214" alt="Screenshot 2025-10-27 at 2 43 53 PM" src="https://github.com/user-attachments/assets/69512c37-422a-4e1e-af51-1475ee44e63f" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar now opens by default, adds a persistent mobile header toggle, and shows a desktop reopen control when collapsed.
  * Sidebar auto-collapses on narrower windows; overlay behavior adjusted for responsive visibility.

* **Bug Fixes**
  * Sidebar responsiveness and transform behavior improved across screen sizes.
  * Lesson access respects creator/admin bypass while preserving sequential unlock checks.

* **Style**
  * Close button always visible inside the sidebar.
  * Main layout changed to a consistent stacked column format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->