### PR TITLE
Bug/ody 238 issue with preview url

### DIFF
--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -245,7 +245,7 @@ export function Sidebar({
             <div className="flex w-full flex-col gap-2 pb-2">
               <Link
                 className="rounded-full bg-purple-400 px-6 py-2 text-center text-black hover:bg-purple-500 dark:bg-purple-600 dark:text-white dark:hover:bg-purple-800"
-                href={`/d/${pathname.split('/d/')[1]?.split('/')[0]}`}
+                href={`/d/${pathname.split('/d/')[1]}`}
               >
                 Preview
               </Link>

--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -245,7 +245,7 @@ export function Sidebar({
             <div className="flex w-full flex-col gap-2 pb-2">
               <Link
                 className="rounded-full bg-purple-400 px-6 py-2 text-center text-black hover:bg-purple-500 dark:bg-purple-600 dark:text-white dark:hover:bg-purple-800"
-                href={`/d/${pathname.split("d/")[1]}`}
+                href={`/d/${pathname.split('/d/')[1]?.split('/')[0]}`}
               >
                 Preview
               </Link>

--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -245,7 +245,7 @@ export function Sidebar({
             <div className="flex w-full flex-col gap-2 pb-2">
               <Link
                 className="rounded-full bg-purple-400 px-6 py-2 text-center text-black hover:bg-purple-500 dark:bg-purple-600 dark:text-white dark:hover:bg-purple-800"
-                href={`/d/${pathname.split('/d/')[1]}`}
+                href={`/d/${pathname.split("/d/")[1]}`}
               >
                 Preview
               </Link>


### PR DESCRIPTION
Used two splits for the href link of the preview button to ensure that only the route to the droplet is what is being referenced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar Preview link so the draft URL slug is correctly extracted and Preview links reliably open the intended draft.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->