### PR TITLE
ODY-177 fix back button navigation in draft editor

### DIFF
--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -198,7 +198,7 @@ export function Sidebar({
                 onClick={() =>
                   droplet.status !== "draft"
                     ? setIsOpen(true)
-                    : router.push(`/drafts`)
+                    : router.push(`/my-content`)
                 }
                 className={cn(
                   "flex items-center justify-start gap-2 bg-slate-50 text-base text-black hover:bg-slate-100 dark:bg-slate-800 dark:text-white dark:hover:bg-slate-700",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed url for back button in droplet editor from /drafts to /my-content. This is the correct landing page for that button, resolving the previous issue.

## Screenshots (if appropriate):
<img width="464" height="736" alt="image" src="https://github.com/user-attachments/assets/596fec72-4ea2-4045-9224-b45e0032b3d9" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated home button navigation to direct to the correct destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->