### PR TITLE
allowed for multiple answer selection

### DIFF
--- a/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
@@ -209,10 +209,13 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
       };
 
       const handleOptionCorrectChange = (id: string) => {
-        const updatedOptions = options.map((opt: AnswerOption) => ({
-          ...opt,
-          isCorrect: opt.id === id,
-        }));
+        const updatedOptions = options.map(
+          (opt: AnswerOption) =>
+            opt.id === id
+              ? { ...opt, isCorrect: !opt.isCorrect } // toggle this one
+              : opt, // leave others unchanged
+        );
+
         props.editor.updateBlock(props.block, {
           props: {
             options: updatedOptions,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
For multiple choice questions in blocknote, allow the content creator to set multiple answers to be correct

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multiple-choice quiz block option handling: Clicking options now correctly toggles their selection state instead of always marking the selected option as correct.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->