### PR TITLE
ODY-236 updated authorized user to have the isPublic field as optional

### DIFF
--- a/backend/src/api/authorized-user/content-types/authorized-user/schema.json
+++ b/backend/src/api/authorized-user/content-types/authorized-user/schema.json
@@ -207,7 +207,7 @@
     "isPublic": {
       "type": "boolean",
       "default": false,
-      "required": true
+      "required": false
     },
     "dropletsFavorited": {
       "type": "relation",

--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -11,7 +11,7 @@
       "url": "https://khouryodyssey.org"
     },
     "license": null,
-    "x-generation-date": "2025-11-20T16:38:55.167Z"
+    "x-generation-date": "2025-11-24T19:28:35.972Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -3635,8 +3635,7 @@
           "data": {
             "required": [
               "email",
-              "isEnabled",
-              "isPublic"
+              "isEnabled"
             ],
             "type": "object",
             "properties": {
@@ -4066,8 +4065,7 @@
         "type": "object",
         "required": [
           "email",
-          "isEnabled",
-          "isPublic"
+          "isEnabled"
         ],
         "properties": {
           "email": {
@@ -5088,6 +5086,9 @@
                                                                                     }
                                                                                   }
                                                                                 }
+                                                                              },
+                                                                              "orderIndex": {
+                                                                                "type": "integer"
                                                                               },
                                                                               "createdAt": {
                                                                                 "type": "string",
@@ -32413,6 +32414,9 @@
                   ],
                   "example": "string or id"
                 }
+              },
+              "orderIndex": {
+                "type": "integer"
               }
             }
           }
@@ -35372,6 +35376,9 @@
                 }
               }
             }
+          },
+          "orderIndex": {
+            "type": "integer"
           },
           "createdAt": {
             "type": "string",
@@ -38405,6 +38412,9 @@
                             }
                           }
                         }
+                      },
+                      "orderIndex": {
+                        "type": "integer"
                       },
                       "createdAt": {
                         "type": "string",

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -619,9 +619,7 @@ export interface ApiAuthorizedUserAuthorizedUser extends Schema.CollectionType {
     isEnabled: Attribute.Boolean &
       Attribute.Required &
       Attribute.DefaultTo<true>;
-    isPublic: Attribute.Boolean &
-      Attribute.Required &
-      Attribute.DefaultTo<false>;
+    isPublic: Attribute.Boolean & Attribute.DefaultTo<false>;
     lastName: Attribute.String;
     linkedin: Attribute.String;
     playlists: Attribute.Relation<


### PR DESCRIPTION
Made optional field of isPublic for an authorizedUser type in strapi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added orderIndex integer field to enable flexible item ordering and organization across multiple object schemas.
  * The isPublic field is now optional, providing greater flexibility in object creation and configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->