### PR TITLE
fixed favorite layout

### DIFF
--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -11,7 +11,7 @@
       "url": "https://khouryodyssey.org"
     },
     "license": null,
-    "x-generation-date": "2025-11-26T02:06:19.495Z"
+    "x-generation-date": "2025-12-01T14:10:21.021Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -316,7 +316,7 @@ ${
     <Link
       href={(droplet.status == "draft" ? `/draft` : "") + `/d/${droplet.slug}`}
     >
-      <li className="h-full rounded-md border border-slate-200 bg-slate-50 p-2 transition-colors hover:border-slate-300 dark:border-slate-500 dark:bg-slate-800">
+      <li className="h-full overflow-hidden rounded-md border border-slate-200 bg-slate-50 p-2 transition-colors hover:border-slate-300 dark:border-slate-500 dark:bg-slate-800">
         <div className="flex h-full flex-col justify-between gap-3 p-4">
           <div className="space-y-3">
             <div className="flex flex-0 flex-row flex-wrap gap-1.5">
@@ -418,11 +418,11 @@ ${
           </div>
 
           {/* Bottom section with ratings, favorite button, and archive button */}
-          <div className="flex items-center justify-between gap-2">
+          <div className="flex w-full flex-nowrap items-center justify-between gap-2">
             {/* Left side - ratings */}
-            <div className="flex items-center">
+            <div className="flex min-w-0 items-center">
               {droplet.averageRating && droplet.averageRating != 0.0 ? (
-                <div className="origin-left scale-[0.55]">
+                <div className="max-w-full origin-left scale-[0.55]">
                   <StarRating
                     value={droplet.averageRating || 0}
                     enrollmentID={""}
@@ -434,7 +434,7 @@ ${
             </div>
 
             {/* Right side - favorite and archive buttons */}
-            <div className="flex items-center gap-2">
+            <div className="ml-2 flex flex-shrink-0 items-center gap-2">
               <Button
                 size="sm"
                 onClick={(e) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Made the favorite icon stay within the droplet tile even if there is a droplet rating.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Star ratings now support average rendering mode with enhanced display consistency.

* **Style**
  * Improved layout and spacing for better visual alignment of ratings and action controls, with enhanced overflow handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->