### PR TITLE
ODY-302 Reduce over-fetching in getAuthorizedUserByEmail with populat…

### DIFF
--- a/frontend/app/(droplets)/d/[slug]/recap/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/recap/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { StarRating } from "@/components/ui/rating-stars";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { USER_POPULATES } from "@/lib/requests/user-populates";
 import {
   getEnrollmentsByAuthorizedUser,
   updateCompletionDate,
@@ -106,7 +107,10 @@ export default async function DropletRecapRoute({ params }: Props) {
       },
     });
 
-    const authUser = await getAuthorizedUserByEmail(user.email);
+    const authUser = await getAuthorizedUserByEmail(
+      user.email,
+      USER_POPULATES.profile,
+    );
     let enrollID: string = "";
     const highlights = await getHighlightsByDroplet(authUser.id, droplet.id);
     const notes = await getNotesByDroplet(authUser.id, droplet.id);

--- a/frontend/app/(general)/dashboard/page.tsx
+++ b/frontend/app/(general)/dashboard/page.tsx
@@ -14,6 +14,7 @@ import {
   sorting,
 } from "@/lib/globals";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { USER_POPULATES } from "@/lib/requests/user-populates";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { getUserGroups } from "@/lib/requests/groups";
 import { notFound } from "next/navigation";
@@ -34,7 +35,10 @@ export default async function DashboardRoute({ searchParams }: Props) {
     return notFound();
   }
   const { sortKey } = sorting.find((item) => item.slug === sort) || defaultSort;
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getAuthorizedUserByEmail(
+    user.email,
+    USER_POPULATES.dashboard,
+  );
   const archivedPlaylists = authorizedUser.playlists?.filter((playlist) =>
     playlist.users_archived?.some((user) => user.id === authorizedUser.id),
   );

--- a/frontend/app/(general)/feed/page.tsx
+++ b/frontend/app/(general)/feed/page.tsx
@@ -3,6 +3,7 @@ import { FeedContainer } from "@/components/feed/feed-container";
 import { notFound } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { USER_POPULATES } from "@/lib/requests/user-populates";
 
 export const metadata: Metadata = {
   title: "Feed",
@@ -13,7 +14,10 @@ export const revalidate = 0;
 export default async function FeedPage() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return notFound();
-  const authUser = await getAuthorizedUserByEmail(user.email);
+  const authUser = await getAuthorizedUserByEmail(
+    user.email,
+    USER_POPULATES.social,
+  );
 
   return (
     <>

--- a/frontend/app/(general)/my-content/page.tsx
+++ b/frontend/app/(general)/my-content/page.tsx
@@ -15,6 +15,7 @@ import { Separator } from "@/components/ui/separator";
 import { Metadata } from "next";
 import { PlaylistCard } from "@/components/playlists/playlist-card";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { USER_POPULATES } from "@/lib/requests/user-populates";
 
 export const metadata: Metadata = {
   title: "Create",
@@ -31,7 +32,10 @@ export default async function CreateRoute() {
       !isAuthorizedUserFaculty(user.roles))
   )
     redirect("/unauthorized");
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getAuthorizedUserByEmail(
+    user.email,
+    USER_POPULATES.creation,
+  );
 
   const playlists = authorizedUser.created_playlists;
 

--- a/frontend/app/(general)/prof/[username]/page.tsx
+++ b/frontend/app/(general)/prof/[username]/page.tsx
@@ -1,4 +1,5 @@
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { USER_POPULATES } from "@/lib/requests/user-populates";
 import { AuthorizedUser, Enrollment } from "@/types";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { fetchFriends } from "@/lib/requests/friends";
@@ -17,7 +18,13 @@ export default async function PublicProfilePage({
   try {
     const userEmail = username + "@northeastern.edu";
     const currentUser = await getCurrentUser();
-    const userData: AuthorizedUser = await getAuthorizedUserByEmail(userEmail);
+    const userData: AuthorizedUser = await getAuthorizedUserByEmail(userEmail, {
+      fields: [...USER_POPULATES.social.fields],
+      populate: {
+        ...USER_POPULATES.social.populate,
+        droplets: { fields: ["*"] },
+      },
+    });
     const isViewingOwnProfile = currentUser?.email === userEmail;
 
     if (!userData.isPublic && !isViewingOwnProfile) {
@@ -50,7 +57,10 @@ export default async function PublicProfilePage({
 
     if (currentUser?.email) {
       try {
-        const maybeUserData = await getAuthorizedUserByEmail(currentUser.email);
+        const maybeUserData = await getAuthorizedUserByEmail(
+          currentUser.email,
+          USER_POPULATES.social,
+        );
         if (!maybeUserData || typeof maybeUserData.id !== "number") {
           throw new Error("Current user data is missing a valid id");
         }

--- a/frontend/app/(general)/settings/friends/page.tsx
+++ b/frontend/app/(general)/settings/friends/page.tsx
@@ -7,6 +7,7 @@ import {
   fetchAuthorizedUsers,
   getAuthorizedUserByEmail,
 } from "@/lib/requests/authorized-user";
+import { USER_POPULATES } from "@/lib/requests/user-populates";
 import { FriendSentRequests } from "@/components/friends/friend-sent-requests";
 import { FriendSearch } from "@/components/friends/friend-search";
 import {
@@ -29,7 +30,10 @@ export default async function AuthorProfileSettings({
   const user = await getCurrentUser();
   if (!user?.email) return notFound();
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getAuthorizedUserByEmail(
+    user.email,
+    USER_POPULATES.social,
+  );
   if (!authorizedUser) return notFound();
 
   const sentRequests = await getSentRequestIds(authorizedUser);

--- a/frontend/app/(general)/settings/page.tsx
+++ b/frontend/app/(general)/settings/page.tsx
@@ -13,6 +13,7 @@ import { getCurrentUser } from "@/lib/auth/session";
 import { getInitials, condenseRoleTitles } from "@/lib/utils";
 import { User2Icon } from "lucide-react";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { USER_POPULATES } from "@/lib/requests/user-populates";
 import { AuthorizedUser } from "@/types";
 
 export default async function Settings() {
@@ -21,6 +22,7 @@ export default async function Settings() {
   if (user?.email) {
     authorizedUser = (await getAuthorizedUserByEmail(
       user.email,
+      USER_POPULATES.profile,
     )) as AuthorizedUser;
     if (!authorizedUser?.id) {
       throw new Error("Authorized user not found");

--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { getCurrentUser } from "@/lib/auth/session";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { USER_POPULATES } from "@/lib/requests/user-populates";
 import { getGroupBySlugV2 } from "@/lib/requests/groups";
 import { notFound } from "next/navigation";
 import { MemberList } from "@/components/group/member-list";
@@ -28,7 +29,10 @@ export default async function GroupDetailPage({ params }: Props) {
   const user = await getCurrentUser();
   if (!user?.email) return null;
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getAuthorizedUserByEmail(
+    user.email,
+    USER_POPULATES.profile,
+  );
   if (!authorizedUser) return null;
 
   const p = await params;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,6 +9,7 @@ import "./globals.css";
 import { FirstVisitPopup } from "@/components/first-time/first-visit-popup";
 import { getCurrentUser } from "../lib/auth/session";
 import { getAuthorizedUserByEmail } from "../lib/requests/authorized-user";
+import { USER_POPULATES } from "../lib/requests/user-populates";
 import { ThemeClientProvider } from "@/components/theme.client.provider";
 import AccessRequestBanner from "@/components/requests/access-request-banner";
 import { EnvironmentBanner } from "@/components/debug/environmentBanner";
@@ -41,7 +42,10 @@ export default async function RootLayout({
 
   if (user?.email) {
     try {
-      authorizedUser = await getAuthorizedUserByEmail(user.email);
+      authorizedUser = await getAuthorizedUserByEmail(
+        user.email,
+        USER_POPULATES.profile,
+      );
     } catch (error) {
       console.error("Error fetching authorized user:", error);
     }

--- a/frontend/components/admin/progress/student-progress.tsx
+++ b/frontend/components/admin/progress/student-progress.tsx
@@ -16,7 +16,23 @@ export async function StudentProgress() {
   const user = await getCurrentUser();
   if (!user?.email) return null;
 
-  const author = await getAuthorizedUserByEmail(user.email);
+  const author = await getAuthorizedUserByEmail(user.email, {
+    fields: ["id"],
+    populate: {
+      created_playlists: {
+        fields: ["id", "name"],
+        populate: {
+          authorized_users: { fields: ["id", "email"] },
+          droplets: {
+            fields: ["id"],
+            populate: {
+              lessons: { fields: ["id"] },
+            },
+          },
+        },
+      },
+    },
+  });
   if (!author) return null;
 
   const playlists = author.created_playlists;

--- a/frontend/components/friends/blocked-users.tsx
+++ b/frontend/components/friends/blocked-users.tsx
@@ -1,4 +1,5 @@
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { USER_POPULATES } from "@/lib/requests/user-populates";
 import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
 import { BlockedUsersBlock } from "./blocked-users-block";
@@ -6,7 +7,10 @@ import { BlockedUsersBlock } from "./blocked-users-block";
 export async function BlockedUsers() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return notFound();
-  const authUser = await getAuthorizedUserByEmail(user.email);
+  const authUser = await getAuthorizedUserByEmail(
+    user.email,
+    USER_POPULATES.social,
+  );
   const blockedUsers = authUser.blocked;
 
   return (

--- a/frontend/components/friends/friend-sent-requests.tsx
+++ b/frontend/components/friends/friend-sent-requests.tsx
@@ -1,4 +1,5 @@
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { USER_POPULATES } from "@/lib/requests/user-populates";
 import { FriendSentRequestsBlock } from "./friend-sent-requests-block";
 import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
@@ -6,7 +7,10 @@ import { notFound } from "next/navigation";
 export async function FriendSentRequests() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return notFound();
-  const authUser = await getAuthorizedUserByEmail(user.email);
+  const authUser = await getAuthorizedUserByEmail(
+    user.email,
+    USER_POPULATES.social,
+  );
   const sentRequests = authUser.sent_requests
     .filter(
       (friend) =>

--- a/frontend/components/header/header-wrapper.tsx
+++ b/frontend/components/header/header-wrapper.tsx
@@ -1,6 +1,7 @@
 import { getCurrentUser } from "@/lib/auth/session";
 import { AuthorizedUser } from "@/types";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { USER_POPULATES } from "@/lib/requests/user-populates";
 import { Header } from "./index";
 
 export async function HeaderWrapper() {
@@ -10,6 +11,7 @@ export async function HeaderWrapper() {
   if (user?.email) {
     authorizedUser = (await getAuthorizedUserByEmail(
       user.email,
+      USER_POPULATES.profile,
     )) as AuthorizedUser;
   }
 

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -7,6 +7,7 @@ import qs from "qs";
 import { AuthorizedUserSchema } from "../validations/authorized-user";
 import { getAuthorizedUserRoleIdByTitle } from "./authorized-user-roles";
 import { AuthorizedUserRoleTitle } from "../globals";
+import { USER_POPULATES } from "./user-populates";
 
 const NEXT_PUBLIC_STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -24,96 +25,8 @@ export async function getAuthorizedUserByEmail<
   {
     sort,
     filters,
-    populate = {
-      received_requests: {
-        fields: ["*"],
-      },
-      sent_requests: {
-        fields: ["*"],
-      },
-      blocked: {
-        fields: ["*"],
-      },
-      was_blocked: {
-        fields: ["*"],
-      },
-      droplets: {
-        fields: ["*"],
-      },
-      created_playlists: {
-        fields: ["*"],
-        populate: {
-          droplets: {
-            fields: "*",
-            populate: {
-              lessons: {
-                fields: ["*"], // or just ["id"] if you only need the count
-              },
-            },
-          },
-        },
-      },
-      playlists: {
-        fields: ["*"],
-        populate: {
-          droplets: {
-            fields: "*",
-            populate: {
-              lessons: {
-                fields: ["*"], // or just ["id"] if you only need the count
-              },
-            },
-          },
-          users_archived: {
-            fields: ["*"],
-          },
-        },
-      },
-      friendships: {
-        populate: {
-          authorized_users: {
-            fields: [
-              "id",
-              "email",
-              "firstName",
-              "lastName",
-              "bio",
-              "github",
-              "linkedin",
-              "profilePhoto",
-              "website",
-            ],
-            populate: {
-              blocked: {
-                fields: ["id"],
-              },
-              was_blocked: {
-                fields: ["id"],
-              },
-            },
-          },
-        },
-      },
-      groups: {
-        populate: {
-          playlists: {
-            fields: ["id"],
-          },
-        },
-        fields: ["id"],
-      },
-    },
-    fields = [
-      "*",
-      "firstName",
-      "lastName",
-      "bio",
-      "id",
-      "timeZone",
-      "linkedin",
-      "github",
-      "website",
-    ],
+    populate = USER_POPULATES.minimal.populate,
+    fields = [...USER_POPULATES.minimal.fields],
   }: StrapiRequestParams = {},
 ): Promise<T> {
   const path = `/authorized-users`;

--- a/frontend/lib/requests/user-populates.ts
+++ b/frontend/lib/requests/user-populates.ts
@@ -1,0 +1,90 @@
+const PROFILE_FIELDS = [
+  "id",
+  "email",
+  "firstName",
+  "lastName",
+  "bio",
+  "profilePhoto",
+  "linkedin",
+  "github",
+  "website",
+  "isPublic",
+  "timeZone",
+  "firstTime",
+];
+
+export const USER_POPULATES = {
+  minimal: {
+    fields: ["id", "email"],
+    populate: {},
+  },
+  profile: {
+    fields: PROFILE_FIELDS,
+    populate: {},
+  },
+  social: {
+    fields: PROFILE_FIELDS,
+    populate: {
+      received_requests: { fields: ["*"] },
+      sent_requests: { fields: ["*"] },
+      blocked: { fields: ["*"] },
+      was_blocked: { fields: ["*"] },
+      friendships: {
+        populate: {
+          authorized_users: {
+            fields: [
+              "id",
+              "email",
+              "firstName",
+              "lastName",
+              "bio",
+              "github",
+              "linkedin",
+              "profilePhoto",
+              "website",
+            ],
+            populate: {
+              blocked: { fields: ["id"] },
+              was_blocked: { fields: ["id"] },
+            },
+          },
+        },
+      },
+    },
+  },
+  dashboard: {
+    fields: PROFILE_FIELDS,
+    populate: {
+      playlists: {
+        fields: ["id", "name", "slug"],
+        populate: {
+          users_archived: { fields: ["id"] },
+        },
+      },
+      groups: {
+        fields: ["id"],
+      },
+    },
+  },
+  creation: {
+    fields: PROFILE_FIELDS,
+    populate: {
+      droplets: {
+        fields: ["*"],
+      },
+      created_playlists: {
+        fields: ["*"],
+        populate: {
+          droplets: {
+            fields: ["id", "name", "slug"],
+            populate: {
+              lessons: {
+                fields: ["id"],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/frontend/testing/requests/authorized-users.test.js
+++ b/frontend/testing/requests/authorized-users.test.js
@@ -234,7 +234,6 @@ describe("Authorized User Tests", () => {
         urlParams: expect.objectContaining({
           pagination: { pageSize: 50, page: 2 },
         }),
-        next: expect.any(Object),
         cache: "no-store",
         flattenResponse: false,
       });

--- a/frontend/testing/requests/groups.test.js
+++ b/frontend/testing/requests/groups.test.js
@@ -1733,13 +1733,8 @@ describe("Groups Tests", () => {
             pageSize: 250,
             page: 1,
           },
-          revalidate: 0,
         },
         cache: "no-store",
-        next: {
-          revalidate: 0,
-          tags: ["due-dates"],
-        },
       });
 
       expect(result).toEqual(mockDueDates);
@@ -1858,13 +1853,8 @@ describe("Groups Tests", () => {
             pageSize: 250,
             page: 1,
           },
-          revalidate: 0,
-          cache: "no-store",
         },
-        next: {
-          tags: ["due-dates"],
-          revalidate: 0,
-        },
+        cache: "no-store",
       });
 
       expect(result).toEqual(mockDueDates);

--- a/frontend/tests/components/admin/authorized-user-client.test.tsx
+++ b/frontend/tests/components/admin/authorized-user-client.test.tsx
@@ -26,6 +26,8 @@ describe("AuthorizedUserClient", () => {
     profilePhoto: "",
     blocked: [],
     was_blocked: [],
+    isPublic: true,
+    website: "",
     timeZone: "America/New_York" as TimeZone,
   }));
 

--- a/frontend/tests/components/friends/friend-sent-requests-block.test.tsx
+++ b/frontend/tests/components/friends/friend-sent-requests-block.test.tsx
@@ -31,6 +31,8 @@ describe("FriendSentRequestsBlock", () => {
     received_requests: [],
     blocked: [],
     was_blocked: [],
+    isPublic: true,
+    website: "",
     timeZone: "America/New_York" as TimeZone,
   };
   const mockRequest = {
@@ -50,6 +52,8 @@ describe("FriendSentRequestsBlock", () => {
     received_requests: [],
     blocked: [],
     was_blocked: [],
+    isPublic: true,
+    website: "",
     timeZone: "America/New_York" as TimeZone,
   };
 


### PR DESCRIPTION


## Description
Replaced the massive default populate in getAuthorizedUserByEmail with 5 targeted presets (minimal,profile, social, dashboard, creation) in a new user-populates.ts file. Default is now minimal (id + email) since 30+ callsites only need the user id. Callsites that need more data explicitly pass the right preset.      

Fixed 3 pre-existing test failures from ODY-301 where test assertions still expected the old cache/next options combo that was removed. Also added missing isPublic and website fields to a couple test mocks that were out of date with the AuthorizedUser type.

## Motivation and Context
 
The old default populate was about 80 lines and pulled in everything - friend requests, blocked users, droplets, playlists with nested droplets and lessons, friendships with nested user data, groups, etc. That was hitting strapi with like 15-20 SQL queries every time someone called this function, even though most places just needed the user id to pass to another function.





## Checklist:


- [X] My code follows the code style of this project.
- [X] I have moved the ticket to "In Review"
- [X] I have added reviewers to this PR
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.