### PR TITLE
fixed feed announcement filtering

### DIFF
--- a/frontend/components/feed/feed-block.tsx
+++ b/frontend/components/feed/feed-block.tsx
@@ -305,7 +305,7 @@ export function FeedBlock({
               {parsedContent.userName}
             </span>
             <span>
-              {"\u00A0"}has given you kudos for{"\u00A0"}
+              {"\u00A0"}has given you kudos for completing{"\u00A0"}
             </span>
             {announcement.droplet ? (
               <span

--- a/frontend/lib/requests/feed.ts
+++ b/frontend/lib/requests/feed.ts
@@ -4,7 +4,6 @@ import { Announcement, AuthorizedUser, Droplet } from "@/types";
 import qs from "qs";
 import { flattenAttributes } from "../utils";
 import { revalidatePath } from "next/cache";
-import { AnnouncementType } from "@/types";
 
 const NEXT_PUBLIC_STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -56,6 +55,7 @@ export async function fetchAnnouncements(
             },
           },
           {
+            type: "droplet",
             droplet: {
               enrollments: {
                 authorizedUser: {
@@ -157,17 +157,7 @@ export async function fetchAnnouncements(
       },
     );
     const data = await response.json();
-    const announcements = flattenAttributes(data.data);
-
-    return announcements.filter((a: Announcement) => {
-      if (
-        (a.type === "friend" || a.type === "kudos") &&
-        a.authorized_user?.id === user.id
-      ) {
-        return false;
-      }
-      return true;
-    });
+    return flattenAttributes(data.data);
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to fetch announcement data.");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Updated the logic for fetching feed announcements so that the only friend announcements that are displayed are ones where the user corresponding to the announcement is friends with the current user.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x ] My code follows the code style of this project.
- [ x] I have moved the ticket to "In Review"
- [x ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for droplet-type announcements in your feed.

* **Bug Fixes**
  * Updated announcement filtering to properly display announcement types that were previously excluded.
  * Improved wording clarity in kudos notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->