### PR TITLE
Bug/ody 169 tabs on groups page arent working

### DIFF
--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -203,8 +203,6 @@ export default async function GroupDetailPage({ params }: Props) {
               data-testid="group-edit-controls"
             />
           </ContentSection>
-
-          <Separator />
         </div>
       </div>
     </div>

--- a/frontend/components/group/group-management-dashboard.tsx
+++ b/frontend/components/group/group-management-dashboard.tsx
@@ -9,7 +9,7 @@ import { AuthorizedUser, DueDate, Group } from "@/types";
 import { PlaylistCard } from "@/components/playlists/playlist-card";
 import { GroupProgressGrid } from "@/components/group/group-progress-grid";
 import { Button } from "../ui/button";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 interface RenderGroupDashboardProps {
@@ -57,28 +57,29 @@ export function GroupDashboard({
   const router = useRouter();
 
   const tabParam = searchParams.get("tab");
-  
+
   // Calculate selected index directly from URL
   const selectedIndex = (() => {
     const index = tabNames.indexOf(tabParam || "droplets");
     return index >= 0 ? index : 0;
   })();
 
+  // Track which tabs have been visited - initialize with current tab from URL
+  const [visitedTabs, setVisitedTabs] = useState<Set<number>>(
+    new Set([selectedIndex]),
+  );
+
+  // Update visited tabs when URL changes
+  useEffect(() => {
+    setVisitedTabs((prev) => new Set(prev).add(selectedIndex));
+  }, [selectedIndex]);
+
   const handleTabSelect = (index: number) => {
+    setVisitedTabs((prev) => new Set(prev).add(index));
     const tabName = tabNames[index];
     const params = new URLSearchParams(searchParams.toString());
     params.set("tab", tabName);
     router.replace(`?${params.toString()}`);
-  };
-
-  // Track which tabs have been visited
-  const [visitedTabs, setVisitedTabs] = useState<Set<number>>(
-    new Set([selectedIndex])
-  );
-
-  const handleTabSelectWithTracking = (index: number) => {
-    setVisitedTabs((prev) => new Set(prev).add(index));
-    handleTabSelect(index);
   };
 
   return (
@@ -91,11 +92,7 @@ export function GroupDashboard({
           display: block;
         }
       `}</style>
-      <Tabs
-        title=""
-        onSelect={handleTabSelectWithTracking}
-        selectedIndex={selectedIndex}
-      >
+      <Tabs title="" onSelect={handleTabSelect} selectedIndex={selectedIndex}>
         <TabList className="flex border-b">
           <Tab className={tabStyle}>Droplets</Tab>
           <Tab className={tabStyle}>Playlists</Tab>
@@ -153,31 +150,33 @@ export function GroupDashboard({
           </ContentSection>
         </TabPanel>
         <TabPanel>
-          <ContentSection
-            title=""
-            emptyMessage="No playlists have been added to this group yet."
-          >
-            {group.playlists && group.playlists.length > 0 ? (
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                {group.playlists.map((playlist) => (
-                  <PlaylistCard
-                    key={playlist.id}
-                    playlist={playlist}
-                    dueDate={
-                      dueDates?.find(
-                        (dueDate) => dueDate.playlist?.id === playlist.id,
-                      )?.dueDate || ""
-                    }
-                    timeZone={authUser.timeZone?.trim()}
-                  />
-                ))}
-              </div>
-            ) : (
-              <div className="rounded-lg border border-dashed p-8 text-center text-slate-500 dark:border-slate-500 dark:text-slate-300">
-                No playlists have been added to this group yet.
-              </div>
-            )}
-          </ContentSection>
+          {visitedTabs.has(1) ? (
+            <ContentSection
+              title=""
+              emptyMessage="No playlists have been added to this group yet."
+            >
+              {group.playlists && group.playlists.length > 0 ? (
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  {group.playlists.map((playlist) => (
+                    <PlaylistCard
+                      key={playlist.id}
+                      playlist={playlist}
+                      dueDate={
+                        dueDates?.find(
+                          (dueDate) => dueDate.playlist?.id === playlist.id,
+                        )?.dueDate || ""
+                      }
+                      timeZone={authUser.timeZone?.trim()}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div className="rounded-lg border border-dashed p-8 text-center text-slate-500 dark:border-slate-500 dark:text-slate-300">
+                  No playlists have been added to this group yet.
+                </div>
+              )}
+            </ContentSection>
+          ) : null}
         </TabPanel>
         {(canEdit || isAdmin) && (
           <TabPanel>

--- a/frontend/components/group/group-management-dashboard.tsx
+++ b/frontend/components/group/group-management-dashboard.tsx
@@ -57,133 +57,154 @@ export function GroupDashboard({
   const router = useRouter();
 
   const tabParam = searchParams.get("tab");
-  const defaultIndex = tabNames.indexOf(tabParam || "droplets");
-  const [selectedIndex, setSelectedIndex] = useState(
-    defaultIndex >= 0 ? defaultIndex : 0,
-  );
+  
+  // Calculate selected index directly from URL
+  const selectedIndex = (() => {
+    const index = tabNames.indexOf(tabParam || "droplets");
+    return index >= 0 ? index : 0;
+  })();
 
   const handleTabSelect = (index: number) => {
-    setSelectedIndex(index);
     const tabName = tabNames[index];
-
     const params = new URLSearchParams(searchParams.toString());
     params.set("tab", tabName);
     router.replace(`?${params.toString()}`);
   };
 
+  // Track which tabs have been visited
+  const [visitedTabs, setVisitedTabs] = useState<Set<number>>(
+    new Set([selectedIndex])
+  );
+
+  const handleTabSelectWithTracking = (index: number) => {
+    setVisitedTabs((prev) => new Set(prev).add(index));
+    handleTabSelect(index);
+  };
+
   return (
-    <Tabs
-      title=""
-      forceRenderTabPanel
-      onSelect={handleTabSelect}
-      selectedIndex={selectedIndex}
-    >
-      <TabList className="flex border-b">
-        <Tab className={tabStyle}>Droplets</Tab>
-        <Tab className={tabStyle}>Playlists</Tab>
-        {(canEdit || isAdmin) && <Tab className={tabStyle}>Progress</Tab>}
-      </TabList>
-      <TabPanel>
-        <ContentSection
-          title=""
-          emptyMessage="No droplets have been added to this group yet."
-        >
-          {group.droplets && group.droplets.length > 0 ? (
-            <div className="flex flex-col gap-4">
-              <div className="grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2">
-                {paginatedDroplets?.map((droplet) => (
-                  <div key={droplet.id} className="h-full w-full">
-                    <GroupDropletTile
-                      key={droplet.id}
-                      droplet={droplet}
-                      dueDate={
-                        dueDates?.find(
-                          (dueDate) => dueDate.droplet?.id === droplet.id,
-                        )?.dueDate || ""
-                      }
-                      authUser={authUser}
-                    />
-                  </div>
-                ))}
-              </div>
-              <div className="flex justify-end gap-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={handlePrevPage}
-                  disabled={currentPage === 0}
-                  className={`${currentPage === 0 ? "visibility: hidden" : "visibility: visible"} dark:bg-slate-300 dark:text-black`}
-                >
-                  Previous
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={handleNextPage}
-                  disabled={currentPage === totalPages - 1}
-                  className={`${currentPage === totalPages - 1 ? "visibility: hidden" : "visibility: visible"} dark:bg-slate-300 dark:text-black`}
-                >
-                  Next
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <div className="rounded-lg border border-dashed p-8 text-center text-slate-500 dark:border-slate-500 dark:text-slate-300">
-              No droplets have been added to this group yet.
-            </div>
-          )}
-        </ContentSection>
-      </TabPanel>
-      <TabPanel>
-        <ContentSection
-          title=""
-          emptyMessage="No playlists have been added to this group yet."
-        >
-          {group.playlists && group.playlists.length > 0 ? (
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              {group.playlists.map((playlist) => (
-                <PlaylistCard
-                  key={playlist.id}
-                  playlist={playlist}
-                  dueDate={
-                    dueDates?.find(
-                      (dueDate) => dueDate.playlist?.id === playlist.id,
-                    )?.dueDate || ""
-                  }
-                  timeZone={authUser.timeZone?.trim()}
-                />
-              ))}
-            </div>
-          ) : (
-            <div className="rounded-lg border border-dashed p-8 text-center text-slate-500 dark:border-slate-500 dark:text-slate-300">
-              No playlists have been added to this group yet.
-            </div>
-          )}
-        </ContentSection>
-      </TabPanel>
-      {(canEdit || isAdmin) && (
+    <>
+      <style jsx global>{`
+        .react-tabs__tab-panel {
+          display: none;
+        }
+        .react-tabs__tab-panel--selected {
+          display: block;
+        }
+      `}</style>
+      <Tabs
+        title=""
+        onSelect={handleTabSelectWithTracking}
+        selectedIndex={selectedIndex}
+      >
+        <TabList className="flex border-b">
+          <Tab className={tabStyle}>Droplets</Tab>
+          <Tab className={tabStyle}>Playlists</Tab>
+          {(canEdit || isAdmin) && <Tab className={tabStyle}>Progress</Tab>}
+        </TabList>
         <TabPanel>
           <ContentSection
             title=""
-            emptyMessage="No students are enrolled in any droplets or playlists."
+            emptyMessage="No droplets have been added to this group yet."
           >
-            {((group.droplets && group.droplets.length > 0) ||
-              (group.playlists && group.playlists.length > 0)) &&
-            group.members &&
-            group.members.length > 0 ? (
-              <div className="flex flex-row items-start overflow-x-auto">
-                <div className="" key={group.id}>
-                  <GroupProgressGrid group={group} statuses={statuses} />
+            {group.droplets && group.droplets.length > 0 ? (
+              <div className="flex flex-col gap-4">
+                <div className="grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2">
+                  {paginatedDroplets?.map((droplet) => (
+                    <div key={droplet.id} className="h-full w-full">
+                      <GroupDropletTile
+                        key={droplet.id}
+                        droplet={droplet}
+                        dueDate={
+                          dueDates?.find(
+                            (dueDate) => dueDate.droplet?.id === droplet.id,
+                          )?.dueDate || ""
+                        }
+                        authUser={authUser}
+                      />
+                    </div>
+                  ))}
+                </div>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handlePrevPage}
+                    disabled={currentPage === 0}
+                    className={`${currentPage === 0 ? "visibility: hidden" : "visibility: visible"} dark:bg-slate-300 dark:text-black`}
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleNextPage}
+                    disabled={currentPage === totalPages - 1}
+                    className={`${currentPage === totalPages - 1 ? "visibility: hidden" : "visibility: visible"} dark:bg-slate-300 dark:text-black`}
+                  >
+                    Next
+                  </Button>
                 </div>
               </div>
             ) : (
               <div className="rounded-lg border border-dashed p-8 text-center text-slate-500 dark:border-slate-500 dark:text-slate-300">
-                No droplets or members have been added to this group yet.
+                No droplets have been added to this group yet.
               </div>
             )}
           </ContentSection>
         </TabPanel>
-      )}
-    </Tabs>
+        <TabPanel>
+          <ContentSection
+            title=""
+            emptyMessage="No playlists have been added to this group yet."
+          >
+            {group.playlists && group.playlists.length > 0 ? (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {group.playlists.map((playlist) => (
+                  <PlaylistCard
+                    key={playlist.id}
+                    playlist={playlist}
+                    dueDate={
+                      dueDates?.find(
+                        (dueDate) => dueDate.playlist?.id === playlist.id,
+                      )?.dueDate || ""
+                    }
+                    timeZone={authUser.timeZone?.trim()}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-dashed p-8 text-center text-slate-500 dark:border-slate-500 dark:text-slate-300">
+                No playlists have been added to this group yet.
+              </div>
+            )}
+          </ContentSection>
+        </TabPanel>
+        {(canEdit || isAdmin) && (
+          <TabPanel>
+            {visitedTabs.has(2) ? (
+              <ContentSection
+                title=""
+                emptyMessage="No students are enrolled in any droplets or playlists."
+              >
+                {((group.droplets && group.droplets.length > 0) ||
+                  (group.playlists && group.playlists.length > 0)) &&
+                group.members &&
+                group.members.length > 0 ? (
+                  <div className="flex flex-row items-start overflow-x-auto">
+                    <div className="" key={group.id}>
+                      <GroupProgressGrid group={group} statuses={statuses} />
+                    </div>
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-dashed p-8 text-center text-slate-500 dark:border-slate-500 dark:text-slate-300">
+                    No droplets or members have been added to this group yet.
+                  </div>
+                )}
+              </ContentSection>
+            ) : null}
+          </TabPanel>
+        )}
+      </Tabs>
+    </>
   );
 }

--- a/frontend/components/group/group-management-dashboard.tsx
+++ b/frontend/components/group/group-management-dashboard.tsx
@@ -24,7 +24,14 @@ interface RenderGroupDashboardProps {
 }
 
 const tabStyle =
-  "px-4 py-2 cursor-pointer border-b-2 border-transparent focus:outline-none hover:border-gray-300";
+  "px-4 py-2 cursor-pointer border-b-2 transition-colors focus:outline-none";
+
+const getTabClassName = (isSelected: boolean) =>
+  `${tabStyle} ${
+    isSelected
+      ? "border-blue-500 text-blue-600 dark:border-blue-400 dark:text-blue-400"
+      : "border-transparent hover:border-gray-300 hover:text-gray-700 dark:hover:border-gray-600 dark:hover:text-gray-300"
+  }`;
 
 export function GroupDashboard({
   group,
@@ -93,10 +100,12 @@ export function GroupDashboard({
         }
       `}</style>
       <Tabs title="" onSelect={handleTabSelect} selectedIndex={selectedIndex}>
-        <TabList className="flex border-b">
-          <Tab className={tabStyle}>Droplets</Tab>
-          <Tab className={tabStyle}>Playlists</Tab>
-          {(canEdit || isAdmin) && <Tab className={tabStyle}>Progress</Tab>}
+        <TabList className="flex border-b border-gray-200 dark:border-gray-700">
+          <Tab className={getTabClassName(selectedIndex === 0)}>Droplets</Tab>
+          <Tab className={getTabClassName(selectedIndex === 1)}>Playlists</Tab>
+          {(canEdit || isAdmin) && (
+            <Tab className={getTabClassName(selectedIndex === 2)}>Progress</Tab>
+          )}
         </TabList>
         <TabPanel>
           <ContentSection

--- a/frontend/tests/components/group/group-management-dashboard.test.tsx
+++ b/frontend/tests/components/group/group-management-dashboard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, within } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   DropletLesson,
@@ -13,7 +13,7 @@ import {
 import { GroupDashboard } from "@/components/group/group-management-dashboard";
 
 const mockReplace = jest.fn();
-const mockSearchParams = new URLSearchParams();
+let mockSearchParams = new URLSearchParams();
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -136,11 +136,26 @@ describe("GroupDashboard", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSearchParams.delete("tab");
+    mockSearchParams = new URLSearchParams();
   });
 
-  describe("Tab Rendering", () => {
-    it("renders all tabs for users who can edit", () => {
+  describe("Tab Rendering and Permissions", () => {
+    it("renders Droplets and Playlists tabs for all users", () => {
+      render(
+        <GroupDashboard
+          group={mockGroup}
+          canEdit={false}
+          authUser={mockAuthUser}
+          dueDates={[]}
+          statuses={{}}
+        />,
+      );
+
+      expect(screen.getByText("Droplets")).toBeInTheDocument();
+      expect(screen.getByText("Playlists")).toBeInTheDocument();
+    });
+
+    it("shows Progress tab when user can edit", () => {
       render(
         <GroupDashboard
           group={mockGroup}
@@ -151,12 +166,10 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      expect(screen.getByText("Droplets")).toBeInTheDocument();
-      expect(screen.getByText("Playlists")).toBeInTheDocument();
       expect(screen.getByText("Progress")).toBeInTheDocument();
     });
 
-    it("shows progress tab for admin users", () => {
+    it("shows Progress tab when user is admin", () => {
       const adminUser = { ...mockAuthUser, id: 2 };
 
       render(
@@ -172,7 +185,7 @@ describe("GroupDashboard", () => {
       expect(screen.getByText("Progress")).toBeInTheDocument();
     });
 
-    it("hides progress tab when user cannot edit and is not admin", () => {
+    it("hides Progress tab when user has no permissions", () => {
       const regularUser = { ...mockAuthUser, id: 999 };
 
       render(
@@ -188,101 +201,28 @@ describe("GroupDashboard", () => {
       expect(screen.queryByText("Progress")).not.toBeInTheDocument();
     });
 
-    it("renders only Droplets and Playlists tabs when canEdit is false", () => {
+    it("hides Progress tab when canEdit is undefined and user is not admin", () => {
       const regularUser = { ...mockAuthUser, id: 999 };
 
       render(
         <GroupDashboard
           group={mockGroup}
-          canEdit={false}
+          canEdit={undefined}
           authUser={regularUser}
           dueDates={[]}
           statuses={{}}
         />,
       );
 
-      expect(screen.getByText("Droplets")).toBeInTheDocument();
-      expect(screen.getByText("Playlists")).toBeInTheDocument();
+      expect(screen.queryByText("Progress")).not.toBeInTheDocument();
     });
   });
 
-  describe("Tab Navigation", () => {
-    it("switches to Playlists tab when clicked", () => {
+  describe("Droplets Tab - Default View", () => {
+    it("displays droplets on initial render", () => {
       render(
         <GroupDashboard
-          group={{ ...mockGroup, playlists: mockPlaylists }}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      fireEvent.click(screen.getByText("Playlists"));
-
-      expect(screen.getByTestId("playlist-1")).toBeInTheDocument();
-    });
-
-    it("switches to Progress tab when clicked", () => {
-      render(
-        <GroupDashboard
-          group={{
-            ...mockGroup,
-            droplets: [mockDroplets[0]],
-            members: mockGroup.members,
-          }}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      fireEvent.click(screen.getByText("Progress"));
-
-      expect(screen.getByTestId("progress-grid")).toBeInTheDocument();
-    });
-
-    it("updates URL parameter on tab change", () => {
-      render(
-        <GroupDashboard
-          group={mockGroup}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      fireEvent.click(screen.getByText("Playlists"));
-
-      expect(mockReplace).toHaveBeenCalledWith(
-        expect.stringContaining("tab=playlists"),
-      );
-    });
-
-    it("initializes with tab from URL parameter", () => {
-      mockSearchParams.set("tab", "playlists");
-
-      render(
-        <GroupDashboard
-          group={{ ...mockGroup, playlists: mockPlaylists }}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      expect(screen.getByTestId("playlist-1")).toBeInTheDocument();
-    });
-
-    it("defaults to droplets tab when invalid tab parameter", () => {
-      mockSearchParams.set("tab", "invalid");
-
-      render(
-        <GroupDashboard
-          group={{ ...mockGroup, droplets: [mockDroplets[0]] }}
+          group={{ ...mockGroup, droplets: mockDroplets.slice(0, 3) }}
           canEdit={true}
           authUser={mockAuthUser}
           dueDates={[]}
@@ -291,27 +231,11 @@ describe("GroupDashboard", () => {
       );
 
       expect(screen.getByTestId("droplet-1")).toBeInTheDocument();
-    });
-  });
-
-  describe("Droplets Tab", () => {
-    it("displays first page of droplets", () => {
-      render(
-        <GroupDashboard
-          group={{ ...mockGroup, droplets: mockDroplets }}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      expect(screen.getByTestId("droplet-1")).toBeInTheDocument();
-      expect(screen.getByTestId("droplet-6")).toBeInTheDocument();
-      expect(screen.queryByTestId("droplet-7")).not.toBeInTheDocument();
+      expect(screen.getByTestId("droplet-2")).toBeInTheDocument();
+      expect(screen.getByTestId("droplet-3")).toBeInTheDocument();
     });
 
-    it("shows empty state when no droplets", () => {
+    it("shows empty state when no droplets exist", () => {
       render(
         <GroupDashboard
           group={mockGroup}
@@ -330,7 +254,7 @@ describe("GroupDashboard", () => {
     it("displays due dates for droplets", () => {
       render(
         <GroupDashboard
-          group={{ ...mockGroup, droplets: mockDroplets }}
+          group={{ ...mockGroup, droplets: [mockDroplets[0]] }}
           canEdit={true}
           authUser={mockAuthUser}
           dueDates={mockDueDates}
@@ -341,10 +265,12 @@ describe("GroupDashboard", () => {
       expect(screen.getByText(/2023-12-31/)).toBeInTheDocument();
     });
 
-    it("handles droplets without due dates", () => {
+    it("handles missing droplets array", () => {
+      const groupNoDroplets = { ...mockGroup, droplets: undefined };
+
       render(
         <GroupDashboard
-          group={{ ...mockGroup, droplets: [mockDroplets[1]] }}
+          group={groupNoDroplets as any}
           canEdit={true}
           authUser={mockAuthUser}
           dueDates={[]}
@@ -352,12 +278,14 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      expect(screen.getByTestId("droplet-2")).toBeInTheDocument();
+      expect(
+        screen.getByText("No droplets have been added to this group yet."),
+      ).toBeInTheDocument();
     });
   });
 
-  describe("Pagination", () => {
-    it("shows pagination buttons when droplets exceed page size", () => {
+  describe("Droplets Pagination", () => {
+    it("shows first 6 droplets on initial page", () => {
       render(
         <GroupDashboard
           group={{ ...mockGroup, droplets: mockDroplets }}
@@ -368,8 +296,9 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      expect(screen.getByText("Previous")).toBeInTheDocument();
-      expect(screen.getByText("Next")).toBeInTheDocument();
+      expect(screen.getByTestId("droplet-1")).toBeInTheDocument();
+      expect(screen.getByTestId("droplet-6")).toBeInTheDocument();
+      expect(screen.queryByTestId("droplet-7")).not.toBeInTheDocument();
     });
 
     it("disables Previous button on first page", () => {
@@ -387,7 +316,7 @@ describe("GroupDashboard", () => {
       expect(prevButton).toBeDisabled();
     });
 
-    it("enables Next button when more pages available", () => {
+    it("enables Next button when more droplets exist", () => {
       render(
         <GroupDashboard
           group={{ ...mockGroup, droplets: mockDroplets }}
@@ -402,7 +331,9 @@ describe("GroupDashboard", () => {
       expect(nextButton).not.toBeDisabled();
     });
 
-    it("navigates to next page when Next clicked", () => {
+    it("shows next page when Next button clicked", async () => {
+      const user = userEvent.setup();
+
       render(
         <GroupDashboard
           group={{ ...mockGroup, droplets: mockDroplets }}
@@ -413,14 +344,18 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      fireEvent.click(screen.getByText("Next"));
+      await act(async () => {
+        await user.click(screen.getByText("Next"));
+      });
 
       expect(screen.getByTestId("droplet-7")).toBeInTheDocument();
       expect(screen.getByTestId("droplet-12")).toBeInTheDocument();
       expect(screen.queryByTestId("droplet-1")).not.toBeInTheDocument();
     });
 
-    it("navigates to previous page when Previous clicked", () => {
+    it("navigates back to first page when Previous clicked", async () => {
+      const user = userEvent.setup();
+
       render(
         <GroupDashboard
           group={{ ...mockGroup, droplets: mockDroplets }}
@@ -431,14 +366,21 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      fireEvent.click(screen.getByText("Next"));
-      fireEvent.click(screen.getByText("Previous"));
+      await act(async () => {
+        await user.click(screen.getByText("Next"));
+      });
+
+      await act(async () => {
+        await user.click(screen.getByText("Previous"));
+      });
 
       expect(screen.getByTestId("droplet-1")).toBeInTheDocument();
       expect(screen.queryByTestId("droplet-7")).not.toBeInTheDocument();
     });
 
-    it("disables Next button on last page", () => {
+    it("disables Next button on last page", async () => {
+      const user = userEvent.setup();
+
       render(
         <GroupDashboard
           group={{ ...mockGroup, droplets: mockDroplets }}
@@ -449,31 +391,15 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      fireEvent.click(screen.getByText("Next"));
+      await act(async () => {
+        await user.click(screen.getByText("Next"));
+      });
 
       const nextButton = screen.getByText("Next");
       expect(nextButton).toBeDisabled();
     });
 
-    it("calculates total pages correctly", () => {
-      const sevenDroplets = mockDroplets.slice(0, 7);
-
-      render(
-        <GroupDashboard
-          group={{ ...mockGroup, droplets: sevenDroplets }}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      expect(screen.getByTestId("droplet-6")).toBeInTheDocument();
-      fireEvent.click(screen.getByText("Next"));
-      expect(screen.getByTestId("droplet-7")).toBeInTheDocument();
-    });
-
-    it("handles exactly 6 droplets without pagination", () => {
+    it("handles exactly 6 droplets without Next button active", () => {
       const sixDroplets = mockDroplets.slice(0, 6);
 
       render(
@@ -491,8 +417,8 @@ describe("GroupDashboard", () => {
     });
   });
 
-  describe("Playlists Tab", () => {
-    it("displays playlists when tab is selected", () => {
+  describe("Playlists Tab - Lazy Loading", () => {
+    it("does not render playlists content initially", () => {
       render(
         <GroupDashboard
           group={{ ...mockGroup, playlists: mockPlaylists }}
@@ -503,13 +429,29 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      fireEvent.click(screen.getByText("Playlists"));
+      expect(screen.queryByTestId("playlist-1")).not.toBeInTheDocument();
+    });
+
+    it("renders playlists immediately when URL has playlists tab", () => {
+      mockSearchParams.set("tab", "playlists");
+
+      render(
+        <GroupDashboard
+          group={{ ...mockGroup, playlists: mockPlaylists }}
+          canEdit={true}
+          authUser={mockAuthUser}
+          dueDates={[]}
+          statuses={{}}
+        />,
+      );
 
       expect(screen.getByTestId("playlist-1")).toBeInTheDocument();
       expect(screen.getByTestId("playlist-2")).toBeInTheDocument();
     });
 
-    it("shows empty state when no playlists", () => {
+    it("shows empty state immediately when URL has playlists tab and no playlists", () => {
+      mockSearchParams.set("tab", "playlists");
+
       render(
         <GroupDashboard
           group={mockGroup}
@@ -520,14 +462,32 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      fireEvent.click(screen.getByText("Playlists"));
+      expect(
+        screen.getByText("No playlists have been added to this group yet."),
+      ).toBeInTheDocument();
+    });
+
+    it("handles missing playlists array when initialized with URL", () => {
+      mockSearchParams.set("tab", "playlists");
+      const groupNoPlaylists = { ...mockGroup, playlists: undefined };
+
+      render(
+        <GroupDashboard
+          group={groupNoPlaylists as any}
+          canEdit={true}
+          authUser={mockAuthUser}
+          dueDates={[]}
+          statuses={{}}
+        />,
+      );
 
       expect(
         screen.getByText("No playlists have been added to this group yet."),
       ).toBeInTheDocument();
     });
 
-    it("displays playlist due dates", () => {
+    it("displays playlist due dates when initialized with URL", () => {
+      mockSearchParams.set("tab", "playlists");
       const playlistDueDate = {
         playlist: mockPlaylists[0],
         dueDate: "2024-01-15",
@@ -545,46 +505,12 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      fireEvent.click(screen.getByText("Playlists"));
-
       expect(screen.getByText(/2024-01-15/)).toBeInTheDocument();
-    });
-
-    it("passes timezone to PlaylistCard", () => {
-      render(
-        <GroupDashboard
-          group={{ ...mockGroup, playlists: mockPlaylists }}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      fireEvent.click(screen.getByText("Playlists"));
-
-      expect(screen.getByTestId("playlist-1")).toBeInTheDocument();
-    });
-
-    it("handles playlists without due dates", () => {
-      render(
-        <GroupDashboard
-          group={{ ...mockGroup, playlists: mockPlaylists }}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      fireEvent.click(screen.getByText("Playlists"));
-
-      expect(screen.getByTestId("playlist-1")).toBeInTheDocument();
     });
   });
 
-  describe("Progress Tab", () => {
-    it("displays progress grid when content and members exist", () => {
+  describe("Progress Tab - Lazy Loading", () => {
+    it("does not render progress content initially", () => {
       render(
         <GroupDashboard
           group={{
@@ -599,12 +525,12 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      fireEvent.click(screen.getByText("Progress"));
-
-      expect(screen.getByTestId("progress-grid")).toBeInTheDocument();
+      expect(screen.queryByTestId("progress-grid")).not.toBeInTheDocument();
     });
 
-    it("shows progress when only droplets exist", () => {
+    it("renders progress immediately when URL has progress tab", () => {
+      mockSearchParams.set("tab", "progress");
+
       render(
         <GroupDashboard
           group={{
@@ -619,12 +545,52 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      fireEvent.click(screen.getByText("Progress"));
-
       expect(screen.getByTestId("progress-grid")).toBeInTheDocument();
     });
 
-    it("shows progress when only playlists exist", () => {
+    it("shows empty state when no droplets or playlists and initialized with URL", () => {
+      mockSearchParams.set("tab", "progress");
+
+      render(
+        <GroupDashboard
+          group={{ ...mockGroup, members: mockGroup.members }}
+          canEdit={true}
+          authUser={mockAuthUser}
+          dueDates={[]}
+          statuses={{}}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          "No droplets or members have been added to this group yet.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("shows empty state when no members exist and initialized with URL", () => {
+      mockSearchParams.set("tab", "progress");
+
+      render(
+        <GroupDashboard
+          group={{ ...mockGroup, droplets: [mockDroplets[0]], members: [] }}
+          canEdit={true}
+          authUser={mockAuthUser}
+          dueDates={[]}
+          statuses={{}}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          "No droplets or members have been added to this group yet.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("renders progress with playlists only when initialized with URL", () => {
+      mockSearchParams.set("tab", "progress");
+
       render(
         <GroupDashboard
           group={{
@@ -639,52 +605,11 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      fireEvent.click(screen.getByText("Progress"));
-
       expect(screen.getByTestId("progress-grid")).toBeInTheDocument();
     });
 
-    it("shows empty state when no droplets or playlists", () => {
-      render(
-        <GroupDashboard
-          group={{ ...mockGroup, members: mockGroup.members }}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      fireEvent.click(screen.getByText("Progress"));
-
-      expect(
-        screen.getByText(
-          "No droplets or members have been added to this group yet.",
-        ),
-      ).toBeInTheDocument();
-    });
-
-    it("shows empty state when no members", () => {
-      render(
-        <GroupDashboard
-          group={{ ...mockGroup, droplets: [mockDroplets[0]], members: [] }}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      fireEvent.click(screen.getByText("Progress"));
-
-      expect(
-        screen.getByText(
-          "No droplets or members have been added to this group yet.",
-        ),
-      ).toBeInTheDocument();
-    });
-
-    it("passes statuses to GroupProgressGrid", () => {
+    it("passes statuses to progress grid when initialized with URL", () => {
+      mockSearchParams.set("tab", "progress");
       const mockStatuses = {
         "1": { completionPercentage: 75, completionDate: new Date() },
       };
@@ -703,14 +628,44 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      fireEvent.click(screen.getByText("Progress"));
-
       expect(screen.getByTestId("progress-grid")).toBeInTheDocument();
     });
   });
 
-  describe("Empty States", () => {
-    it("shows droplets empty state", () => {
+  describe("URL Tab Parameter Handling", () => {
+    it("defaults to droplets tab when no URL parameter", () => {
+      render(
+        <GroupDashboard
+          group={{ ...mockGroup, droplets: [mockDroplets[0]] }}
+          canEdit={true}
+          authUser={mockAuthUser}
+          dueDates={[]}
+          statuses={{}}
+        />,
+      );
+
+      expect(screen.getByTestId("droplet-1")).toBeInTheDocument();
+    });
+
+    it("defaults to droplets tab when invalid URL parameter", () => {
+      mockSearchParams.set("tab", "invalid");
+
+      render(
+        <GroupDashboard
+          group={{ ...mockGroup, droplets: [mockDroplets[0]] }}
+          canEdit={true}
+          authUser={mockAuthUser}
+          dueDates={[]}
+          statuses={{}}
+        />,
+      );
+
+      expect(screen.getByTestId("droplet-1")).toBeInTheDocument();
+    });
+
+    it("updates URL when tab is clicked", async () => {
+      const user = userEvent.setup();
+
       render(
         <GroupDashboard
           group={mockGroup}
@@ -721,12 +676,19 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      expect(
-        screen.getByText("No droplets have been added to this group yet."),
-      ).toBeInTheDocument();
+      await act(async () => {
+        await user.click(screen.getByText("Playlists"));
+      });
+
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringContaining("tab=playlists"),
+      );
     });
 
-    it("shows playlists empty state", () => {
+    it("preserves existing URL parameters when changing tabs", async () => {
+      const user = userEvent.setup();
+      mockSearchParams.set("filter", "active");
+
       render(
         <GroupDashboard
           group={mockGroup}
@@ -737,84 +699,20 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      fireEvent.click(screen.getByText("Playlists"));
+      await act(async () => {
+        await user.click(screen.getByText("Playlists"));
+      });
 
-      expect(
-        screen.getByText("No playlists have been added to this group yet."),
-      ).toBeInTheDocument();
-    });
-
-    it("applies dark mode classes to empty states", () => {
-      const { container } = render(
-        <GroupDashboard
-          group={mockGroup}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringContaining("filter=active"),
       );
-
-      const emptyState = container.querySelector(".dark\\:border-slate-500");
-      expect(emptyState).toBeInTheDocument();
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringContaining("tab=playlists"),
+      );
     });
   });
 
   describe("Edge Cases", () => {
-    it("handles group without droplets array", () => {
-      const groupNoDroplets = { ...mockGroup, droplets: undefined };
-
-      render(
-        <GroupDashboard
-          group={groupNoDroplets as any}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      expect(
-        screen.getByText("No droplets have been added to this group yet."),
-      ).toBeInTheDocument();
-    });
-
-    it("handles group without playlists array", () => {
-      const groupNoPlaylists = { ...mockGroup, playlists: undefined };
-
-      render(
-        <GroupDashboard
-          group={groupNoPlaylists as any}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      fireEvent.click(screen.getByText("Playlists"));
-
-      expect(
-        screen.getByText("No playlists have been added to this group yet."),
-      ).toBeInTheDocument();
-    });
-
-    it("handles canEdit being undefined", () => {
-      const regularUser = { ...mockAuthUser, id: 999 };
-
-      render(
-        <GroupDashboard
-          group={mockGroup}
-          canEdit={undefined}
-          authUser={regularUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      expect(screen.queryByText("Progress")).not.toBeInTheDocument();
-    });
-
     it("handles group without admins array", () => {
       const groupNoAdmins = { ...mockGroup, admins: undefined };
 
@@ -845,10 +743,10 @@ describe("GroupDashboard", () => {
       expect(screen.getByTestId("droplet-1")).toBeInTheDocument();
     });
 
-    it("handles single droplet", () => {
-      render(
+    it("applies dark mode classes to empty states", () => {
+      const { container } = render(
         <GroupDashboard
-          group={{ ...mockGroup, droplets: [mockDroplets[0]] }}
+          group={mockGroup}
           canEdit={true}
           authUser={mockAuthUser}
           dueDates={[]}
@@ -856,15 +754,12 @@ describe("GroupDashboard", () => {
         />,
       );
 
-      expect(screen.getByTestId("droplet-1")).toBeInTheDocument();
-      const nextButton = screen.getByText("Next");
-      expect(nextButton).toBeDisabled();
+      const emptyState = container.querySelector(".dark\\:border-slate-500");
+      expect(emptyState).toBeInTheDocument();
     });
-  });
 
-  describe("Styling", () => {
-    it("applies tab styling classes", () => {
-      const { container } = render(
+    it("applies correct styling to tabs", () => {
+      render(
         <GroupDashboard
           group={mockGroup}
           canEdit={true}
@@ -878,21 +773,6 @@ describe("GroupDashboard", () => {
       expect(tab).toHaveClass("px-4");
       expect(tab).toHaveClass("py-2");
       expect(tab).toHaveClass("cursor-pointer");
-    });
-
-    it("applies grid layout to droplets", () => {
-      const { container } = render(
-        <GroupDashboard
-          group={{ ...mockGroup, droplets: [mockDroplets[0]] }}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
-
-      const grid = container.querySelector(".grid-cols-1");
-      expect(grid).toBeInTheDocument();
     });
 
     it("applies dark mode classes to pagination buttons", () => {
@@ -910,10 +790,8 @@ describe("GroupDashboard", () => {
       expect(nextButton).toHaveClass("dark:bg-slate-300");
       expect(nextButton).toHaveClass("dark:text-black");
     });
-  });
 
-  describe("Accessibility", () => {
-    it("tabs are keyboard accessible", () => {
+    it("renders all tabs with correct ARIA attributes", () => {
       render(
         <GroupDashboard
           group={mockGroup}
@@ -923,21 +801,14 @@ describe("GroupDashboard", () => {
           statuses={{}}
         />,
       );
-    });
 
-    it("pagination buttons are properly labeled", () => {
-      render(
-        <GroupDashboard
-          group={{ ...mockGroup, droplets: mockDroplets }}
-          canEdit={true}
-          authUser={mockAuthUser}
-          dueDates={[]}
-          statuses={{}}
-        />,
-      );
+      const dropletsTab = screen.getByText("Droplets");
+      const playlistsTab = screen.getByText("Playlists");
+      const progressTab = screen.getByText("Progress");
 
-      expect(screen.getByText("Previous")).toBeInTheDocument();
-      expect(screen.getByText("Next")).toBeInTheDocument();
+      expect(dropletsTab).toBeInTheDocument();
+      expect(playlistsTab).toBeInTheDocument();
+      expect(progressTab).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fixed group tabs and kept tab retention
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tab-based dashboard navigation with URL-driven tab selection for shareable links.
  * Visited-tab tracking so panels render only after first visit.

* **Improvements**
  * Lazy-loading of tab content (Droplets, Playlists, Progress) for better performance.
  * Droplets shown in a paginated grid with Previous/Next controls.
  * Progress tab visibility gated by user permissions.
  * Minor layout tweak: removed an extra visual divider.

* **Tests**
  * Test suite updated to cover URL tab sync, permission-based visibility, lazy-loading, pagination, and empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->