### PR TITLE
ODY-179 add BlockNote quiz blocks

### DIFF
--- a/frontend/app/test-blocknote/page.tsx
+++ b/frontend/app/test-blocknote/page.tsx
@@ -29,7 +29,7 @@ export default function TestBlockNotePage() {
       <div className="mx-auto max-w-4xl">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
-            BlockNote Callout Test
+            BlockNote Custom Block Test
           </h1>
           <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
             Type "/" to see callout options: warning, question, important,

--- a/frontend/app/test-blocknote/page.tsx
+++ b/frontend/app/test-blocknote/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
+import { useTheme } from "next-themes";
 
 // Dynamically import BlockNote components with no SSR
 const BlockNoteEditor = dynamic(
@@ -11,10 +12,27 @@ const BlockNoteEditor = dynamic(
 
 export default function TestBlockNotePage() {
   const [isMounted, setIsMounted] = useState(false);
+  const { theme, resolvedTheme } = useTheme();
 
   useEffect(() => {
     setIsMounted(true);
   }, []);
+
+  // Debug logging
+  useEffect(() => {
+    if (isMounted) {
+      console.log("Next.js theme:", theme);
+      console.log("Next.js resolvedTheme:", resolvedTheme);
+      const container = document.querySelector(".bn-container");
+      if (container) {
+        console.log(
+          "BlockNote data-color-scheme:",
+          container.getAttribute("data-color-scheme"),
+        );
+        console.log("BlockNote classes:", container.className);
+      }
+    }
+  }, [isMounted, theme, resolvedTheme]);
 
   if (!isMounted) {
     return (

--- a/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
@@ -1,6 +1,7 @@
 import { createReactBlockSpec } from "@blocknote/react";
 import { defaultProps } from "@blocknote/core";
 import { Trash2Icon, PlusIcon, XIcon } from "lucide-react";
+import React from "react";
 
 interface AnswerOption {
   id: string;
@@ -29,6 +30,40 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
     render: (props) => {
       const { question } = props.block.props;
       const options = (props.block.props.options || []) as AnswerOption[];
+      const blockRef = React.useRef<HTMLDivElement>(null);
+
+      React.useEffect(() => {
+        if (blockRef.current) {
+          const blockContent = blockRef.current.closest(
+            ".bn-block-content",
+          ) as HTMLElement;
+          if (blockContent) {
+            const removeStyles = () => {
+              blockContent.removeAttribute("style");
+            };
+
+            removeStyles();
+
+            const observer = new MutationObserver(removeStyles);
+            observer.observe(blockContent, {
+              attributes: true,
+              attributeFilter: ["style"],
+            });
+
+            const events = ["click", "mousedown", "focus", "focusin"];
+            events.forEach((event) => {
+              blockContent.addEventListener(event, removeStyles, true);
+            });
+
+            return () => {
+              observer.disconnect();
+              events.forEach((event) => {
+                blockContent.removeEventListener(event, removeStyles, true);
+              });
+            };
+          }
+        }
+      }, []);
 
       const handleQuestionChange = (
         e: React.ChangeEvent<HTMLTextAreaElement>,
@@ -83,23 +118,32 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
       };
 
       return (
-        <div className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800">
+        <div
+          ref={blockRef}
+          onMouseDown={(e) => {
+            if (blockRef.current) {
+              const blockContent = blockRef.current.closest(
+                ".bn-block-content",
+              ) as HTMLElement;
+              if (blockContent) {
+                blockContent.removeAttribute("style");
+              }
+            }
+          }}
+          className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800"
+        >
           {/* Header */}
-          <div
-            className="mb-4 flex w-full flex-row items-center justify-between p-4"
-            contentEditable="false"
-          >
+          <div className="mb-4 flex w-full flex-row items-center justify-between p-4">
             <h2 className="text-lg">Multiple Choice Quiz</h2>
-            <div contentEditable="false">
-              <Trash2Icon
-                className="cursor-pointer text-red-600 hover:text-red-700"
-                onClick={handleDelete}
-                data-testid="delete-block"
-              />
-            </div>
+            <Trash2Icon
+              className="cursor-pointer text-red-600 hover:text-red-700"
+              onClick={handleDelete}
+              onMouseDown={(e) => e.preventDefault()}
+              data-testid="delete-block"
+            />
           </div>
 
-          <div className="space-y-6 px-4" contentEditable="false">
+          <div className="space-y-6 px-4">
             {/* Question */}
             <div>
               <label className="mb-2 block text-left text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -122,14 +166,13 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
                 {options.map((option: AnswerOption, index: number) => (
                   <div key={option.id} className="flex items-start gap-2">
                     {/* Checkbox for correct answer */}
-                    <div contentEditable="false">
-                      <input
-                        type="checkbox"
-                        checked={option.isCorrect}
-                        onChange={() => handleOptionCorrectChange(option.id)}
-                        className="mt-4 h-5 w-5 cursor-pointer"
-                      />
-                    </div>
+                    <input
+                      type="checkbox"
+                      checked={option.isCorrect}
+                      onChange={() => handleOptionCorrectChange(option.id)}
+                      onMouseDown={(e) => e.stopPropagation()}
+                      className="mt-4 h-5 w-5 cursor-pointer"
+                    />
 
                     {/* Option text */}
                     <textarea
@@ -143,14 +186,13 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
 
                     {/* Delete option button */}
                     {options.length > 2 && (
-                      <div contentEditable="false">
-                        <button
-                          onClick={() => handleRemoveOption(option.id)}
-                          className="mt-3 rounded p-2 text-red-600 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/20"
-                        >
-                          <XIcon size={20} />
-                        </button>
-                      </div>
+                      <button
+                        onClick={() => handleRemoveOption(option.id)}
+                        onMouseDown={(e) => e.stopPropagation()}
+                        className="mt-3 rounded p-2 text-red-600 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/20"
+                      >
+                        <XIcon size={20} />
+                      </button>
                     )}
                   </div>
                 ))}
@@ -158,15 +200,14 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
 
               {/* Add Option Button */}
               {options.length < 6 && (
-                <div contentEditable="false">
-                  <button
-                    onClick={handleAddOption}
-                    className="mt-3 flex items-center gap-2 rounded-md border border-gray-300 px-4 py-2 text-sm transition-colors hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-700"
-                  >
-                    <PlusIcon size={16} />
-                    Add Option
-                  </button>
-                </div>
+                <button
+                  onClick={handleAddOption}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  className="mt-3 flex items-center gap-2 rounded-md border border-gray-300 px-4 py-2 text-sm transition-colors hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-700"
+                >
+                  <PlusIcon size={16} />
+                  Add Option
+                </button>
               )}
             </div>
           </div>

--- a/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
@@ -33,36 +33,159 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
       const blockRef = React.useRef<HTMLDivElement>(null);
 
       React.useEffect(() => {
-        if (blockRef.current) {
-          const blockContent = blockRef.current.closest(
-            ".bn-block-content",
-          ) as HTMLElement;
-          if (blockContent) {
-            const removeStyles = () => {
-              blockContent.removeAttribute("style");
-            };
+        if (!blockRef.current) return;
 
-            removeStyles();
+        const updateTextColors = () => {
+          // Check current theme
+          const container = blockRef.current?.closest(".bn-container");
+          const isLightMode =
+            container && container.classList.contains("light");
+          const isDarkMode = container && container.classList.contains("dark");
 
-            const observer = new MutationObserver(removeStyles);
-            observer.observe(blockContent, {
-              attributes: true,
-              attributeFilter: ["style"],
+          if (!container) return;
+
+          // Find all text elements inside the quiz block
+          const textareas = blockRef.current?.querySelectorAll("textarea");
+          const inputs = blockRef.current?.querySelectorAll("input");
+          const labels = blockRef.current?.querySelectorAll("label");
+          const headings = blockRef.current?.querySelectorAll("h2, h3, h4");
+          const buttons = blockRef.current?.querySelectorAll("button");
+          const allElements = blockRef.current?.querySelectorAll("*");
+
+          // Function to clear color styles
+          const clearColorStyles = (element: Element) => {
+            const htmlEl = element as HTMLElement;
+            htmlEl.style.removeProperty("color");
+            htmlEl.style.removeProperty("-webkit-text-fill-color");
+            if (htmlEl.tagName === "TEXTAREA" || htmlEl.tagName === "INPUT") {
+              htmlEl.style.removeProperty("caret-color");
+            }
+          };
+
+          // Function to set dark color (for light mode only)
+          const setDarkColor = (element: Element) => {
+            const htmlEl = element as HTMLElement;
+            // Skip if element has no text and no children with text
+            if (htmlEl.children.length > 0 && !htmlEl.textContent?.trim()) {
+              return;
+            }
+            const darkColor = "rgb(17, 24, 39)";
+            htmlEl.style.setProperty("color", darkColor, "important");
+            htmlEl.style.setProperty(
+              "-webkit-text-fill-color",
+              darkColor,
+              "important",
+            );
+            if (htmlEl.tagName === "TEXTAREA" || htmlEl.tagName === "INPUT") {
+              htmlEl.style.setProperty("caret-color", darkColor, "important");
+            }
+          };
+
+          // In dark mode: clear all our color overrides to let BlockNote handle it
+          if (isDarkMode) {
+            textareas?.forEach(clearColorStyles);
+            inputs?.forEach(clearColorStyles);
+            labels?.forEach(clearColorStyles);
+            headings?.forEach(clearColorStyles);
+            buttons?.forEach(clearColorStyles);
+            allElements?.forEach((el) => {
+              const htmlEl = el as HTMLElement;
+              if (
+                htmlEl.textContent?.trim() ||
+                htmlEl.tagName === "TEXTAREA" ||
+                htmlEl.tagName === "INPUT" ||
+                htmlEl.tagName === "LABEL" ||
+                htmlEl.tagName === "BUTTON" ||
+                htmlEl.tagName === "H2" ||
+                htmlEl.tagName === "H3" ||
+                htmlEl.tagName === "H4"
+              ) {
+                clearColorStyles(htmlEl);
+              }
             });
-
-            const events = ["click", "mousedown", "focus", "focusin"];
-            events.forEach((event) => {
-              blockContent.addEventListener(event, removeStyles, true);
-            });
-
-            return () => {
-              observer.disconnect();
-              events.forEach((event) => {
-                blockContent.removeEventListener(event, removeStyles, true);
-              });
-            };
+            return;
           }
+
+          // In light mode: apply dark colors
+          if (isLightMode) {
+            textareas?.forEach(setDarkColor);
+            inputs?.forEach(setDarkColor);
+            labels?.forEach(setDarkColor);
+            headings?.forEach(setDarkColor);
+            buttons?.forEach(setDarkColor);
+            allElements?.forEach((el) => {
+              const htmlEl = el as HTMLElement;
+              if (
+                htmlEl.textContent?.trim() ||
+                htmlEl.tagName === "TEXTAREA" ||
+                htmlEl.tagName === "INPUT" ||
+                htmlEl.tagName === "LABEL" ||
+                htmlEl.tagName === "BUTTON" ||
+                htmlEl.tagName === "H2" ||
+                htmlEl.tagName === "H3" ||
+                htmlEl.tagName === "H4"
+              ) {
+                setDarkColor(htmlEl);
+              }
+            });
+          }
+        };
+
+        // Run immediately
+        updateTextColors();
+
+        // Watch for theme changes on the container
+        const container = blockRef.current?.closest(".bn-container");
+        const containerObserver = container
+          ? new MutationObserver(() => {
+              // Theme changed, update colors
+              setTimeout(updateTextColors, 0);
+            })
+          : null;
+
+        if (container && containerObserver) {
+          containerObserver.observe(container, {
+            attributes: true,
+            attributeFilter: ["class"],
+          });
         }
+
+        // Set up observer to run on any changes
+        const observer = new MutationObserver(() => {
+          // Small delay to let BlockNote apply its styles first
+          setTimeout(updateTextColors, 0);
+        });
+
+        if (blockRef.current) {
+          observer.observe(blockRef.current, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ["style", "data-selected"],
+          });
+        }
+
+        // Also run on events
+        const events = ["click", "mousedown", "focus", "focusin", "mouseup"];
+        events.forEach((event) => {
+          blockRef.current?.addEventListener(event, updateTextColors, true);
+        });
+
+        // Run on selection changes (check less frequently)
+        const checkSelection = setInterval(updateTextColors, 200);
+
+        return () => {
+          observer.disconnect();
+          containerObserver?.disconnect();
+          clearInterval(checkSelection);
+          events.forEach((event) => {
+            blockRef.current?.removeEventListener(
+              event,
+              updateTextColors,
+              true,
+            );
+          });
+        };
       }, []);
 
       const handleQuestionChange = (
@@ -130,7 +253,7 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
               }
             }
           }}
-          className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800"
+          className="w-full rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800"
         >
           {/* Header */}
           <div className="mb-4 flex w-full flex-row items-center justify-between p-4">

--- a/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
@@ -1,0 +1,177 @@
+import { createReactBlockSpec } from "@blocknote/react";
+import { defaultProps } from "@blocknote/core";
+import { Trash2Icon, PlusIcon, XIcon } from "lucide-react";
+
+interface AnswerOption {
+  id: string;
+  text: string;
+  isCorrect: boolean;
+}
+
+export const MultipleChoiceQuiz = createReactBlockSpec(
+  {
+    type: "quiz-multiple-choice",
+    propSchema: {
+      ...defaultProps,
+      question: {
+        default: "",
+      },
+      options: {
+        default: [
+          { id: "1", text: "", isCorrect: true },
+          { id: "2", text: "", isCorrect: false },
+        ] as any,
+      },
+    },
+    content: "none",
+  },
+  {
+    render: (props) => {
+      const { question } = props.block.props;
+      const options = (props.block.props.options || []) as AnswerOption[];
+
+      const handleQuestionChange = (
+        e: React.ChangeEvent<HTMLTextAreaElement>,
+      ) => {
+        props.editor.updateBlock(props.block, {
+          props: { question: e.target.value },
+        });
+      };
+
+      const handleOptionTextChange = (id: string, text: string) => {
+        const updatedOptions = options.map((opt: AnswerOption) =>
+          opt.id === id ? { ...opt, text } : opt,
+        );
+        props.editor.updateBlock(props.block, {
+          props: { options: updatedOptions as any },
+        });
+      };
+
+      const handleOptionCorrectChange = (id: string) => {
+        const updatedOptions = options.map((opt: AnswerOption) => ({
+          ...opt,
+          isCorrect: opt.id === id,
+        }));
+        props.editor.updateBlock(props.block, {
+          props: { options: updatedOptions as any },
+        });
+      };
+
+      const handleAddOption = () => {
+        const newOption = {
+          id: Date.now().toString(),
+          text: "",
+          isCorrect: false,
+        };
+        props.editor.updateBlock(props.block, {
+          props: { options: [...options, newOption] as any },
+        });
+      };
+
+      const handleRemoveOption = (id: string) => {
+        if (options.length <= 2) return;
+        const updatedOptions = options.filter(
+          (opt: AnswerOption) => opt.id !== id,
+        );
+        props.editor.updateBlock(props.block, {
+          props: { options: updatedOptions as any },
+        });
+      };
+
+      const handleDelete = () => {
+        props.editor.removeBlocks([props.block]);
+      };
+
+      return (
+        <div className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800">
+          {/* Header */}
+          <div
+            className="mb-4 flex w-full flex-row items-center justify-between p-4"
+            contentEditable="false"
+          >
+            <h2 className="text-lg">Multiple Choice Quiz</h2>
+            <div contentEditable="false">
+              <Trash2Icon
+                className="cursor-pointer text-red-600 hover:text-red-700"
+                onClick={handleDelete}
+                data-testid="delete-block"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-6 px-4" contentEditable="false">
+            {/* Question */}
+            <div>
+              <label className="mb-2 block text-left text-sm font-medium text-gray-700 dark:text-gray-300">
+                Question:
+              </label>
+              <textarea
+                value={question}
+                onChange={handleQuestionChange}
+                placeholder="Nothing here yet..."
+                className="resize-vertical min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+            </div>
+
+            {/* Answer Options */}
+            <div>
+              <label className="mb-2 block text-left text-sm font-medium text-gray-700 dark:text-gray-300">
+                Answer Options:
+              </label>
+              <div className="space-y-3">
+                {options.map((option: AnswerOption, index: number) => (
+                  <div key={option.id} className="flex items-start gap-2">
+                    {/* Checkbox for correct answer */}
+                    <div contentEditable="false">
+                      <input
+                        type="checkbox"
+                        checked={option.isCorrect}
+                        onChange={() => handleOptionCorrectChange(option.id)}
+                        className="mt-4 h-5 w-5 cursor-pointer"
+                      />
+                    </div>
+
+                    {/* Option text */}
+                    <textarea
+                      value={option.text}
+                      onChange={(e) =>
+                        handleOptionTextChange(option.id, e.target.value)
+                      }
+                      placeholder={`Option ${index + 1}`}
+                      className="resize-vertical min-h-[60px] flex-1 rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                    />
+
+                    {/* Delete option button */}
+                    {options.length > 2 && (
+                      <div contentEditable="false">
+                        <button
+                          onClick={() => handleRemoveOption(option.id)}
+                          className="mt-3 rounded p-2 text-red-600 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/20"
+                        >
+                          <XIcon size={20} />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              {/* Add Option Button */}
+              {options.length < 6 && (
+                <div contentEditable="false">
+                  <button
+                    onClick={handleAddOption}
+                    className="mt-3 flex items-center gap-2 rounded-md border border-gray-300 px-4 py-2 text-sm transition-colors hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-700"
+                  >
+                    <PlusIcon size={16} />
+                    Add Option
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      );
+    },
+  },
+);

--- a/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
@@ -314,7 +314,7 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
                         onMouseDown={(e) => e.stopPropagation()}
                         className="mt-3 rounded p-2 text-red-600 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/20"
                       >
-                        <XIcon size={20} />
+                        <XIcon size={20} color="red" />
                       </button>
                     )}
                   </div>

--- a/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
@@ -23,36 +23,157 @@ export const OpenEndedQuiz = createReactBlockSpec(
       const blockRef = React.useRef<HTMLDivElement>(null);
 
       React.useEffect(() => {
-        if (blockRef.current) {
-          const blockContent = blockRef.current.closest(
-            ".bn-block-content",
-          ) as HTMLElement;
-          if (blockContent) {
-            const removeStyles = () => {
-              blockContent.removeAttribute("style");
-            };
+        if (!blockRef.current) return;
 
-            removeStyles();
+        const updateTextColors = () => {
+          // Check current theme
+          const container = blockRef.current?.closest(".bn-container");
+          const isLightMode =
+            container && container.classList.contains("light");
+          const isDarkMode = container && container.classList.contains("dark");
 
-            const observer = new MutationObserver(removeStyles);
-            observer.observe(blockContent, {
-              attributes: true,
-              attributeFilter: ["style"],
+          if (!container) return;
+
+          // Find all text elements inside the quiz block
+          const textareas = blockRef.current?.querySelectorAll("textarea");
+          const inputs = blockRef.current?.querySelectorAll("input");
+          const labels = blockRef.current?.querySelectorAll("label");
+          const headings = blockRef.current?.querySelectorAll("h2, h3, h4");
+          const buttons = blockRef.current?.querySelectorAll("button");
+          const allElements = blockRef.current?.querySelectorAll("*");
+
+          // Function to clear color styles
+          const clearColorStyles = (element: Element) => {
+            const htmlEl = element as HTMLElement;
+            htmlEl.style.removeProperty("color");
+            htmlEl.style.removeProperty("-webkit-text-fill-color");
+            if (htmlEl.tagName === "TEXTAREA" || htmlEl.tagName === "INPUT") {
+              htmlEl.style.removeProperty("caret-color");
+            }
+          };
+
+          // Function to set dark color (for light mode only)
+          const setDarkColor = (element: Element) => {
+            const htmlEl = element as HTMLElement;
+            if (htmlEl.children.length > 0 && !htmlEl.textContent?.trim()) {
+              return;
+            }
+            const darkColor = "rgb(17, 24, 39)";
+            htmlEl.style.setProperty("color", darkColor, "important");
+            htmlEl.style.setProperty(
+              "-webkit-text-fill-color",
+              darkColor,
+              "important",
+            );
+            if (htmlEl.tagName === "TEXTAREA" || htmlEl.tagName === "INPUT") {
+              htmlEl.style.setProperty("caret-color", darkColor, "important");
+            }
+          };
+
+          // In dark mode: clear all our color overrides to let BlockNote handle it
+          if (isDarkMode) {
+            textareas?.forEach(clearColorStyles);
+            inputs?.forEach(clearColorStyles);
+            labels?.forEach(clearColorStyles);
+            headings?.forEach(clearColorStyles);
+            buttons?.forEach(clearColorStyles);
+            allElements?.forEach((el) => {
+              const htmlEl = el as HTMLElement;
+              if (
+                htmlEl.textContent?.trim() ||
+                htmlEl.tagName === "TEXTAREA" ||
+                htmlEl.tagName === "INPUT" ||
+                htmlEl.tagName === "LABEL" ||
+                htmlEl.tagName === "BUTTON" ||
+                htmlEl.tagName === "H2" ||
+                htmlEl.tagName === "H3" ||
+                htmlEl.tagName === "H4"
+              ) {
+                clearColorStyles(htmlEl);
+              }
             });
-
-            const events = ["click", "mousedown", "focus", "focusin"];
-            events.forEach((event) => {
-              blockContent.addEventListener(event, removeStyles, true);
-            });
-
-            return () => {
-              observer.disconnect();
-              events.forEach((event) => {
-                blockContent.removeEventListener(event, removeStyles, true);
-              });
-            };
+            return;
           }
+
+          // In light mode: apply dark colors
+          if (isLightMode) {
+            textareas?.forEach(setDarkColor);
+            inputs?.forEach(setDarkColor);
+            labels?.forEach(setDarkColor);
+            headings?.forEach(setDarkColor);
+            buttons?.forEach(setDarkColor);
+            allElements?.forEach((el) => {
+              const htmlEl = el as HTMLElement;
+              if (
+                htmlEl.textContent?.trim() ||
+                htmlEl.tagName === "TEXTAREA" ||
+                htmlEl.tagName === "INPUT" ||
+                htmlEl.tagName === "LABEL" ||
+                htmlEl.tagName === "BUTTON" ||
+                htmlEl.tagName === "H2" ||
+                htmlEl.tagName === "H3" ||
+                htmlEl.tagName === "H4"
+              ) {
+                setDarkColor(htmlEl);
+              }
+            });
+          }
+        };
+
+        // Run immediately
+        updateTextColors();
+
+        // Watch for theme changes on the container
+        const container = blockRef.current?.closest(".bn-container");
+        const containerObserver = container
+          ? new MutationObserver(() => {
+              // Theme changed, update colors
+              setTimeout(updateTextColors, 0);
+            })
+          : null;
+
+        if (container && containerObserver) {
+          containerObserver.observe(container, {
+            attributes: true,
+            attributeFilter: ["class"],
+          });
         }
+
+        // Set up observer to run on any changes
+        const observer = new MutationObserver(() => {
+          setTimeout(updateTextColors, 0);
+        });
+
+        if (blockRef.current) {
+          observer.observe(blockRef.current, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ["style", "data-selected"],
+          });
+        }
+
+        // Also run on events
+        const events = ["click", "mousedown", "focus", "focusin", "mouseup"];
+        events.forEach((event) => {
+          blockRef.current?.addEventListener(event, updateTextColors, true);
+        });
+
+        // Run on selection changes (check less frequently)
+        const checkSelection = setInterval(updateTextColors, 200);
+
+        return () => {
+          observer.disconnect();
+          containerObserver?.disconnect();
+          clearInterval(checkSelection);
+          events.forEach((event) => {
+            blockRef.current?.removeEventListener(
+              event,
+              updateTextColors,
+              true,
+            );
+          });
+        };
       }, []);
 
       const handleQuestionChange = (
@@ -88,7 +209,7 @@ export const OpenEndedQuiz = createReactBlockSpec(
               }
             }
           }}
-          className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800"
+          className="w-full rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800"
         >
           {/* Header */}
           <div className="mb-4 flex w-full flex-row items-center justify-between p-4">

--- a/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
@@ -1,6 +1,7 @@
 import { createReactBlockSpec } from "@blocknote/react";
 import { defaultProps } from "@blocknote/core";
 import { Trash2Icon } from "lucide-react";
+import React from "react";
 
 export const OpenEndedQuiz = createReactBlockSpec(
   {
@@ -19,6 +20,40 @@ export const OpenEndedQuiz = createReactBlockSpec(
   {
     render: (props) => {
       const { question, correctAnswer } = props.block.props;
+      const blockRef = React.useRef<HTMLDivElement>(null);
+
+      React.useEffect(() => {
+        if (blockRef.current) {
+          const blockContent = blockRef.current.closest(
+            ".bn-block-content",
+          ) as HTMLElement;
+          if (blockContent) {
+            const removeStyles = () => {
+              blockContent.removeAttribute("style");
+            };
+
+            removeStyles();
+
+            const observer = new MutationObserver(removeStyles);
+            observer.observe(blockContent, {
+              attributes: true,
+              attributeFilter: ["style"],
+            });
+
+            const events = ["click", "mousedown", "focus", "focusin"];
+            events.forEach((event) => {
+              blockContent.addEventListener(event, removeStyles, true);
+            });
+
+            return () => {
+              observer.disconnect();
+              events.forEach((event) => {
+                blockContent.removeEventListener(event, removeStyles, true);
+              });
+            };
+          }
+        }
+      }, []);
 
       const handleQuestionChange = (
         e: React.ChangeEvent<HTMLTextAreaElement>,
@@ -41,26 +76,35 @@ export const OpenEndedQuiz = createReactBlockSpec(
       };
 
       return (
-        <div className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800">
+        <div
+          ref={blockRef}
+          onMouseDown={(e) => {
+            if (blockRef.current) {
+              const blockContent = blockRef.current.closest(
+                ".bn-block-content",
+              ) as HTMLElement;
+              if (blockContent) {
+                blockContent.removeAttribute("style");
+              }
+            }
+          }}
+          className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800"
+        >
           {/* Header */}
-          <div
-            className="mb-4 flex w-full flex-row items-center justify-between p-4"
-            contentEditable="false"
-          >
+          <div className="mb-4 flex w-full flex-row items-center justify-between p-4">
             <h2 className="text-lg">Open-Ended Quiz</h2>
-            <div contentEditable="false">
-              <Trash2Icon
-                className="cursor-pointer text-red-600 hover:text-red-700"
-                onClick={handleDelete}
-                data-testid="delete-block"
-              />
-            </div>
+            <Trash2Icon
+              className="cursor-pointer text-red-600 hover:text-red-700"
+              onClick={handleDelete}
+              onMouseDown={(e) => e.stopPropagation()}
+              data-testid="delete-block"
+            />
           </div>
 
           <div className="space-y-6 px-4">
             {/* Question */}
             <div>
-              <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label className="mb-2 block text-left text-sm font-medium text-gray-700 dark:text-gray-300">
                 Question:
               </label>
               <textarea
@@ -73,7 +117,7 @@ export const OpenEndedQuiz = createReactBlockSpec(
 
             {/* Correct Answer */}
             <div>
-              <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label className="mb-2 block text-left text-sm font-medium text-gray-700 dark:text-gray-300">
                 Correct Answer:
               </label>
               <textarea

--- a/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
@@ -1,0 +1,95 @@
+import { createReactBlockSpec } from "@blocknote/react";
+import { defaultProps } from "@blocknote/core";
+import { Trash2Icon } from "lucide-react";
+
+export const OpenEndedQuiz = createReactBlockSpec(
+  {
+    type: "quiz-open-ended",
+    propSchema: {
+      ...defaultProps,
+      question: {
+        default: "",
+      },
+      correctAnswer: {
+        default: "",
+      },
+    },
+    content: "none",
+  },
+  {
+    render: (props) => {
+      const { question, correctAnswer } = props.block.props;
+
+      const handleQuestionChange = (
+        e: React.ChangeEvent<HTMLTextAreaElement>,
+      ) => {
+        props.editor.updateBlock(props.block, {
+          props: { question: e.target.value },
+        });
+      };
+
+      const handleCorrectAnswerChange = (
+        e: React.ChangeEvent<HTMLTextAreaElement>,
+      ) => {
+        props.editor.updateBlock(props.block, {
+          props: { correctAnswer: e.target.value },
+        });
+      };
+
+      const handleDelete = () => {
+        props.editor.removeBlocks([props.block]);
+      };
+
+      return (
+        <div className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800">
+          {/* Header */}
+          <div
+            className="mb-4 flex w-full flex-row items-center justify-between p-4"
+            contentEditable="false"
+          >
+            <h2 className="text-lg">Open-Ended Quiz</h2>
+            <div contentEditable="false">
+              <Trash2Icon
+                className="cursor-pointer text-red-600 hover:text-red-700"
+                onClick={handleDelete}
+                data-testid="delete-block"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-6 px-4">
+            {/* Question */}
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Question:
+              </label>
+              <textarea
+                value={question}
+                onChange={handleQuestionChange}
+                placeholder="Nothing here yet..."
+                className="resize-vertical min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+            </div>
+
+            {/* Correct Answer */}
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Correct Answer:
+              </label>
+              <textarea
+                value={correctAnswer}
+                onChange={handleCorrectAnswerChange}
+                placeholder="Enter the correct answer..."
+                className="resize-vertical min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                Student answers will be checked for exact match
+                (case-insensitive)
+              </p>
+            </div>
+          </div>
+        </div>
+      );
+    },
+  },
+);

--- a/frontend/components/ui/blocknote/blocks/quiz-true-false-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-true-false-block.tsx
@@ -1,0 +1,107 @@
+import { createReactBlockSpec } from "@blocknote/react";
+import { defaultProps } from "@blocknote/core";
+import { Trash2Icon } from "lucide-react";
+
+export const TrueFalseQuiz = createReactBlockSpec(
+  {
+    type: "quiz-true-false",
+    propSchema: {
+      ...defaultProps,
+      question: {
+        default: "",
+      },
+      correctAnswer: {
+        default: true,
+        values: [true, false],
+      },
+    },
+    content: "none",
+  },
+  {
+    render: (props) => {
+      const { question, correctAnswer } = props.block.props;
+
+      const handleQuestionChange = (
+        e: React.ChangeEvent<HTMLTextAreaElement>,
+      ) => {
+        props.editor.updateBlock(props.block, {
+          props: { question: e.target.value },
+        });
+      };
+
+      const handleAnswerChange = (value: boolean) => {
+        props.editor.updateBlock(props.block, {
+          props: { correctAnswer: value },
+        });
+      };
+
+      const handleDelete = () => {
+        props.editor.removeBlocks([props.block]);
+      };
+
+      return (
+        <div className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800">
+          {/* Header matching QuizEditor */}
+          <div
+            className="mb-4 flex w-full flex-row items-center justify-between p-4"
+            contentEditable="false"
+          >
+            {" "}
+            <h2 className="text-lg">True/False Quiz</h2>
+            <Trash2Icon
+              className="cursor-pointer text-red-600 hover:text-red-700"
+              onClick={handleDelete}
+              data-testid="delete-block"
+            />
+          </div>
+
+          <div className="space-y-6 px-4">
+            {/* Question */}
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Question:
+              </label>
+              <textarea
+                value={question}
+                onChange={handleQuestionChange}
+                placeholder="Nothing here yet..."
+                className="resize-vertical min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+            </div>
+
+            {/* Answer Selection */}
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Correct Answer:
+              </label>
+              <div className="flex gap-4" contentEditable={false}>
+                <button
+                  onClick={() => handleAnswerChange(true)}
+                  contentEditable="false"
+                  className={`flex-1 rounded-md border-2 p-3 font-medium transition-colors ${
+                    correctAnswer === true
+                      ? "border-green-500 bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300"
+                      : "border-gray-300 bg-white text-gray-700 hover:border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500"
+                  }`}
+                >
+                  True
+                </button>
+                <button
+                  onClick={() => handleAnswerChange(false)}
+                  contentEditable="false"
+                  className={`flex-1 rounded-md border-2 p-3 font-medium transition-colors ${
+                    correctAnswer === false
+                      ? "border-red-500 bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300"
+                      : "border-gray-300 bg-white text-gray-700 hover:border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500"
+                  }`}
+                >
+                  False
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    },
+  },
+);

--- a/frontend/components/ui/blocknote/blocks/quiz-true-false-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-true-false-block.tsx
@@ -1,6 +1,7 @@
 import { createReactBlockSpec } from "@blocknote/react";
 import { defaultProps } from "@blocknote/core";
 import { Trash2Icon } from "lucide-react";
+import React from "react";
 
 export const TrueFalseQuiz = createReactBlockSpec(
   {
@@ -20,6 +21,40 @@ export const TrueFalseQuiz = createReactBlockSpec(
   {
     render: (props) => {
       const { question, correctAnswer } = props.block.props;
+      const blockRef = React.useRef<HTMLDivElement>(null);
+
+      React.useEffect(() => {
+        if (blockRef.current) {
+          const blockContent = blockRef.current.closest(
+            ".bn-block-content",
+          ) as HTMLElement;
+          if (blockContent) {
+            const removeStyles = () => {
+              blockContent.removeAttribute("style");
+            };
+
+            removeStyles();
+
+            const observer = new MutationObserver(removeStyles);
+            observer.observe(blockContent, {
+              attributes: true,
+              attributeFilter: ["style"],
+            });
+
+            const events = ["click", "mousedown", "focus", "focusin"];
+            events.forEach((event) => {
+              blockContent.addEventListener(event, removeStyles, true);
+            });
+
+            return () => {
+              observer.disconnect();
+              events.forEach((event) => {
+                blockContent.removeEventListener(event, removeStyles, true);
+              });
+            };
+          }
+        }
+      }, []);
 
       const handleQuestionChange = (
         e: React.ChangeEvent<HTMLTextAreaElement>,
@@ -33,6 +68,17 @@ export const TrueFalseQuiz = createReactBlockSpec(
         props.editor.updateBlock(props.block, {
           props: { correctAnswer: value },
         });
+
+        setTimeout(() => {
+          if (blockRef.current) {
+            const blockContent = blockRef.current.closest(
+              ".bn-block-content",
+            ) as HTMLElement;
+            if (blockContent) {
+              blockContent.removeAttribute("style");
+            }
+          }
+        }, 0);
       };
 
       const handleDelete = () => {
@@ -40,17 +86,27 @@ export const TrueFalseQuiz = createReactBlockSpec(
       };
 
       return (
-        <div className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800">
+        <div
+          ref={blockRef}
+          onMouseDown={(e) => {
+            if (blockRef.current) {
+              const blockContent = blockRef.current.closest(
+                ".bn-block-content",
+              ) as HTMLElement;
+              if (blockContent) {
+                blockContent.removeAttribute("style");
+              }
+            }
+          }}
+          className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800"
+        >
           {/* Header matching QuizEditor */}
-          <div
-            className="mb-4 flex w-full flex-row items-center justify-between p-4"
-            contentEditable="false"
-          >
-            {" "}
+          <div className="mb-4 flex w-full flex-row items-center justify-between p-4">
             <h2 className="text-lg">True/False Quiz</h2>
             <Trash2Icon
               className="cursor-pointer text-red-600 hover:text-red-700"
               onClick={handleDelete}
+              onMouseDown={(e) => e.stopPropagation()}
               data-testid="delete-block"
             />
           </div>
@@ -58,7 +114,7 @@ export const TrueFalseQuiz = createReactBlockSpec(
           <div className="space-y-6 px-4">
             {/* Question */}
             <div>
-              <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label className="mb-2 block text-left text-sm font-medium text-gray-700 dark:text-gray-300">
                 Question:
               </label>
               <textarea
@@ -71,13 +127,23 @@ export const TrueFalseQuiz = createReactBlockSpec(
 
             {/* Answer Selection */}
             <div>
-              <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label className="mb-2 block text-left text-sm font-medium text-gray-700 dark:text-gray-300">
                 Correct Answer:
               </label>
-              <div className="flex gap-4" contentEditable={false}>
+              <div className="flex gap-4">
                 <button
                   onClick={() => handleAnswerChange(true)}
-                  contentEditable="false"
+                  onMouseDown={(e) => {
+                    e.stopPropagation();
+                    if (blockRef.current) {
+                      const blockContent = blockRef.current.closest(
+                        ".bn-block-content",
+                      ) as HTMLElement;
+                      if (blockContent) {
+                        blockContent.removeAttribute("style");
+                      }
+                    }
+                  }}
                   className={`flex-1 rounded-md border-2 p-3 font-medium transition-colors ${
                     correctAnswer === true
                       ? "border-green-500 bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300"
@@ -88,7 +154,17 @@ export const TrueFalseQuiz = createReactBlockSpec(
                 </button>
                 <button
                   onClick={() => handleAnswerChange(false)}
-                  contentEditable="false"
+                  onMouseDown={(e) => {
+                    e.stopPropagation();
+                    if (blockRef.current) {
+                      const blockContent = blockRef.current.closest(
+                        ".bn-block-content",
+                      ) as HTMLElement;
+                      if (blockContent) {
+                        blockContent.removeAttribute("style");
+                      }
+                    }
+                  }}
                   className={`flex-1 rounded-md border-2 p-3 font-medium transition-colors ${
                     correctAnswer === false
                       ? "border-red-500 bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300"

--- a/frontend/components/ui/blocknote/blocks/quiz-true-false-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-true-false-block.tsx
@@ -24,36 +24,157 @@ export const TrueFalseQuiz = createReactBlockSpec(
       const blockRef = React.useRef<HTMLDivElement>(null);
 
       React.useEffect(() => {
-        if (blockRef.current) {
-          const blockContent = blockRef.current.closest(
-            ".bn-block-content",
-          ) as HTMLElement;
-          if (blockContent) {
-            const removeStyles = () => {
-              blockContent.removeAttribute("style");
-            };
+        if (!blockRef.current) return;
 
-            removeStyles();
+        const updateTextColors = () => {
+          // Check current theme
+          const container = blockRef.current?.closest(".bn-container");
+          const isLightMode =
+            container && container.classList.contains("light");
+          const isDarkMode = container && container.classList.contains("dark");
 
-            const observer = new MutationObserver(removeStyles);
-            observer.observe(blockContent, {
-              attributes: true,
-              attributeFilter: ["style"],
+          if (!container) return;
+
+          // Find all text elements inside the quiz block
+          const textareas = blockRef.current?.querySelectorAll("textarea");
+          const inputs = blockRef.current?.querySelectorAll("input");
+          const labels = blockRef.current?.querySelectorAll("label");
+          const headings = blockRef.current?.querySelectorAll("h2, h3, h4");
+          const buttons = blockRef.current?.querySelectorAll("button");
+          const allElements = blockRef.current?.querySelectorAll("*");
+
+          // Function to clear color styles
+          const clearColorStyles = (element: Element) => {
+            const htmlEl = element as HTMLElement;
+            htmlEl.style.removeProperty("color");
+            htmlEl.style.removeProperty("-webkit-text-fill-color");
+            if (htmlEl.tagName === "TEXTAREA" || htmlEl.tagName === "INPUT") {
+              htmlEl.style.removeProperty("caret-color");
+            }
+          };
+
+          // Function to set dark color (for light mode only)
+          const setDarkColor = (element: Element) => {
+            const htmlEl = element as HTMLElement;
+            if (htmlEl.children.length > 0 && !htmlEl.textContent?.trim()) {
+              return;
+            }
+            const darkColor = "rgb(17, 24, 39)";
+            htmlEl.style.setProperty("color", darkColor, "important");
+            htmlEl.style.setProperty(
+              "-webkit-text-fill-color",
+              darkColor,
+              "important",
+            );
+            if (htmlEl.tagName === "TEXTAREA" || htmlEl.tagName === "INPUT") {
+              htmlEl.style.setProperty("caret-color", darkColor, "important");
+            }
+          };
+
+          // In dark mode: clear all our color overrides to let BlockNote handle it
+          if (isDarkMode) {
+            textareas?.forEach(clearColorStyles);
+            inputs?.forEach(clearColorStyles);
+            labels?.forEach(clearColorStyles);
+            headings?.forEach(clearColorStyles);
+            buttons?.forEach(clearColorStyles);
+            allElements?.forEach((el) => {
+              const htmlEl = el as HTMLElement;
+              if (
+                htmlEl.textContent?.trim() ||
+                htmlEl.tagName === "TEXTAREA" ||
+                htmlEl.tagName === "INPUT" ||
+                htmlEl.tagName === "LABEL" ||
+                htmlEl.tagName === "BUTTON" ||
+                htmlEl.tagName === "H2" ||
+                htmlEl.tagName === "H3" ||
+                htmlEl.tagName === "H4"
+              ) {
+                clearColorStyles(htmlEl);
+              }
             });
-
-            const events = ["click", "mousedown", "focus", "focusin"];
-            events.forEach((event) => {
-              blockContent.addEventListener(event, removeStyles, true);
-            });
-
-            return () => {
-              observer.disconnect();
-              events.forEach((event) => {
-                blockContent.removeEventListener(event, removeStyles, true);
-              });
-            };
+            return;
           }
+
+          // In light mode: apply dark colors
+          if (isLightMode) {
+            textareas?.forEach(setDarkColor);
+            inputs?.forEach(setDarkColor);
+            labels?.forEach(setDarkColor);
+            headings?.forEach(setDarkColor);
+            buttons?.forEach(setDarkColor);
+            allElements?.forEach((el) => {
+              const htmlEl = el as HTMLElement;
+              if (
+                htmlEl.textContent?.trim() ||
+                htmlEl.tagName === "TEXTAREA" ||
+                htmlEl.tagName === "INPUT" ||
+                htmlEl.tagName === "LABEL" ||
+                htmlEl.tagName === "BUTTON" ||
+                htmlEl.tagName === "H2" ||
+                htmlEl.tagName === "H3" ||
+                htmlEl.tagName === "H4"
+              ) {
+                setDarkColor(htmlEl);
+              }
+            });
+          }
+        };
+
+        // Run immediately
+        updateTextColors();
+
+        // Watch for theme changes on the container
+        const container = blockRef.current?.closest(".bn-container");
+        const containerObserver = container
+          ? new MutationObserver(() => {
+              // Theme changed, update colors
+              setTimeout(updateTextColors, 0);
+            })
+          : null;
+
+        if (container && containerObserver) {
+          containerObserver.observe(container, {
+            attributes: true,
+            attributeFilter: ["class"],
+          });
         }
+
+        // Set up observer to run on any changes
+        const observer = new MutationObserver(() => {
+          setTimeout(updateTextColors, 0);
+        });
+
+        if (blockRef.current) {
+          observer.observe(blockRef.current, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ["style", "data-selected"],
+          });
+        }
+
+        // Also run on events
+        const events = ["click", "mousedown", "focus", "focusin", "mouseup"];
+        events.forEach((event) => {
+          blockRef.current?.addEventListener(event, updateTextColors, true);
+        });
+
+        // Run on selection changes (check less frequently)
+        const checkSelection = setInterval(updateTextColors, 200);
+
+        return () => {
+          observer.disconnect();
+          containerObserver?.disconnect();
+          clearInterval(checkSelection);
+          events.forEach((event) => {
+            blockRef.current?.removeEventListener(
+              event,
+              updateTextColors,
+              true,
+            );
+          });
+        };
       }, []);
 
       const handleQuestionChange = (
@@ -68,17 +189,6 @@ export const TrueFalseQuiz = createReactBlockSpec(
         props.editor.updateBlock(props.block, {
           props: { correctAnswer: value },
         });
-
-        setTimeout(() => {
-          if (blockRef.current) {
-            const blockContent = blockRef.current.closest(
-              ".bn-block-content",
-            ) as HTMLElement;
-            if (blockContent) {
-              blockContent.removeAttribute("style");
-            }
-          }
-        }, 0);
       };
 
       const handleDelete = () => {
@@ -98,7 +208,7 @@ export const TrueFalseQuiz = createReactBlockSpec(
               }
             }
           }}
-          className="w-full max-w-2xl rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800"
+          className="w-full rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800"
         >
           {/* Header matching QuizEditor */}
           <div className="mb-4 flex w-full flex-row items-center justify-between p-4">

--- a/frontend/components/ui/blocknote/editor/block-note-test-editor.tsx
+++ b/frontend/components/ui/blocknote/editor/block-note-test-editor.tsx
@@ -7,6 +7,7 @@ import {
 } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
+import "./custom-blocknote.css";
 import { Callout } from "@/components/ui/blocknote/blocks/callout-block";
 import { TrueFalseQuiz } from "@/components/ui/blocknote/blocks/quiz-true-false-block";
 import { OpenEndedQuiz } from "@/components/ui/blocknote/blocks/quiz-open-ended-block";
@@ -44,6 +45,7 @@ export default function BlockNoteTestEditor() {
         editor={editor}
         slashMenu={false}
         theme={resolvedTheme === "dark" ? "dark" : "light"}
+        data-quiz-blocks
       >
         <SuggestionMenuController
           triggerCharacter="/"

--- a/frontend/components/ui/blocknote/editor/block-note-test-editor.tsx
+++ b/frontend/components/ui/blocknote/editor/block-note-test-editor.tsx
@@ -7,6 +7,7 @@ import {
 } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
+import "./custom-blocknote.css";
 import { Callout } from "@/components/ui/blocknote/blocks/callout-block";
 import { TrueFalseQuiz } from "@/components/ui/blocknote/blocks/quiz-true-false-block";
 import { OpenEndedQuiz } from "@/components/ui/blocknote/blocks/quiz-open-ended-block";

--- a/frontend/components/ui/blocknote/editor/block-note-test-editor.tsx
+++ b/frontend/components/ui/blocknote/editor/block-note-test-editor.tsx
@@ -7,7 +7,6 @@ import {
 } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
-import "./custom-blocknote.css";
 import { Callout } from "@/components/ui/blocknote/blocks/callout-block";
 import { TrueFalseQuiz } from "@/components/ui/blocknote/blocks/quiz-true-false-block";
 import { OpenEndedQuiz } from "@/components/ui/blocknote/blocks/quiz-open-ended-block";

--- a/frontend/components/ui/blocknote/editor/block-note-test-editor.tsx
+++ b/frontend/components/ui/blocknote/editor/block-note-test-editor.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { BlockNoteSchema, defaultBlockSpecs } from "@blocknote/core";
 import {
   useCreateBlockNote,
@@ -9,17 +8,26 @@ import {
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
 import { Callout } from "@/components/ui/blocknote/blocks/callout-block";
-import { getCalloutSlashMenuItems } from "@/components/ui/blocknote/editor/slash-menu-config";
+import { TrueFalseQuiz } from "@/components/ui/blocknote/blocks/quiz-true-false-block";
+import { OpenEndedQuiz } from "@/components/ui/blocknote/blocks/quiz-open-ended-block";
+import { MultipleChoiceQuiz } from "@/components/ui/blocknote/blocks/quiz-multiple-choice-block";
+import {
+  getCalloutSlashMenuItems,
+  getQuizSlashMenuItems,
+} from "@/components/ui/blocknote/editor/slash-menu-config";
 import { useTheme } from "next-themes";
 
 export default function BlockNoteTestEditor() {
-  const { resolvedTheme } = useTheme(); // Get Odyssey's theme
+  const { resolvedTheme } = useTheme();
 
   const editor = useCreateBlockNote({
     schema: BlockNoteSchema.create({
       blockSpecs: {
         ...defaultBlockSpecs,
         callout: Callout(),
+        "quiz-true-false": TrueFalseQuiz(),
+        "quiz-open-ended": OpenEndedQuiz(),
+        "quiz-multiple-choice": MultipleChoiceQuiz(),
       },
     }),
   });
@@ -27,6 +35,7 @@ export default function BlockNoteTestEditor() {
   const getCustomSlashMenuItems = (editor: any) => [
     ...getDefaultReactSlashMenuItems(editor),
     ...getCalloutSlashMenuItems(editor),
+    ...getQuizSlashMenuItems(editor),
   ];
 
   return (

--- a/frontend/components/ui/blocknote/editor/block-note-test-editor.tsx
+++ b/frontend/components/ui/blocknote/editor/block-note-test-editor.tsx
@@ -45,7 +45,6 @@ export default function BlockNoteTestEditor() {
         editor={editor}
         slashMenu={false}
         theme={resolvedTheme === "dark" ? "dark" : "light"}
-        data-quiz-blocks
       >
         <SuggestionMenuController
           triggerCharacter="/"

--- a/frontend/components/ui/blocknote/editor/custom-blocknote.css
+++ b/frontend/components/ui/blocknote/editor/custom-blocknote.css
@@ -1,0 +1,78 @@
+/* Force dark text in quiz blocks - light mode only */
+/* Target by data-content-type attribute on any element */
+
+/* All quiz block content */
+.bn-container.light [data-content-type="quiz-multiple-choice"] *,
+.bn-container.light [data-content-type="quiz-true-false"] *,
+.bn-container.light [data-content-type="quiz-open-ended"] *,
+.bn-container.light [data-content-type^="quiz-"] * {
+  color: rgb(17 24 39) !important;
+  -webkit-text-fill-color: rgb(17 24 39) !important;
+}
+
+/* Form elements specifically */
+.bn-container.light [data-content-type^="quiz-"] textarea,
+.bn-container.light [data-content-type^="quiz-"] input {
+  color: rgb(17 24 39) !important;
+  -webkit-text-fill-color: rgb(17 24 39) !important;
+  caret-color: rgb(17 24 39) !important;
+}
+
+/* When block is selected - override BlockNote's selection color */
+.bn-container.light
+  .bn-block[data-selected="true"]
+  [data-content-type^="quiz-"]
+  *,
+.bn-container.light
+  .bn-block[data-selected="true"]
+  [data-content-type="quiz-multiple-choice"]
+  *,
+.bn-container.light
+  .bn-block[data-selected="true"]
+  [data-content-type="quiz-true-false"]
+  *,
+.bn-container.light
+  .bn-block[data-selected="true"]
+  [data-content-type="quiz-open-ended"]
+  * {
+  color: rgb(17 24 39) !important;
+  -webkit-text-fill-color: rgb(17 24 39) !important;
+}
+
+.bn-container.light
+  .bn-block[data-selected="true"]
+  [data-content-type^="quiz-"]
+  textarea,
+.bn-container.light
+  .bn-block[data-selected="true"]
+  [data-content-type^="quiz-"]
+  input {
+  color: rgb(17 24 39) !important;
+  -webkit-text-fill-color: rgb(17 24 39) !important;
+  caret-color: rgb(17 24 39) !important;
+}
+
+/* Also check if data-content-type is on bn-block-content */
+.bn-container.light .bn-block-content[data-content-type^="quiz-"] *,
+.bn-container.light
+  .bn-block[data-selected="true"]
+  .bn-block-content[data-content-type^="quiz-"]
+  * {
+  color: rgb(17 24 39) !important;
+  -webkit-text-fill-color: rgb(17 24 39) !important;
+}
+
+.bn-container.light .bn-block-content[data-content-type^="quiz-"] textarea,
+.bn-container.light .bn-block-content[data-content-type^="quiz-"] input,
+.bn-container.light
+  .bn-block[data-selected="true"]
+  .bn-block-content[data-content-type^="quiz-"]
+  textarea,
+.bn-container.light
+  .bn-block[data-selected="true"]
+  .bn-block-content[data-content-type^="quiz-"]
+  input {
+  color: rgb(17 24 39) !important;
+  -webkit-text-fill-color: rgb(17 24 39) !important;
+  caret-color: rgb(17 24 39) !important;
+}

--- a/frontend/components/ui/blocknote/editor/slash-menu-config.ts
+++ b/frontend/components/ui/blocknote/editor/slash-menu-config.ts
@@ -73,3 +73,71 @@ export const getCalloutSlashMenuItems = (
     "Gray default callout",
   ),
 ];
+export const getQuizSlashMenuItems = (editor: any) => [
+  {
+    title: "True/False Quiz",
+    onItemClick: () => {
+      editor.insertBlocks(
+        [
+          {
+            type: "quiz-true-false",
+            props: {
+              question: "",
+              correctAnswer: true,
+            },
+          },
+        ],
+        editor.getTextCursorPosition().block,
+        "after",
+      );
+    },
+    aliases: ["true false", "tf", "quiz tf", "true/false", "quiz"],
+    group: "Quizzes",
+    subtext: "Create a true/false question",
+  },
+  {
+    title: "Open-Ended Quiz",
+    onItemClick: () => {
+      editor.insertBlocks(
+        [
+          {
+            type: "quiz-open-ended",
+            props: {
+              question: "",
+              correctAnswer: "",
+            },
+          },
+        ],
+        editor.getTextCursorPosition().block,
+        "after",
+      );
+    },
+    aliases: ["open ended", "open", "essay", "free response", "quiz open"],
+    group: "Quizzes",
+    subtext: "Create an open-ended question",
+  },
+  {
+    title: "Multiple Choice Quiz",
+    onItemClick: () => {
+      editor.insertBlocks(
+        [
+          {
+            type: "quiz-multiple-choice",
+            props: {
+              question: "",
+              options: [
+                { id: "1", text: "", isCorrect: true },
+                { id: "2", text: "", isCorrect: false },
+              ],
+            },
+          },
+        ],
+        editor.getTextCursorPosition().block,
+        "after",
+      );
+    },
+    aliases: ["multiple choice", "mc", "quiz mc", "mcq"],
+    group: "Quizzes",
+    subtext: "Create a multiple choice question",
+  },
+];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds three quiz block types to the BlockNote editor: True/False, Open-Ended, and Multiple Choice. These blocks provide content creators with a modern, Notion-like editing experience while maintaining complete visual consistency for students—quiz rendering will be identical between v1 and v2 content.

To test:
- navigate to /test-blocknote
- test all three new quiz slash commands in BlockNote page


**TO DO:**

- fix styling in non-safari browsers so that clicking on a non-text area on a quiz block doesn't turn all text white

## Screenshots (if appropriate):
<img width="1180" height="867" alt="Screenshot 2025-11-07 at 4 10 33 PM" src="https://github.com/user-attachments/assets/0a14fc40-151d-4995-8c36-981c49c77e8a" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three quiz blocks: Multiple Choice (editable options, single correct choice, 2–6 options), Open‑Ended (question + expected answer), and True/False (toggle correct answer). Each has in-place editors, delete control, and slash‑menu insertion.

* **Style**
  * New stylesheet to enforce consistent dark text and form styling for quiz blocks in light mode.

* **Chores**
  * Test page heading updated to "BlockNote Custom Block Test" and added theme/debug logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->