### PR TITLE
ODY-309: Batch member enrollment queries on group detail page to fix N+1

### DIFF
--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -11,7 +11,7 @@ import { GroupDashboard } from "@/components/group/group-management-dashboard";
 import { isAuthorizedUserAdmin } from "@/lib/utils";
 import DueDateAnnouncements from "@/components/group/due-date-announcements";
 import { getGroupDueDates } from "@/lib/requests/groups";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getEnrollmentsForGroupMembers } from "@/lib/requests/enrollment";
 import { AuthorizedUser, DueDate } from "@/types";
 import { DateTime } from "luxon";
 
@@ -88,38 +88,36 @@ export default async function GroupDetailPage({ params }: Props) {
     });
 
     try {
-      const memberEnrollmentsPromises = sortedMembers.map(async (member) => {
-        const enrollments = await getEnrollmentsByAuthorizedUser(member.id);
-        return { member, enrollments };
-      });
+      const memberIds = sortedMembers.map((m) => m.id);
+      const dropletIds = group.droplets.map((d) => d.id);
 
-      const memberEnrollments = await Promise.all(memberEnrollmentsPromises);
+      const allEnrollments = await getEnrollmentsForGroupMembers(
+        memberIds,
+        dropletIds,
+      );
 
-      memberEnrollments.forEach(({ member, enrollments }) => {
-        enrollments?.forEach((enrollment) => {
-          if (!enrollment.droplet) {
-            return;
-          }
+      allEnrollments.forEach((enrollment) => {
+        if (!enrollment.droplet || !enrollment.authorizedUser) return;
 
-          const completedLessons =
-            enrollment.viewedLessons?.map((lesson) => lesson.id) || [];
-          const dropletLessons = enrollment.droplet?.lessons?.length || 1;
-          const percentCompleted =
-            (completedLessons?.length / dropletLessons) * 100 || 0;
+        const memberId = enrollment.authorizedUser.id;
+        const completedLessons =
+          enrollment.viewedLessons?.map((lesson) => lesson.id) || [];
+        const dropletLessons = enrollment.droplet?.lessons?.length || 1;
+        const percentCompleted =
+          (completedLessons.length / dropletLessons) * 100 || 0;
 
-          const key = `${member.id}-${enrollment.droplet.id}`;
-          if (!completionStatuses[key]) {
-            completionStatuses[key] = {
-              completionPercentage: 0,
-              completionDate: undefined,
-            };
-          }
+        const key = `${memberId}-${enrollment.droplet.id}`;
+        if (!completionStatuses[key]) {
+          completionStatuses[key] = {
+            completionPercentage: 0,
+            completionDate: undefined,
+          };
+        }
 
-          completionStatuses[key].completionPercentage = percentCompleted;
-          if (enrollment.completionDate) {
-            completionStatuses[key].completionDate = enrollment.completionDate;
-          }
-        });
+        completionStatuses[key].completionPercentage = percentCompleted;
+        if (enrollment.completionDate) {
+          completionStatuses[key].completionDate = enrollment.completionDate;
+        }
       });
     } catch (error) {
       console.error("Error fetching completion statuses:", error);

--- a/frontend/lib/requests/enrollment.ts
+++ b/frontend/lib/requests/enrollment.ts
@@ -76,6 +76,58 @@ export async function getEnrollmentsByAuthorizedUser(
 }
 
 /**
+ * Fetches enrollments for multiple members filtered to specific droplets in a
+ * single paginated Strapi query. Replaces N per-member calls with 1 batched call.
+ */
+export async function getEnrollmentsForGroupMembers(
+  memberIds: number[],
+  groupDropletIds: number[],
+): Promise<Enrollment[]> {
+  const path = `/enrollments`;
+  const pageSize = 250;
+  let page = 1;
+  let allEnrollments: Enrollment[] = [];
+
+  while (true) {
+    const urlParams = {
+      filters: {
+        $and: [
+          { authorizedUser: { id: { $in: memberIds } } },
+          { droplet: { id: { $in: groupDropletIds } } },
+        ],
+      },
+      populate: {
+        droplet: {
+          populate: {
+            lessons: { fields: ["id", "name", "slug"] },
+          },
+          fields: ["id"],
+        },
+        viewedLessons: { fields: ["id", "name", "slug"] },
+        authorizedUser: { fields: ["id"] },
+      },
+      fields: ["id", "isComplete", "completionDate"],
+      pagination: { page, pageSize },
+    };
+
+    const enrollmentsPage = await fetchAPI<Enrollment[]>(path, {
+      urlParams,
+      next: { tags: ["enrollments"], revalidate: 0 },
+      cache: "no-store",
+    });
+
+    if (!enrollmentsPage || enrollmentsPage.length === 0) break;
+
+    allEnrollments = allEnrollments.concat(enrollmentsPage);
+
+    if (enrollmentsPage.length < pageSize) break;
+    page++;
+  }
+
+  return allEnrollments;
+}
+
+/**
  * Determines if the given authorized user is enrolled in the given Droplet.
  * @param authorizedUserId The unique ID of the authorized user.
  * @param dropletId The unique ID of the Droplet.

--- a/frontend/testing/requests/enrollments.test.js
+++ b/frontend/testing/requests/enrollments.test.js
@@ -1,5 +1,6 @@
 const {
   getEnrollmentsByAuthorizedUser,
+  getEnrollmentsForGroupMembers,
   getIsEnrolled,
   getIsEnrollComplete,
   changeEnrollmentRating,
@@ -117,6 +118,170 @@ describe("Enrollment Tests", () => {
       fetchAPI.mockRejectedValueOnce(new Error("Failed to fetch enrollments"));
 
       await expect(getEnrollmentsByAuthorizedUser(500)).rejects.toThrow();
+    });
+  });
+
+  describe("getEnrollmentsForGroupMembers", () => {
+    const memberIds = [1, 2, 3];
+    const dropletIds = [10, 20];
+
+    function makeMockEnrollment(id, memberId, dropletId) {
+      return {
+        id: String(id),
+        authorizedUser: { id: memberId },
+        droplet: {
+          id: dropletId,
+          lessons: [{ id: 1, name: "Lesson 1", slug: "lesson-1" }],
+        },
+        viewedLessons: [],
+        isComplete: false,
+        completionDate: undefined,
+      };
+    }
+
+    it("should return enrollments from a single page", async () => {
+      const mockEnrollments = [
+        makeMockEnrollment(1, 1, 10),
+        makeMockEnrollment(2, 2, 10),
+        makeMockEnrollment(3, 3, 20),
+      ];
+      fetchAPI.mockResolvedValueOnce(mockEnrollments);
+
+      const result = await getEnrollmentsForGroupMembers(
+        memberIds,
+        dropletIds,
+      );
+
+      expect(result).toEqual(mockEnrollments);
+      expect(fetchAPI).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return empty array when no enrollments exist", async () => {
+      fetchAPI.mockResolvedValueOnce([]);
+
+      const result = await getEnrollmentsForGroupMembers(
+        memberIds,
+        dropletIds,
+      );
+
+      expect(result).toEqual([]);
+      expect(fetchAPI).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return empty array when fetchAPI returns null", async () => {
+      fetchAPI.mockResolvedValueOnce(null);
+
+      const result = await getEnrollmentsForGroupMembers(
+        memberIds,
+        dropletIds,
+      );
+
+      expect(result).toEqual([]);
+      expect(fetchAPI).toHaveBeenCalledTimes(1);
+    });
+
+    it("should paginate when first page is full (250 results)", async () => {
+      const fullPage = Array.from({ length: 250 }, (_, i) =>
+        makeMockEnrollment(i + 1, memberIds[i % 3], dropletIds[i % 2]),
+      );
+      const partialPage = [makeMockEnrollment(251, 1, 10)];
+
+      fetchAPI
+        .mockResolvedValueOnce(fullPage)
+        .mockResolvedValueOnce(partialPage);
+
+      const result = await getEnrollmentsForGroupMembers(
+        memberIds,
+        dropletIds,
+      );
+
+      expect(result).toHaveLength(251);
+      expect(fetchAPI).toHaveBeenCalledTimes(2);
+      expect(fetchAPI.mock.calls[0][1].urlParams.pagination.page).toBe(1);
+      expect(fetchAPI.mock.calls[1][1].urlParams.pagination.page).toBe(2);
+    });
+
+    it("should stop paginating when a full page is followed by an empty page", async () => {
+      const fullPage = Array.from({ length: 250 }, (_, i) =>
+        makeMockEnrollment(i + 1, memberIds[i % 3], dropletIds[i % 2]),
+      );
+      fetchAPI.mockResolvedValueOnce(fullPage).mockResolvedValueOnce([]);
+
+      const result = await getEnrollmentsForGroupMembers(
+        memberIds,
+        dropletIds,
+      );
+
+      expect(result).toHaveLength(250);
+      expect(fetchAPI).toHaveBeenCalledTimes(2);
+    });
+
+    it("should handle three pages of results", async () => {
+      const page1 = Array.from({ length: 250 }, (_, i) =>
+        makeMockEnrollment(i + 1, memberIds[i % 3], dropletIds[i % 2]),
+      );
+      const page2 = Array.from({ length: 250 }, (_, i) =>
+        makeMockEnrollment(i + 251, memberIds[i % 3], dropletIds[i % 2]),
+      );
+      const page3 = Array.from({ length: 50 }, (_, i) =>
+        makeMockEnrollment(i + 501, memberIds[i % 3], dropletIds[i % 2]),
+      );
+
+      fetchAPI
+        .mockResolvedValueOnce(page1)
+        .mockResolvedValueOnce(page2)
+        .mockResolvedValueOnce(page3);
+
+      const result = await getEnrollmentsForGroupMembers(
+        memberIds,
+        dropletIds,
+      );
+
+      expect(result).toHaveLength(550);
+      expect(fetchAPI).toHaveBeenCalledTimes(3);
+      expect(fetchAPI.mock.calls[0][1].urlParams.pagination.page).toBe(1);
+      expect(fetchAPI.mock.calls[1][1].urlParams.pagination.page).toBe(2);
+      expect(fetchAPI.mock.calls[2][1].urlParams.pagination.page).toBe(3);
+    });
+
+    it("should send correct $in filters for member and droplet IDs", async () => {
+      fetchAPI.mockResolvedValueOnce([]);
+
+      await getEnrollmentsForGroupMembers(memberIds, dropletIds);
+
+      const callArgs = fetchAPI.mock.calls[0];
+      expect(callArgs[0]).toBe("/enrollments");
+
+      const { filters } = callArgs[1].urlParams;
+      expect(filters.$and).toEqual([
+        { authorizedUser: { id: { $in: memberIds } } },
+        { droplet: { id: { $in: dropletIds } } },
+      ]);
+    });
+
+    it("should request authorizedUser, droplet, and viewedLessons in populate", async () => {
+      fetchAPI.mockResolvedValueOnce([]);
+
+      await getEnrollmentsForGroupMembers(memberIds, dropletIds);
+
+      const { populate, fields } = fetchAPI.mock.calls[0][1].urlParams;
+      expect(populate.authorizedUser).toEqual({ fields: ["id"] });
+      expect(populate.droplet.populate.lessons).toEqual({
+        fields: ["id", "name", "slug"],
+      });
+      expect(populate.viewedLessons).toEqual({
+        fields: ["id", "name", "slug"],
+      });
+      expect(fields).toContain("isComplete");
+      expect(fields).toContain("completionDate");
+    });
+
+    it("should handle fetch errors", async () => {
+      fetchAPI.mockRejectedValueOnce(new Error("API Error"));
+
+      await expect(
+        getEnrollmentsForGroupMembers(memberIds, dropletIds),
+      ).rejects.toThrow("API Error");
     });
   });
 


### PR DESCRIPTION
## Description

Created a batch function to send 1 strapi query by filtering for exact enrollments. Added Pagination to groups with over 250 enrollments as well.

## Motivation and Context

When loading Groups every possible enrollment is fetched which bloats the load times.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.