### PR TITLE
ODY-258 fix styling in callout blocks, removed tags

### DIFF
--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -82,8 +82,14 @@ type BlockNoteInlineContent = {
 };
 
 // Strapi Blocks text node (minimal subset we care about)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type StrapiBlocksTextNode = Record<string, any>;
+type StrapiBlocksTextNode = {
+  type: "text";
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  code?: boolean;
+};
 
 type BlockNoteListItem = {
   type: string;

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -81,6 +81,10 @@ type BlockNoteInlineContent = {
   styles?: BlockNoteTextStyles;
 };
 
+// Strapi Blocks text node (minimal subset we care about)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type StrapiBlocksTextNode = Record<string, any>;
+
 type BlockNoteListItem = {
   type: string;
   content?: BlockNoteInlineContent[];
@@ -144,6 +148,33 @@ function convertInlineContentToHtml(
       })
       .join("") || ""
   );
+}
+
+// Helper: convert BlockNote inline content into Strapi Blocks text nodes
+function convertInlineContentToStrapiBlocks(
+  inlineContent: BlockNoteInlineContent[],
+): StrapiBlocksTextNode[] {
+  return inlineContent.map((contentItem) => {
+    const text = contentItem.text ?? "";
+
+    // Base Strapi "text" node
+    const node: StrapiBlocksTextNode = {
+      type: "text",
+      text,
+    };
+
+    const styles = contentItem.styles;
+    if (styles) {
+      if (styles.bold) node.bold = true;
+      if (styles.italic) node.italic = true;
+      if (styles.underline) node.underline = true;
+      if (styles.code) node.code = true;
+
+      // For now we keep LaTeX as plain text – it's rendered later by GenericBlockRenderer
+    }
+
+    return node;
+  });
 }
 
 // Helper function to convert inline content to plain text (for markdown)
@@ -547,7 +578,8 @@ function convertSingleBlock(blockAny: any, blockIndex: number): Block | null {
 
       const calloutContent = (blockAny.content ??
         []) as BlockNoteInlineContent[];
-      const calloutText = convertInlineContentToHtml(calloutContent);
+      const calloutChildren =
+        convertInlineContentToStrapiBlocks(calloutContent);
 
       return {
         __component: "droplets.callout",
@@ -555,7 +587,7 @@ function convertSingleBlock(blockAny: any, blockIndex: number): Block | null {
         content: [
           {
             type: "paragraph",
-            children: [{ type: "text", text: calloutText }],
+            children: calloutChildren,
           },
         ],
         color:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed callout blocks to not show tags with bolded or italicized text.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):
<img width="961" height="315" alt="Screenshot 2025-12-15 at 12 03 40 PM" src="https://github.com/user-attachments/assets/1aad5e14-eb46-4dc6-acfe-8aadb0108ca7" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved callout rendering to use a structured content representation so inline formatting (bold, italic, underline, code) is preserved and displayed more accurately in callouts. No other block rendering behavior visible to users was changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->