### PR TITLE
made sidebar collapsable for drafts

### DIFF
--- a/frontend/app/(editing)/draft/d/[slug]/[lessonSlug]/page.tsx
+++ b/frontend/app/(editing)/draft/d/[slug]/[lessonSlug]/page.tsx
@@ -65,7 +65,7 @@ export default async function Lesson({ params }: Props) {
   if (!lesson) return notFound();
 
   return (
-    <div className="xl:-ml-48">
+    <div>
       <LessonRenderer lesson={lesson} dropletSlug={p.slug} />
     </div>
   );

--- a/frontend/app/(editing)/draft/d/[slug]/layout.tsx
+++ b/frontend/app/(editing)/draft/d/[slug]/layout.tsx
@@ -68,13 +68,13 @@ export default async function CheckPermission({ params, children }: Props) {
   });
 
   return (
-    <div className="flex min-h-screen flex-col xl:flex-row md:border-2 md:border-dashed md:border-slate-200 md:dark:border-slate-700">
+    <div className="flex min-h-screen flex-col md:border-2 md:border-dashed md:border-slate-200 xl:flex-row md:dark:border-slate-700">
       <Sidebar
         droplet={droplet}
         user={user}
         availableDroplets={availableDroplets}
       />
-      <main className="mx-auto w-full flex-1 items-center justify-center rounded-lg ">
+      <main className="mx-auto w-full flex-1 items-center justify-center rounded-lg">
         {!droplet.inReview ? (
           <div className="bg-red-100 p-1 text-center dark:bg-red-100 dark:text-black">
             ** Information that you enter will be saved automatically. **

--- a/frontend/app/(editing)/draft/d/[slug]/layout.tsx
+++ b/frontend/app/(editing)/draft/d/[slug]/layout.tsx
@@ -68,13 +68,13 @@ export default async function CheckPermission({ params, children }: Props) {
   });
 
   return (
-    <div className="flex min-h-screen flex-col xl:flex-row">
+    <div className="flex min-h-screen flex-col xl:flex-row md:border-2 md:border-dashed md:border-slate-200 md:dark:border-slate-700">
       <Sidebar
         droplet={droplet}
         user={user}
         availableDroplets={availableDroplets}
       />
-      <main className="mx-auto w-full flex-1 items-center justify-center rounded-lg md:border-2 md:border-dashed md:border-slate-200 md:dark:border-slate-700">
+      <main className="mx-auto w-full flex-1 items-center justify-center rounded-lg ">
         {!droplet.inReview ? (
           <div className="bg-red-100 p-1 text-center dark:bg-red-100 dark:text-black">
             ** Information that you enter will be saved automatically. **

--- a/frontend/components/draft/lesson/lesson-renderer.tsx
+++ b/frontend/components/draft/lesson/lesson-renderer.tsx
@@ -354,7 +354,7 @@ export function LessonRenderer({ lesson, dropletSlug }: LessonRendererProps) {
 
   return (
     <>
-      <div className="mb-5 flex flex-col items-center justify-start rounded-md border border-slate-200 px-4 pt-4 pb-7 dark:border-slate-500">
+      <div className="mb-5 flex flex-col items-center justify-start rounded-md px-4 pt-4 pb-7">
         <LessonNameInput
           className="mb-3 w-[700px] max-w-2xl text-center"
           initialContent={`<h1>${name}</h1>`}

--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -198,7 +198,6 @@ export function Sidebar({
           onClick={() => setExpanded(true)}
         >
           <PanelRightClose className="h-6 w-6 dark:text-white" />
-          <span className="sr-only">Open sidebar</span>
         </button>
       )}
       <aside

--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -70,7 +70,7 @@ export function Sidebar({
   >;
   availableDroplets: Pick<Droplet, "id" | "name" | "slug" | "lessons">[];
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(true);
   const pathname = usePathname();
 
   const {
@@ -86,8 +86,17 @@ export function Sidebar({
     .sort((a, b) => a.orderIndex - b.orderIndex);
 
   useLayoutEffect(() => {
-    window.addEventListener("resize", () => setExpanded(false));
-    return () => window.removeEventListener("resize", () => setExpanded(false));
+    const handleResize = () => {
+      // Auto-collapse sidebar on mobile screens
+      if (window.innerWidth < 1280) {
+        setExpanded(false);
+      }
+    };
+
+    handleResize();
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   const handleDropletPost = async () => {
@@ -155,8 +164,8 @@ export function Sidebar({
     <>
       <div
         className={cn(
-          "fixed inset-0 bg-slate-900/50 transition-opacity dark:bg-slate-900/80",
-          expanded ? "z-30 opacity-1" : "-z-10 opacity-0",
+          "fixed inset-0 bg-slate-900/50 transition-opacity xl:hidden dark:bg-slate-900/80",
+          expanded ? "z-30 opacity-100" : "-z-10 opacity-0",
         )}
         onClick={() => setExpanded(false)}
       />
@@ -181,12 +190,22 @@ export function Sidebar({
           {droplet.name}
         </Link>
       </div>
-
+      {!expanded && (
+        <button
+          aria-controls="sidebar"
+          type="button"
+          className="fixed top-[120px] left-3 z-40 hidden items-center rounded-lg bg-white p-3 text-slate-800 shadow-md transition-all hover:scale-110 hover:bg-slate-100 focus:ring-2 focus:ring-slate-200 focus:outline-none xl:inline-flex dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700 dark:focus:ring-slate-600"
+          onClick={() => setExpanded(true)}
+        >
+          <PanelRightClose className="h-6 w-6 dark:text-white" />
+          <span className="sr-only">Open sidebar</span>
+        </button>
+      )}
       <aside
         id="sidebar"
         className={cn(
           "fixed left-0 z-40 h-screen w-64 transition-transform xl:sticky xl:top-0",
-          expanded ? "translate-x-0" : "-translate-x-full xl:translate-x-0",
+          expanded ? "translate-x-0" : "-translate-x-full",
         )}
         aria-label="Sidebar"
       >
@@ -211,10 +230,7 @@ export function Sidebar({
               </Button>
               <div className="w-full"></div>
 
-              <button
-                onClick={() => setExpanded(false)}
-                className={`xl:hidden`}
-              >
+              <button onClick={() => setExpanded(false)}>
                 <PanelRightOpen />
               </button>
             </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Made sidebar collapsable for draft droplets

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a button to open the sidebar when collapsed on smaller screens.

* **Bug Fixes**
  * Improved sidebar collapse behavior to trigger only at specific viewport widths rather than on every resize.

* **Style**
  * Sidebar now expands by default.
  * Adjusted border styling in the lesson editor layout.
  * Refined responsive margin and overlay styling for better visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->