### PR TITLE
ODY-167 fixed auto collapse

### DIFF
--- a/frontend/components/droplets/sidebar.tsx
+++ b/frontend/components/droplets/sidebar.tsx
@@ -179,7 +179,6 @@ export default function Sidebar({
                       ? activeLinkClasses
                       : inactiveLinkClasses
                   }
-                  onClick={() => setExpanded(false)}
                 >
                   <TargetIcon className="shrink-0" />
                   <span className="ms-3 leading-snug">Overview</span>
@@ -219,7 +218,6 @@ export default function Sidebar({
                             e.preventDefault();
                             return;
                           }
-                          setExpanded(false);
                         }}
                         aria-disabled={!!isLocked}
                       >
@@ -257,7 +255,6 @@ export default function Sidebar({
                       ? activeLinkClasses
                       : inactiveLinkClasses
                   }
-                  onClick={() => setExpanded(false)}
                 >
                   <HistoryIcon className="shrink-0" />
                   <span className="ms-3 leading-snug">Recap</span>

--- a/frontend/tests/components/droplets/sidebar.test.tsx
+++ b/frontend/tests/components/droplets/sidebar.test.tsx
@@ -620,10 +620,6 @@ describe("Sidebar", () => {
 
       fireEvent.click(screen.getByTestId("sidebar-overlay"));
       fireEvent.click(screen.getByText("Lesson 1"));
-
-      expect(screen.getByRole("complementary")).toHaveClass(
-        "-translate-x-full",
-      );
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Droplet sidebar automatically collapsed when a lesson was clicked. Resolved this so that it stays open.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar now remains expanded when navigating between sections instead of automatically collapsing
  * Backdrop overlay no longer closes the sidebar when clicked

<!-- end of auto-generated comment: release notes by coderabbit.ai -->