### PR TITLE
fixed bug reporting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ README.md
 docker-compose.yml
 **/*.json
 .next
+frontend/components/ui/blocknote/editor/custom-blocknote.css

--- a/frontend/components/admin/reports/report.tsx
+++ b/frontend/components/admin/reports/report.tsx
@@ -12,7 +12,7 @@ import { DateTime } from "luxon";
 export function ReportBlock({ report }: { report: Report }) {
   const handleDeleteReport = async (reportId: string) => {
     const response = await deleteReport(reportId);
-    if (response && !response.error) {
+    if (response && response.success) {
       toast.success("Report removed");
     } else {
       toast.error("Failed to remove report");

--- a/frontend/components/droplets/reports/bug/form.tsx
+++ b/frontend/components/droplets/reports/bug/form.tsx
@@ -20,7 +20,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { createBugReport } from "@/lib/actions";
 import { reportSchema } from "@/lib/validations/report";
 import { ArrowRightIcon, LoaderIcon } from "lucide-react";
-import { redirect, usePathname } from "next/navigation";
+import { redirect, usePathname, useSearchParams } from "next/navigation";
 
 type Props = {
   name?: string | null;
@@ -31,6 +31,8 @@ type Props = {
 export function ReportBugForm({ name, email, onSuccess }: Props) {
   const pathname = usePathname();
   const [isPending, startTransition] = useTransition();
+  const searchParams = useSearchParams();
+  const currentTab = searchParams.get("adminTab");
 
   const form = useForm<z.infer<typeof reportSchema>>({
     resolver: zodResolver(reportSchema),
@@ -53,7 +55,9 @@ export function ReportBugForm({ name, email, onSuccess }: Props) {
           onSuccess();
           toast.success("Your report has been successfully submitted.");
           if (values.path === "/admin") {
-            redirect(values.path + "?ts=" + Date.now());
+            redirect(
+              values.path + "?ts=" + Date.now() + "&adminTab=" + currentTab,
+            );
           }
         }
       });

--- a/frontend/components/ui/blocknote/editor/custom-blocknote.css
+++ b/frontend/components/ui/blocknote/editor/custom-blocknote.css
@@ -102,8 +102,8 @@
 .bn-inline-latex-input {
   min-width: 0.5ch;
   outline: none;
-  font-family: "KaTeX_Main", "KaTeX_Math", "KaTeX_AMS", "Times New Roman",
-    Georgia, serif;
+  font-family:
+    "KaTeX_Main", "KaTeX_Math", "KaTeX_AMS", "Times New Roman", Georgia, serif;
 }
 
 .bn-inline-latex-preview {

--- a/frontend/components/ui/blocknote/editor/custom-blocknote.css
+++ b/frontend/components/ui/blocknote/editor/custom-blocknote.css
@@ -102,8 +102,8 @@
 .bn-inline-latex-input {
   min-width: 0.5ch;
   outline: none;
-  font-family:
-    "KaTeX_Main", "KaTeX_Math", "KaTeX_AMS", "Times New Roman", Georgia, serif;
+  font-family: "KaTeX_Main", "KaTeX_Math", "KaTeX_AMS", "Times New Roman",
+    Georgia, serif;
 }
 
 .bn-inline-latex-preview {

--- a/frontend/lib/actions.ts
+++ b/frontend/lib/actions.ts
@@ -129,10 +129,11 @@ export async function deleteReport(id: string) {
   });
 
   if (!response.ok) {
-    throw new Error("Failed to delete report");
+    return { error: "Failed to delete report" };
   }
-  redirect("/admin?ts=" + Date.now() + "&adminTab=Reports");
-  return response.json();
+
+  revalidatePath("/admin?adminTab=Reports");
+  return { success: true };
 }
 
 export async function createBugReport(formData: z.infer<typeof reportSchema>) {

--- a/frontend/testing/lib/actions.test.ts
+++ b/frontend/testing/lib/actions.test.ts
@@ -37,6 +37,7 @@ jest.mock("next/navigation", () => ({
 }));
 
 const { redirect } = require("next/navigation");
+const { revalidatePath } = require("next/cache");
 
 describe("Server Actions", () => {
   let mockS3Send: jest.Mock;
@@ -525,13 +526,13 @@ describe("Server Actions", () => {
   });
 
   describe("deleteReport", () => {
-    it("successfully deletes report and redirects", async () => {
+    it("successfully deletes report and revalidates path", async () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ data: {} }),
       });
 
-      await deleteReport("456");
+      const result = await deleteReport("456");
 
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining("/api/reports/456"),
@@ -539,20 +540,18 @@ describe("Server Actions", () => {
           method: "DELETE",
         }),
       );
-      expect(redirect).toHaveBeenCalledWith(expect.stringContaining("/admin"));
-      expect(redirect).toHaveBeenCalledWith(
-        expect.stringContaining("adminTab=Reports"),
-      );
+      expect(revalidatePath).toHaveBeenCalledWith("/admin?adminTab=Reports");
+      expect(result).toEqual({ success: true });
     });
 
-    it("throws error when response not ok", async () => {
+    it("returns error when response not ok", async () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
       });
 
-      await expect(deleteReport("456")).rejects.toThrow(
-        "Failed to delete report",
-      );
+      const result = await deleteReport("456");
+
+      expect(result).toEqual({ error: "Failed to delete report" });
     });
   });
 

--- a/frontend/tests/components/admin/report.test.tsx
+++ b/frontend/tests/components/admin/report.test.tsx
@@ -91,7 +91,7 @@ describe("ReportBlock", () => {
 
   describe("Delete Functionality", () => {
     it("handles successful report deletion", async () => {
-      (deleteReport as jest.Mock).mockResolvedValue({ error: null });
+      (deleteReport as jest.Mock).mockResolvedValue({ success: true });
 
       render(<ReportBlock report={mockReport} />);
 

--- a/frontend/tests/components/droplets/form.test.tsx
+++ b/frontend/tests/components/droplets/form.test.tsx
@@ -3,20 +3,26 @@ import { ReportBugForm } from "@/components/droplets/reports/bug/form";
 import userEvent from "@testing-library/user-event";
 import { createBugReport } from "@/lib/actions";
 import { toast } from "sonner";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 
 jest.mock("@/lib/actions");
 jest.mock("sonner");
 jest.mock("next/navigation", () => ({
   redirect: jest.fn(),
   usePathname: jest.fn(),
+  useSearchParams: jest.fn(),
 }));
 
 describe("ReportBugForm", () => {
   const mockOnSuccess = jest.fn();
+  const mockGet = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: mockGet,
+    });
+    mockGet.mockReturnValue(null); // Default: no adminTab
   });
 
   it("renders form fields correctly", () => {
@@ -40,162 +46,119 @@ describe("ReportBugForm", () => {
     expect(screen.getByDisplayValue(email)).toBeInTheDocument();
   });
 
-  jest.mock("@/lib/actions");
-  jest.mock("sonner");
-  jest.mock("next/navigation", () => ({
-    redirect: jest.fn(),
-    usePathname: () => "/test-path",
-  }));
+  it("handles successful form submission", async () => {
+    (createBugReport as jest.Mock).mockResolvedValue({ ok: true });
 
-  describe("ReportBugForm", () => {
-    const mockOnSuccess = jest.fn();
+    render(<ReportBugForm onSuccess={mockOnSuccess} />);
 
-    it("handles successful form submission", async () => {
-      (createBugReport as jest.Mock).mockResolvedValue({ ok: true });
+    await userEvent.type(screen.getByPlaceholderText("John Doe"), "Test User");
+    await userEvent.type(
+      screen.getByPlaceholderText("f.last@northeastern.edu"),
+      "test@test.com",
+    );
+    await userEvent.type(
+      screen.getByPlaceholderText("Tell us about the issue..."),
+      "Test description",
+    );
 
-      render(<ReportBugForm onSuccess={mockOnSuccess} />);
+    await userEvent.click(screen.getByText("Submit Report"));
 
-      await userEvent.type(
-        screen.getByPlaceholderText("John Doe"),
-        "Test User",
+    await waitFor(() => {
+      expect(createBugReport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fullName: "Test User",
+          email: "test@test.com",
+          description: "Test description",
+        }),
       );
-      await userEvent.type(
-        screen.getByPlaceholderText("f.last@northeastern.edu"),
-        "test@test.com",
+      expect(mockOnSuccess).toHaveBeenCalled();
+      expect(toast.success).toHaveBeenCalledWith(
+        "Your report has been successfully submitted.",
       );
-      await userEvent.type(
-        screen.getByPlaceholderText("Tell us about the issue..."),
-        "Test description",
-      );
+    });
+  });
 
-      await userEvent.click(screen.getByText("Submit Report"));
-
-      await waitFor(() => {
-        expect(createBugReport).toHaveBeenCalledWith(
-          expect.objectContaining({
-            fullName: "Test User",
-            email: "test@test.com",
-            description: "Test description",
-          }),
-        );
-        expect(mockOnSuccess).toHaveBeenCalled();
-        expect(toast.success).toHaveBeenCalledWith(
-          "Your report has been successfully submitted.",
-        );
-      });
+  it("handles failed form submission", async () => {
+    (createBugReport as jest.Mock).mockResolvedValue({
+      ok: false,
+      error: "Test error",
     });
 
-    it("handles failed form submission", async () => {
-      (createBugReport as jest.Mock).mockResolvedValue({
-        ok: false,
-        error: "Test error",
-      });
+    render(<ReportBugForm onSuccess={mockOnSuccess} />);
 
-      render(<ReportBugForm onSuccess={mockOnSuccess} />);
+    await userEvent.type(screen.getByPlaceholderText("John Doe"), "Test User");
+    await userEvent.type(
+      screen.getByPlaceholderText("f.last@northeastern.edu"),
+      "test@test.com",
+    );
+    await userEvent.type(
+      screen.getByPlaceholderText("Tell us about the issue..."),
+      "Test description",
+    );
 
-      await userEvent.type(
-        screen.getByPlaceholderText("John Doe"),
-        "Test User",
-      );
-      await userEvent.type(
-        screen.getByPlaceholderText("f.last@northeastern.edu"),
-        "test@test.com",
-      );
-      await userEvent.type(
-        screen.getByPlaceholderText("Tell us about the issue..."),
-        "Test description",
-      );
+    await userEvent.click(screen.getByText("Submit Report"));
 
-      await userEvent.click(screen.getByText("Submit Report"));
-
-      await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith(
-          "Uh oh! Something went wrong.",
-          {
-            description: "Test error",
-          },
-        );
-      });
-    });
-
-    it("handles failed form submission no error", async () => {
-      (createBugReport as jest.Mock).mockResolvedValue({ ok: false });
-
-      render(<ReportBugForm onSuccess={mockOnSuccess} />);
-
-      await userEvent.type(
-        screen.getByPlaceholderText("John Doe"),
-        "Test User",
-      );
-      await userEvent.type(
-        screen.getByPlaceholderText("f.last@northeastern.edu"),
-        "test@test.com",
-      );
-      await userEvent.type(
-        screen.getByPlaceholderText("Tell us about the issue..."),
-        "Test description",
-      );
-
-      await userEvent.click(screen.getByText("Submit Report"));
-
-      await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith(
-          "Uh oh! Something went wrong.",
-          {
-            description: "",
-          },
-        );
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Uh oh! Something went wrong.", {
+        description: "Test error",
       });
     });
   });
 
-  jest.mock("next/navigation", () => ({
-    usePathname: jest.fn(),
-    redirect: jest.fn(),
-  }));
+  it("handles failed form submission no error", async () => {
+    (createBugReport as jest.Mock).mockResolvedValue({ ok: false });
 
-  describe("ReportBugForm", () => {
-    const mockOnSuccess = jest.fn();
+    render(<ReportBugForm onSuccess={mockOnSuccess} />);
 
-    beforeEach(() => {
-      jest.clearAllMocks();
+    await userEvent.type(screen.getByPlaceholderText("John Doe"), "Test User");
+    await userEvent.type(
+      screen.getByPlaceholderText("f.last@northeastern.edu"),
+      "test@test.com",
+    );
+    await userEvent.type(
+      screen.getByPlaceholderText("Tell us about the issue..."),
+      "Test description",
+    );
+
+    await userEvent.click(screen.getByText("Submit Report"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Uh oh! Something went wrong.", {
+        description: "",
+      });
+    });
+  });
+
+  describe("path field initialization", () => {
+    it("uses pathname when available", () => {
+      (usePathname as jest.Mock).mockReturnValue("/test-path");
+
+      render(<ReportBugForm onSuccess={mockOnSuccess} />);
+
+      const pathInput = screen.getByLabelText(/path/i);
+      expect(pathInput).toHaveValue("/test-path");
     });
 
-    describe("path field initialization", () => {
-      it("uses pathname when available", () => {
-        (usePathname as jest.Mock).mockReturnValue("/test-path");
+    it('uses "Unknown" when pathname is null', async () => {
+      (usePathname as jest.Mock).mockReturnValue(null);
 
-        render(<ReportBugForm onSuccess={mockOnSuccess} />);
+      const { rerender } = render(<ReportBugForm onSuccess={mockOnSuccess} />);
 
-        const pathInput = screen.getByLabelText(/path/i);
-        expect(pathInput).toHaveValue("/test-path");
-      });
+      rerender(<ReportBugForm onSuccess={mockOnSuccess} />);
 
-      it('uses "Unknown" when pathname is null', async () => {
-        (usePathname as jest.Mock).mockReturnValue(null);
+      const pathInput = await screen.findByLabelText(/path/i);
+      expect(pathInput).toHaveValue("Unknown");
+    });
 
-        const { rerender } = render(
-          <ReportBugForm onSuccess={mockOnSuccess} />,
-        );
+    it('uses "Unknown" when pathname is undefined', async () => {
+      (usePathname as jest.Mock).mockReturnValue(undefined);
 
-        rerender(<ReportBugForm onSuccess={mockOnSuccess} />);
+      const { rerender } = render(<ReportBugForm onSuccess={mockOnSuccess} />);
 
-        const pathInput = await screen.findByLabelText(/path/i);
-        expect(pathInput).toHaveValue("Unknown");
-      });
+      rerender(<ReportBugForm onSuccess={mockOnSuccess} />);
 
-      it('uses "Unknown" when pathname is undefined', async () => {
-        (usePathname as jest.Mock).mockReturnValue(undefined);
-
-        const { rerender } = render(
-          <ReportBugForm onSuccess={mockOnSuccess} />,
-        );
-
-        rerender(<ReportBugForm onSuccess={mockOnSuccess} />);
-
-        const pathInput = await screen.findByLabelText(/path/i);
-        expect(pathInput).toHaveValue("Unknown");
-      });
+      const pathInput = await screen.findByLabelText(/path/i);
+      expect(pathInput).toHaveValue("Unknown");
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added a toast popup when a bug report is deleted. Also fixed revalidation for when a report is submitted when on the admin page.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ x] My code follows the code style of this project.
- [x ] I have moved the ticket to "In Review"
- [x ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Report deletion now shows correct success/error notifications using the updated response shape and returns structured errors when deletion fails.

* **Improvements**
  * Admin tab selection is preserved when submitting bug reports and returning to the admin view.
  * Delete flow now triggers page revalidation so deletions appear immediately.

* **Tests**
  * Updated tests to match the new response shape, revalidation behavior, and admin-tab handling.

* **Style**
  * Minor CSS formatting cleanup (no user-visible changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->