### PR TITLE
ODY-244 fix droplet tag darkmode text styling

### DIFF
--- a/frontend/components/draft/metadata/clickable-badges.tsx
+++ b/frontend/components/draft/metadata/clickable-badges.tsx
@@ -203,7 +203,7 @@ export function ClickableBadges({
           onClick={() => setActivePopup("focusArea")}
           disabled={isPending}
         >
-          <Badge className="h-full border border-slate-300 bg-purple-200 text-black hover:bg-purple-400 dark:bg-purple-600 dark:hover:bg-purple-400">
+          <Badge className="h-full border border-slate-300 bg-purple-200 text-black hover:bg-purple-400 dark:bg-purple-600 dark:text-white dark:hover:bg-purple-400">
             {uppercaseFirstChar(localFocusArea)}
           </Badge>
         </button>
@@ -249,7 +249,7 @@ export function ClickableBadges({
           onClick={() => setActivePopup("type")}
           disabled={isPending}
         >
-          <Badge className="h-full border border-slate-300 bg-blue-200 text-black hover:bg-blue-400 dark:bg-blue-900 dark:hover:bg-blue-400">
+          <Badge className="h-full border border-slate-300 bg-blue-200 text-black hover:bg-blue-400 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-400">
             {uppercaseFirstChar(localType)}
           </Badge>
         </button>
@@ -296,7 +296,7 @@ export function ClickableBadges({
           disabled={isPending}
           className="h-full"
         >
-          <Badge className="h-full border border-slate-300 bg-transparent text-black hover:bg-red-300">
+          <Badge className="h-full border border-slate-300 bg-transparent text-black hover:bg-red-300 dark:text-white">
             {tag.name}
           </Badge>
         </button>
@@ -308,7 +308,7 @@ export function ClickableBadges({
           onClick={() => setActivePopup("addTag")}
           disabled={isPending}
         >
-          <div className="flex h-full flex-row items-center text-black">
+          <div className="flex h-full flex-row items-center text-black dark:text-white">
             <Plus className="h-4 w-4" />
             <p>Add Tag</p>
           </div>

--- a/frontend/components/draft/metadata/clickable-badges.tsx
+++ b/frontend/components/draft/metadata/clickable-badges.tsx
@@ -249,7 +249,7 @@ export function ClickableBadges({
           onClick={() => setActivePopup("type")}
           disabled={isPending}
         >
-          <Badge className="h-full border border-slate-300 bg-blue-200 text-black hover:bg-blue-400 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-400">
+          <Badge className="dark:text-whitegit h-full border border-slate-300 bg-blue-200 text-black hover:bg-blue-400 dark:bg-blue-900">
             {uppercaseFirstChar(localType)}
           </Badge>
         </button>

--- a/frontend/components/draft/metadata/clickable-badges.tsx
+++ b/frontend/components/draft/metadata/clickable-badges.tsx
@@ -249,7 +249,7 @@ export function ClickableBadges({
           onClick={() => setActivePopup("type")}
           disabled={isPending}
         >
-          <Badge className="dark:text-whitegit h-full border border-slate-300 bg-blue-200 text-black hover:bg-blue-400 dark:bg-blue-900">
+          <Badge className="dark:text-whitegit h-full border border-slate-300 bg-blue-200 text-black hover:bg-blue-400 dark:bg-blue-900 dark:text-white">
             {uppercaseFirstChar(localType)}
           </Badge>
         </button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed droplet tag styling in dark mode to be visible. Tag text should now be white and legible.

## Motivation and Context

Previously, the text was black, and difficult to read.


## Screenshots (if appropriate):
<img width="553" height="101" alt="Screenshot 2025-12-02 at 1 22 19 PM" src="https://github.com/user-attachments/assets/bcf98f2e-0c84-4214-b2a8-61155d13d451" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved dark-mode text contrast on badges and related tag controls for better readability.
  * Minor styling bug: one badge contains an invalid style token which may cause inconsistent text color or unexpected appearance in dark mode; will be corrected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->