### PR TITLE
Dockerfile updated to match prod

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,9 +2,9 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-COPY package.json ./
+COPY package*.json ./
 
-RUN npm install --legacy-peer-deps
+RUN npm install --include=dev
 
 COPY . .
 


### PR DESCRIPTION
## Description

Fixed the local development Dockerfile to include package-lock.json in the COPY step and reverted the install command from npm install --legacy-peer-deps to npm install --include=dev. Without the lock file, npm was resolving the dependency tree fresh on each build, hoisting @tiptap/extension-gapcursor v2 to the top level instead of keeping v3 nested under @blocknote/core.    

## Motivation and Context

Editing a lesson locally caused a runtime error: Attempted import error: 'Gapcursor' is not exported from '@tiptap/extension-gapcursor'. This happened because @blocknote/core depends on tiptap v3, but without the lock file, npm hoisted the project's tiptap v2 to the top level. BlockNote then resolved the v2 gapcursor instead of its own nested v3 copy, which has a different export structure. Including the lock file ensures the dependency tree matches what works in CI and production.



## Checklist:

- [X] My code follows the code style of this project.
- [X] I have moved the ticket to "In Review"
- [X] I have added reviewers to this PR
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include development dependencies and package lock files when available during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->