### PR TITLE
ODY-229 notes bar content formatting issue

### DIFF
--- a/frontend/components/droplets/lessons/droplet-lesson-wrapper.tsx
+++ b/frontend/components/droplets/lessons/droplet-lesson-wrapper.tsx
@@ -63,7 +63,7 @@ export function DropletLessonWrapper({
     <>
       <div className="lesson-wrapper relative z-30 h-full w-full overflow-x-hidden">
         <div
-          className={`flex flex-col items-center justify-center pr-10 pl-10 md:min-w-[500px] xl:pl-0 ${expanded ? "w-[65%]" : "w-full"}`}
+          className={`flex w-full flex-col items-center justify-center pr-10 pl-10 md:min-w-[500px] xl:pl-0`}
         >
           <LessonRenderer
             lesson={lesson}

--- a/frontend/components/droplets/lessons/droplet-lesson-wrapper.tsx
+++ b/frontend/components/droplets/lessons/droplet-lesson-wrapper.tsx
@@ -89,9 +89,7 @@ export function DropletLessonWrapper({
               className={cn(
                 "absolute h-full min-h-screen min-w-[375px] border border-slate-200 bg-slate-50 dark:border-slate-500 dark:bg-slate-800",
                 "sliding-notes-bar z-10 overflow-y-hidden",
-                expanded
-                  ? "visibility: visible top-0 right-0"
-                  : "visibility: hidden",
+                expanded ? "visible top-0 right-0" : "invisible",
               )}
             >
               <div className="flex items-center justify-end border-b border-slate-200 p-4 dark:border-slate-500">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Opening the notes bar no longer collapses the lesson content. This ensures that there won't be any formatting or overlap issues between the sidebars and the content. 


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Lesson wrapper now always displays at full width, removing dynamic width changes.
  * Notes panel visibility handling updated for more consistent show/hide behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->