### PR TITLE
added personal website spot

### DIFF
--- a/backend/src/api/authorized-user/content-types/authorized-user/schema.json
+++ b/backend/src/api/authorized-user/content-types/authorized-user/schema.json
@@ -220,6 +220,9 @@
       "relation": "manyToMany",
       "target": "api::droplet.droplet",
       "mappedBy": "usersFavorited"
+    },
+    "website": {
+      "type": "string"
     }
   }
 }

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -756,6 +756,7 @@ export interface ApiAuthorizedUserAuthorizedUser extends Schema.CollectionType {
       'manyToMany',
       'api::authorized-user.authorized-user'
     >;
+    website: Attribute.String;
   };
 }
 

--- a/frontend/app/(editing)/draft/d/[slug]/page.tsx
+++ b/frontend/app/(editing)/draft/d/[slug]/page.tsx
@@ -1,8 +1,4 @@
-import {
-  getDropletBySlug,
-  updateDroplet,
-  updateDropletFunFact,
-} from "@/lib/requests/droplet";
+import { getDropletBySlug, updateDropletFunFact } from "@/lib/requests/droplet";
 import type { Droplet } from "@/types";
 import { DropletName } from "@/components/draft/metadata/droplet-name";
 import { LearningObjectives } from "@/components/draft/metadata/learning-objectives/learning-objectives";
@@ -10,11 +6,8 @@ import { getDroplets } from "@/lib/requests/droplet";
 import { getTags } from "@/lib/requests/tag";
 import { NextSteps } from "@/components/draft/metadata/next-steps/next-steps";
 import { Overview } from "@/components/draft/metadata/overview";
-import { Filter } from "@/components/draft/metadata/filter";
 import { Description } from "@/components/draft/metadata/description";
-import { isContentEditor, uppercaseFirstChar } from "@/lib/utils";
-import { Badge } from "@/components/ui/badge";
-import { RegenerateSlugButton } from "@/components/draft/metadata/regenerate-slug";
+import { isContentEditor } from "@/lib/utils";
 import { Authors } from "@/components/draft/metadata/authors";
 import { GradientBackground } from "@/components/gradient-bg";
 import { getCurrentUser } from "@/lib/auth/session";

--- a/frontend/app/(general)/prof/[username]/profile-content.tsx
+++ b/frontend/app/(general)/prof/[username]/profile-content.tsx
@@ -17,6 +17,7 @@ import {
   UserPlus,
   Clock,
   X,
+  LinkIcon,
 } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
@@ -260,6 +261,23 @@ export function ProfileContent({
                   className="dark:!text-white"
                 >
                   <GitHubIcon fontSize="large" />
+                </IconButton>
+              )}
+              {userData.website && (
+                <IconButton
+                  component="a"
+                  href={
+                    userData.website.startsWith("http")
+                      ? userData.website
+                      : `https://${userData.website}`
+                  }
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Website"
+                  sx={{ color: "#333", fontSize: 40 }}
+                  className="dark:!text-white"
+                >
+                  <LinkIcon fontSize="large" />
                 </IconButton>
               )}
             </div>

--- a/frontend/app/(general)/settings/social-forms.tsx
+++ b/frontend/app/(general)/settings/social-forms.tsx
@@ -27,6 +27,9 @@ export function SocialForms({
     authorizedUser?.linkedin || "",
   );
   const [githubValue, setGithubValue] = useState(authorizedUser?.github || "");
+  const [websiteValue, setWebsiteValue] = useState(
+    authorizedUser?.website || "",
+  );
   const [profileImage, setProfileImage] = useState<string | null>(
     authorizedUser?.profilePhoto || "",
   );
@@ -49,6 +52,10 @@ export function SocialForms({
 
   function isValidLinkedinUrl(url: string) {
     return /^https:\/\/(www\.)?linkedin\.com\/in\/[A-Za-z0-9_-]+\/?$/.test(url);
+  }
+
+  function isValidWebsiteUrl(url: string) {
+    return /^https:\/\/([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/.*)?$/.test(url);
   }
 
   const compressImage = async (imageFile: File) => {
@@ -335,6 +342,49 @@ export function SocialForms({
           className="hidden min-w-[120px] sm:block dark:bg-slate-300"
         >
           Save GitHub
+        </Button>
+        <Button
+          type="submit"
+          className="w-[13%] p-0 sm:hidden dark:bg-slate-300"
+        >
+          <Check className="h-5 w-5" />
+        </Button>
+      </form>
+      <form
+        action={async (formData: FormData) => {
+          const website = formData.get("website") as string;
+          if (!isValidWebsiteUrl(website) && website !== "") {
+            toast.error("Please enter a valid website URL");
+            return;
+          }
+          if (authorizedUser?.id) {
+            const result = await updateUserInfo(authorizedUser.id, {
+              website: website,
+            });
+            if (result.success) {
+              setWebsiteValue(website);
+              toast.success("Website URL updated successfully");
+            } else {
+              toast.error("Not a valid Website URL");
+            }
+          }
+        }}
+        className="flex flex-row items-center gap-4 px-6 py-4"
+      >
+        {" "}
+        <div className="mr-5 w-[12%] sm:mr-0">Website:</div>
+        <Input
+          name="website"
+          value={websiteValue}
+          onChange={(e) => setWebsiteValue(e.target.value)}
+          placeholder="Enter your personal website url"
+          className="w-[50%]"
+        />
+        <Button
+          type="submit"
+          className="hidden min-w-[120px] sm:block dark:bg-slate-300"
+        >
+          Save Website
         </Button>
         <Button
           type="submit"

--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -1,32 +1,19 @@
 "use client";
 
 import UnauthorizedRoute from "@/app/(general)/unauthorized/page";
-import { cn, getInitials, getPath, condenseRoleTitles } from "@/lib/utils";
+import { cn, getPath } from "@/lib/utils";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import { AuthorizedUser, Droplet, Lesson, User } from "@/types";
 import {
-  ChevronDownIcon,
-  PersonStanding,
-  LogOutIcon,
-  ShipIcon,
   SettingsIcon,
   ArrowLeftIcon,
   PanelRightClose,
   PanelRightOpen,
   Home,
 } from "lucide-react";
-import { signOut } from "next-auth/react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import React, { useLayoutEffect, useState, useEffect } from "react";
-import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from "../ui/dropdown-menu";
 import { Separator } from "../ui/separator";
 import { AddLesson } from "@/components/draft/add-lesson";
 import {

--- a/frontend/components/footer/content-creator-block.tsx
+++ b/frontend/components/footer/content-creator-block.tsx
@@ -2,7 +2,7 @@
 
 import { AuthorizedUser } from "@/types";
 import Link from "next/link";
-import { Github, Linkedin } from "lucide-react";
+import { Github, LinkIcon, Linkedin } from "lucide-react";
 import { useState } from "react";
 
 export function ContentCreatorBlock({
@@ -55,6 +55,13 @@ export function ContentCreatorBlock({
                 <Link href={contentCreator.github} legacyBehavior>
                   <a target="_blank" rel="noopener noreferrer">
                     <Github className="dark:text-slate-300" />
+                  </a>
+                </Link>
+              )}
+              {contentCreator.website && (
+                <Link href={contentCreator.website} legacyBehavior>
+                  <a target="_blank" rel="noopener noreferrer">
+                    <LinkIcon className="dark:text-slate-300" />
                   </a>
                 </Link>
               )}

--- a/frontend/components/friends/profile-block.tsx
+++ b/frontend/components/friends/profile-block.tsx
@@ -12,7 +12,13 @@ import {
   DialogTitle,
 } from "../ui/dialog";
 import { Button } from "../ui/button";
-import { Github, Linkedin, User2Icon, ExternalLink } from "lucide-react";
+import {
+  Github,
+  Linkedin,
+  User2Icon,
+  ExternalLink,
+  LinkIcon,
+} from "lucide-react";
 import Link from "next/link";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
 import { getInitials } from "@/lib/utils";
@@ -81,6 +87,13 @@ export function ProfileBlock({
               <Link href={otherUser.github} legacyBehavior role="link">
                 <a target="_blank" rel="noopener noreferrer">
                   <Github />
+                </a>
+              </Link>
+            )}
+            {otherUser.website && (
+              <Link href={otherUser.website} legacyBehavior role="link">
+                <a target="_blank" rel="noopener noreferrer">
+                  <LinkIcon />
                 </a>
               </Link>
             )}

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -26,16 +26,16 @@ export async function getAuthorizedUserByEmail<
     filters,
     populate = {
       received_requests: {
-        fields: ["id", "email", "firstName", "lastName", "bio", "profilePhoto"],
+        fields: ["*"],
       },
       sent_requests: {
-        fields: ["id", "email", "firstName", "lastName", "bio", "profilePhoto"],
+        fields: ["*"],
       },
       blocked: {
-        fields: ["id", "email", "firstName", "lastName", "bio", "profilePhoto"],
+        fields: ["*"],
       },
       was_blocked: {
-        fields: ["id", "email", "firstName", "lastName", "bio", "profilePhoto"],
+        fields: ["*"],
       },
       droplets: {
         fields: ["*"],
@@ -78,6 +78,7 @@ export async function getAuthorizedUserByEmail<
               "github",
               "linkedin",
               "profilePhoto",
+              "website",
             ],
             populate: {
               blocked: {
@@ -108,6 +109,7 @@ export async function getAuthorizedUserByEmail<
       "timeZone",
       "linkedin",
       "github",
+      "website",
     ],
   }: StrapiRequestParams = {},
 ): Promise<T> {
@@ -145,6 +147,7 @@ export async function fetchAuthorizedUsers(): Promise<AuthorizedUser[]> {
         "profilePhoto",
         "linkedin",
         "github",
+        "website",
       ],
       populate: {
         roles: { fields: ["title"] },
@@ -243,6 +246,7 @@ export async function fetchContentCreators(): Promise<AuthorizedUser[]> {
         "profilePhoto",
         "linkedin",
         "github",
+        "website",
       ],
       populate: {
         roles: {
@@ -305,6 +309,7 @@ export async function fetchWebsiteCreators(): Promise<AuthorizedUser[]> {
         "profilePhoto",
         "linkedin",
         "github",
+        "website",
       ],
       populate: {
         roles: {
@@ -523,6 +528,7 @@ export async function updateUserInfo(
     linkedin?: string | null;
     github?: string | null;
     photo?: string | null;
+    website?: string | null;
   },
 ) {
   try {
@@ -538,6 +544,7 @@ export async function updateUserInfo(
       linkedin,
       github,
       photo,
+      website,
     } = updates;
     const roleIds = roles
       ? await Promise.all(
@@ -556,6 +563,7 @@ export async function updateUserInfo(
     if (firstTime !== undefined) data.firstTime = updates.firstTime;
     if (linkedin !== undefined) data.linkedin = linkedin;
     if (github !== undefined) data.github = github;
+    if (website !== undefined) data.website = website;
     if (photo !== undefined) data.profilePhoto = photo;
     if (roles && roles.length > 0) {
       data.roles = {
@@ -563,7 +571,7 @@ export async function updateUserInfo(
       };
     }
 
-    const response = await fetch(
+    await fetch(
       `${NEXT_PUBLIC_STRAPI_API_URL}/api/authorized-users/${userId}`,
       {
         method: "PUT",

--- a/frontend/lib/requests/feed.ts
+++ b/frontend/lib/requests/feed.ts
@@ -93,6 +93,7 @@ export async function fetchAnnouncements(
             "linkedin",
             "profilePhoto",
             "isPublic",
+            "website",
           ],
           populate: {
             blocked: {
@@ -113,6 +114,7 @@ export async function fetchAnnouncements(
             "github",
             "linkedin",
             "profilePhoto",
+            "website",
           ],
           populate: {
             blocked: {
@@ -433,6 +435,7 @@ export async function fetchAnnouncementById(id: number) {
             "github",
             "linkedin",
             "profilePhoto",
+            "website",
           ],
           populate: {
             blocked: {

--- a/frontend/lib/requests/friends.ts
+++ b/frontend/lib/requests/friends.ts
@@ -30,6 +30,7 @@ export async function fetchFriends(
             "github",
             "linkedin",
             "profilePhoto",
+            "website",
           ],
           populate: {
             blocked: {
@@ -490,6 +491,7 @@ export async function fetchFriendshipsById(
             "github",
             "linkedin",
             "profilePhoto",
+            "website",
           ],
           populate: {
             blocked: {

--- a/frontend/types/index.d.ts
+++ b/frontend/types/index.d.ts
@@ -62,6 +62,7 @@ export type AuthorizedUser = {
   playlists?: Playlist[];
   linkedin: string;
   github: string;
+  website: string;
   firstTime: boolean;
   firstName: string;
   lastName: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added a box for users to enter their personal website information, and this information is displayed through a link icon in all of the places where the existing LinkedIn and GitHub icons are.
<img width="868" height="225" alt="Screenshot 2025-11-07 at 3 51 08 PM" src="https://github.com/user-attachments/assets/7ea3eb75-0000-47c0-9566-a3765844952c" />

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x ] My code follows the code style of this project.
- [ x] I have moved the ticket to "In Review"
- [ x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now add and manage a website URL in their profile settings with built-in URL validation
  * Website links are displayed on user profiles, content creator cards, and friend profile blocks with a dedicated link icon
  * Website URLs open in a new browser tab when clicked for safe external navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->