### PR TITLE
ODY-159 restricted roles on group creation page

### DIFF
--- a/frontend/app/(groups)/g/management/page.tsx
+++ b/frontend/app/(groups)/g/management/page.tsx
@@ -16,9 +16,14 @@ type Props = {
 
 export default async function GroupManagementPage({ searchParams }: Props) {
   const user = await getCurrentUser();
-  if (!user?.email) {
+  if (
+    !user ||
+    !user?.email ||
+    (!isContentCreator(user.roles) &&
+      !isAuthorizedUserAdmin(user.roles) &&
+      !isAuthorizedUserFaculty(user.roles))
+  )
     return notFound();
-  }
 
   const authorizedUser = await getAuthorizedUserByEmail(user.email);
   if (!authorizedUser) return notFound();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Restricted who can access the group creation page to only admin, content creators and faculty. Before this it was a fully open url. 

- [ ] Confirm by checking that you cannot access /g/management url as a user 


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented role-based access control for group management with support for Admin, Faculty, and Content Creator roles in addition to existing ownership-based permissions. Enhanced authentication requirements to verify user identity and email validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->