### PR TITLE
ODY-221 updated error messaging for exceeding char count limit of des…

### DIFF
--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -478,56 +478,6 @@ export interface ApiAnnouncementAnnouncement extends Schema.CollectionType {
   };
 }
 
-export interface ApiAuthorAuthor extends Schema.CollectionType {
-  collectionName: 'authors';
-  info: {
-    description: '';
-    displayName: 'Author';
-    pluralName: 'authors';
-    singularName: 'author';
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    authorized_user: Attribute.Relation<
-      'api::author.author',
-      'oneToOne',
-      'api::authorized-user.authorized-user'
-    >;
-    bio: Attribute.Text &
-      Attribute.SetMinMaxLength<{
-        maxLength: 400;
-      }>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::author.author',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    droplets: Attribute.Relation<
-      'api::author.author',
-      'manyToMany',
-      'api::droplet.droplet'
-    >;
-    name: Attribute.String & Attribute.Required;
-    photo: Attribute.Media<'images'>;
-    playlists: Attribute.Relation<
-      'api::author.author',
-      'oneToMany',
-      'api::playlist.playlist'
-    >;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::author.author',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
 export interface ApiAuthorizedUserRoleAuthorizedUserRole
   extends Schema.CollectionType {
   collectionName: 'authorized_user_roles';
@@ -585,11 +535,6 @@ export interface ApiAuthorizedUserAuthorizedUser extends Schema.CollectionType {
       'api::authorized-user.authorized-user',
       'manyToMany',
       'api::group.group'
-    >;
-    author: Attribute.Relation<
-      'api::authorized-user.authorized-user',
-      'oneToOne',
-      'api::author.author'
     >;
     bio: Attribute.Text &
       Attribute.SetMinMaxLength<{
@@ -834,11 +779,6 @@ export interface ApiDropletDroplet extends Schema.CollectionType {
       'api::droplet.droplet',
       'manyToMany',
       'api::authorized-user.authorized-user'
-    >;
-    authors: Attribute.Relation<
-      'api::droplet.droplet',
-      'manyToMany',
-      'api::author.author'
     >;
     averageRating: Attribute.Decimal &
       Attribute.SetMinMax<
@@ -1295,8 +1235,10 @@ export interface ApiLessonLesson extends Schema.CollectionType {
         'droplets.expandable',
         'droplets.open-ended-quiz'
       ]
-    > &
-      Attribute.Required;
+    >;
+    blocksV2: Attribute.JSON;
+    blocksVersion: Attribute.Enumeration<['v1', 'v2']> &
+      Attribute.DefaultTo<'v1'>;
     createdAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
       'api::lesson.lesson',
@@ -1403,11 +1345,6 @@ export interface ApiPlaylistPlaylist extends Schema.CollectionType {
       'api::playlist.playlist',
       'oneToMany',
       'api::announcement.announcement'
-    >;
-    author: Attribute.Relation<
-      'api::playlist.playlist',
-      'manyToOne',
-      'api::author.author'
     >;
     authorized_users: Attribute.Relation<
       'api::playlist.playlist',
@@ -1960,7 +1897,6 @@ declare module '@strapi/types' {
       'admin::user': AdminUser;
       'api::access-request.access-request': ApiAccessRequestAccessRequest;
       'api::announcement.announcement': ApiAnnouncementAnnouncement;
-      'api::author.author': ApiAuthorAuthor;
       'api::authorized-user-role.authorized-user-role': ApiAuthorizedUserRoleAuthorizedUserRole;
       'api::authorized-user.authorized-user': ApiAuthorizedUserAuthorizedUser;
       'api::droplet-lesson.droplet-lesson': ApiDropletLessonDropletLesson;

--- a/frontend/components/draft/metadata/hooks/useDropletUpdate.tsx
+++ b/frontend/components/draft/metadata/hooks/useDropletUpdate.tsx
@@ -19,9 +19,15 @@ export function useDropletUpdate(dropletId: number) {
         router.replace(`/draft/d/${response.data.attributes.slug}`);
       }
     } else {
-      setError(
+      if (response.error === "description must be at most 500 characters (description)") {
+        setError(
+        "The description must be less than 500 characters",
+      );
+      } else {
+         setError(
         "A droplet with a similar title is in progress or already exists.",
       );
+      }
     }
   };
 

--- a/frontend/components/draft/metadata/hooks/useDropletUpdate.tsx
+++ b/frontend/components/draft/metadata/hooks/useDropletUpdate.tsx
@@ -19,14 +19,15 @@ export function useDropletUpdate(dropletId: number) {
         router.replace(`/draft/d/${response.data.attributes.slug}`);
       }
     } else {
-      if (response.error === "description must be at most 500 characters (description)") {
-        setError(
-        "The description must be less than 500 characters",
-      );
+      if (
+        response.error ===
+        "description must be at most 500 characters (description)"
+      ) {
+        setError("The description must be less than 500 characters");
       } else {
-         setError(
-        "A droplet with a similar title is in progress or already exists.",
-      );
+        setError(
+          "A droplet with a similar title is in progress or already exists.",
+        );
       }
     }
   };

--- a/frontend/components/new/multi-select.tsx
+++ b/frontend/components/new/multi-select.tsx
@@ -99,7 +99,7 @@ export function MultiSelect({
                   ? "Select Tags..."
                   : label === "Prerequisites"
                     ? "Select Prerequisites..."
-                    : "Select Postrequisites..."}
+                    : "Select Similar Droplets..."}
               </p>
             )}
           </Button>

--- a/frontend/tests/components/new/multi-select.test.tsx
+++ b/frontend/tests/components/new/multi-select.test.tsx
@@ -61,7 +61,9 @@ describe("MultiSelect", () => {
           setSelected={mockSetSelected}
         />,
       );
-      expect(screen.getByText("Select Similar Droplets...")).toBeInTheDocument();
+      expect(
+        screen.getByText("Select Similar Droplets..."),
+      ).toBeInTheDocument();
     });
 
     it("shows selected items as badges", () => {

--- a/frontend/tests/components/new/multi-select.test.tsx
+++ b/frontend/tests/components/new/multi-select.test.tsx
@@ -61,7 +61,7 @@ describe("MultiSelect", () => {
           setSelected={mockSetSelected}
         />,
       );
-      expect(screen.getByText("Select Postrequisites...")).toBeInTheDocument();
+      expect(screen.getByText("Select Similar Droplets...")).toBeInTheDocument();
     });
 
     it("shows selected items as badges", () => {


### PR DESCRIPTION
One-block fix to get error messaging more accurate for exceeding character count for the description metadata of a droplet.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when a description exceeds 500 characters — now shows a clear, user-friendly prompt.
  * Clarified error handling to preserve existing duplicate/in-progress error messaging in other cases.
  * Success behavior unchanged: on successful updates, errors are cleared and users are routed to the updated item.

* **UI/Text**
  * Updated placeholder text to "Select Similar Droplets..." for clearer guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->