### PR TITLE
ODY-228 fix sidebar hover expanding

### DIFF
--- a/frontend/components/droplets/sidebar.tsx
+++ b/frontend/components/droplets/sidebar.tsx
@@ -178,7 +178,6 @@ export default function Sidebar({
           type="button"
           className="fixed top-[120px] left-3 z-40 hidden items-center rounded-lg bg-white p-3 text-slate-800 shadow-md transition-all hover:scale-110 hover:bg-slate-100 focus:ring-2 focus:ring-slate-200 focus:outline-none xl:inline-flex dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700 dark:focus:ring-slate-600"
           onClick={() => setExpanded(true)}
-          onMouseEnter={() => setExpanded(true)}
         >
           <PanelRightClose className="h-6 w-6 dark:text-white" />
           <span className="sr-only">Open sidebar</span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Sidebar no longer expands on hover, only on click. 


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):
<img width="638" height="818" alt="Screenshot 2025-11-24 at 9 29 06 AM" src="https://github.com/user-attachments/assets/00c9ac90-ef2b-45ec-9ec0-6f69a5fc5f0b" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed auto-expand behavior when hovering over the sidebar toggle button on desktop. The sidebar now only expands when explicitly clicked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->