### PR TITLE
ODY-268 fixed styling so that notes bar is always on right

### DIFF
--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -11,7 +11,7 @@
       "url": "https://khouryodyssey.org"
     },
     "license": null,
-    "x-generation-date": "2025-12-12T17:47:41.351Z"
+    "x-generation-date": "2025-12-16T14:23:02.265Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/frontend/components/droplets/lessons/droplet-lesson-wrapper.tsx
+++ b/frontend/components/droplets/lessons/droplet-lesson-wrapper.tsx
@@ -63,7 +63,7 @@ export function DropletLessonWrapper({
     <>
       <div className="lesson-wrapper relative z-30 h-full w-full overflow-x-hidden">
         <div
-          className={`flex w-full flex-col items-center justify-center pl-10 pr-10 md:min-w-[500px] xl:pl-0`}
+          className={`flex w-full flex-col items-center justify-center pr-10 pl-10 md:min-w-[500px] xl:pl-0`}
         >
           <LessonRenderer
             lesson={lesson}

--- a/frontend/components/droplets/lessons/droplet-lesson-wrapper.tsx
+++ b/frontend/components/droplets/lessons/droplet-lesson-wrapper.tsx
@@ -63,7 +63,7 @@ export function DropletLessonWrapper({
     <>
       <div className="lesson-wrapper relative z-30 h-full w-full overflow-x-hidden">
         <div
-          className={`flex w-full flex-col items-center justify-center pr-10 pl-10 md:min-w-[500px] xl:pl-0`}
+          className={`flex w-full flex-col items-center justify-center pl-10 pr-10 md:min-w-[500px] xl:pl-0`}
         >
           <LessonRenderer
             lesson={lesson}
@@ -87,9 +87,9 @@ export function DropletLessonWrapper({
           <>
             <div
               className={cn(
-                "absolute h-full min-h-screen min-w-[375px] border border-slate-200 bg-slate-50 dark:border-slate-500 dark:bg-slate-800",
+                "absolute inset-y-0 right-0 min-w-[375px] border border-slate-200 bg-slate-50 dark:border-slate-500 dark:bg-slate-800",
                 "sliding-notes-bar z-10 overflow-y-hidden",
-                expanded ? "visible top-0 right-0" : "invisible",
+                expanded ? "visible" : "invisible",
               )}
             >
               <div className="flex items-center justify-end border-b border-slate-200 p-4 dark:border-slate-500">


### PR DESCRIPTION
Changed styling of div wrapping notes bar, so that the preview of lessons wouldn't have unnecessary whitespace below the "Next Lesson" buttons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined lesson panel positioning and visibility handling to improve layout consistency and expansion behavior.
  * Adjusted padding/alignment in the lesson wrapper for more consistent content presentation.

* **Documentation**
  * Updated generated documentation metadata timestamp.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->