### PR TITLE
ODY-303 Deduplicate user fetches per render with React.cache

### DIFF
--- a/frontend/app/(creation)/new/playlist/page.tsx
+++ b/frontend/app/(creation)/new/playlist/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { isAuthorizedUserAdmin, isContentCreator } from "@/lib/utils";
 import { getDroplets } from "@/lib/requests/droplet";
 import { PlaylistForm } from "@/components/playlists/playlist-form";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 
 export default async function NewPlaylist() {
   const user = await getCurrentUser();
@@ -13,7 +13,7 @@ export default async function NewPlaylist() {
     (!isContentCreator(user.roles) && !isAuthorizedUserAdmin(user.roles))
   )
     return notFound();
-  const authUser = await getAuthorizedUserByEmail(user.email);
+  const authUser = await getCachedUser(user.email);
 
   const droplets = await getDroplets({
     filters: {

--- a/frontend/app/(droplets)/d/[slug]/[lessonSlug]/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/[lessonSlug]/page.tsx
@@ -1,12 +1,11 @@
 import { Metadata } from "next";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import {
   getEnrollmentsByAuthorizedUser,
   updateCompletionDate,
 } from "@/lib/requests/enrollment";
 import { getDropletBySlug } from "@/lib/requests/droplet";
 import { getLessonBySlug } from "@/lib/requests/lesson";
-import { getServerSession } from "next-auth";
 import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
 import { DropletLessonWrapper } from "@/components/droplets/lessons/droplet-lesson-wrapper";
@@ -46,12 +45,12 @@ export default async function Page({ params }: Props) {
   });
 
   const lesson = await getLessonBySlug(lessonSlug);
-  const session = await getServerSession();
+  const currentUser = await getCurrentUser();
   let completedLessonIds: number[] = [];
   let enrollmentId: string | undefined;
 
-  if (session?.user?.email) {
-    const user = await getAuthorizedUserByEmail(session.user.email);
+  if (currentUser?.email) {
+    const user = await getCachedUser(currentUser.email);
     const enrollments = await getEnrollmentsByAuthorizedUser(user.id);
 
     const enrollment = enrollments.find((e) => e.droplet.id === droplet.id);
@@ -69,9 +68,8 @@ export default async function Page({ params }: Props) {
     }
   }
 
-  const currentUser = await getCurrentUser();
   if (!currentUser || !currentUser?.email) return notFound();
-  const authUser = await getAuthorizedUserByEmail(currentUser.email);
+  const authUser = await getCachedUser(currentUser.email);
 
   const isAuthor =
     droplet.authorized_users &&

--- a/frontend/app/(droplets)/d/[slug]/layout.tsx
+++ b/frontend/app/(droplets)/d/[slug]/layout.tsx
@@ -1,8 +1,7 @@
 import Sidebar from "@/components/droplets/sidebar";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getDropletBySlug } from "@/lib/requests/droplet";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
-import { getServerSession } from "next-auth";
 import { Metadata } from "next/types";
 import { AuthorizedUser, Droplet } from "@/types";
 import { getCurrentUser } from "@/lib/auth/session";
@@ -36,7 +35,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function RootLayout({ params, children }: Props) {
   const { slug } = await params;
-  const session = await getServerSession();
   const user = await getCurrentUser();
 
   if (!user) return notFound();
@@ -46,9 +44,7 @@ export default async function RootLayout({ params, children }: Props) {
   let enrollmentId: string | undefined;
 
   if (user?.email) {
-    authorizedUser = (await getAuthorizedUserByEmail(
-      user.email,
-    )) as AuthorizedUser;
+    authorizedUser = (await getCachedUser(user.email)) as AuthorizedUser;
   }
 
   // Fetch droplet first
@@ -66,8 +62,8 @@ export default async function RootLayout({ params, children }: Props) {
 
   if (!droplet) return notFound();
 
-  if (session?.user?.email) {
-    const sessionUser = await getAuthorizedUserByEmail(session.user.email);
+  if (user?.email) {
+    const sessionUser = await getCachedUser(user.email);
     const enrollments = await getEnrollmentsByAuthorizedUser(sessionUser.id);
 
     const currentEnrollment = enrollments.find(

--- a/frontend/app/(droplets)/d/[slug]/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/page.tsx
@@ -14,7 +14,7 @@ import {
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { StarRating } from "@/components/ui/rating-stars";
 import { AuthorCard } from "@/components/droplets/author-block";
@@ -59,7 +59,7 @@ export default async function DropletRoute({ params }: Props) {
   const user = await getCurrentUser();
 
   if (user?.email) {
-    const authorizedUser = await getAuthorizedUserByEmail(user.email);
+    const authorizedUser = await getCachedUser(user.email);
 
     const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
     isEnrolled = enrollments.some((e) => e.droplet.id === droplet.id);

--- a/frontend/app/(droplets)/d/[slug]/recap/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/recap/page.tsx
@@ -6,13 +6,12 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { StarRating } from "@/components/ui/rating-stars";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { USER_POPULATES } from "@/lib/requests/user-populates";
+import { getCachedUser } from "@/lib/requests/cached";
 import {
   getEnrollmentsByAuthorizedUser,
   updateCompletionDate,
 } from "@/lib/requests/enrollment";
-import { getServerSession } from "next-auth";
+import { getCurrentUser } from "@/lib/auth/session";
 import { CompletedDropletBlock } from "@/components/droplets/completed-droplet-block";
 import { getNotesByDroplet } from "@/lib/requests/notes";
 import { getHighlightsByDroplet } from "@/lib/requests/highlights";
@@ -86,10 +85,10 @@ export default async function DropletRecapRoute({ params }: Props) {
     populate: { tags: { populate: "*" } },
   });
 
-  const session = await getServerSession();
+  const currentUser = await getCurrentUser();
 
-  if (session?.user?.email) {
-    const user = await getAuthorizedUserByEmail(session.user.email);
+  if (currentUser?.email) {
+    const user = await getCachedUser(currentUser.email);
 
     const enrollments = await getEnrollmentsByAuthorizedUser(user.id, {
       populate: {
@@ -107,10 +106,7 @@ export default async function DropletRecapRoute({ params }: Props) {
       },
     });
 
-    const authUser = await getAuthorizedUserByEmail(
-      user.email,
-      USER_POPULATES.profile,
-    );
+    const authUser = await getCachedUser(user.email);
     let enrollID: string = "";
     const highlights = await getHighlightsByDroplet(authUser.id, droplet.id);
     const notes = await getNotesByDroplet(authUser.id, droplet.id);

--- a/frontend/app/(editing)/draft/d/[slug]/layout.tsx
+++ b/frontend/app/(editing)/draft/d/[slug]/layout.tsx
@@ -4,7 +4,7 @@ import { isAuthorizedUserAdmin } from "@/lib/utils";
 import { getDropletBySlug } from "@/lib/requests/droplet";
 import { AuthorizedUser, Droplet } from "@/types";
 import { Sidebar } from "@/components/draft/sidebar";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getDroplets } from "@/lib/requests/droplet";
 import { AuthorizedUserRoleTitle } from "@/lib/globals";
 
@@ -22,9 +22,7 @@ export default async function CheckPermission({ params, children }: Props) {
   const p = await params;
   let authorizedUser: AuthorizedUser | null = null;
   if (user?.email) {
-    authorizedUser = (await getAuthorizedUserByEmail(
-      user.email,
-    )) as AuthorizedUser;
+    authorizedUser = (await getCachedUser(user.email)) as AuthorizedUser;
   }
 
   const droplet = await getDropletBySlug<Droplet>(p.slug, {

--- a/frontend/app/(editing)/draft/p/[slug]/page.tsx
+++ b/frontend/app/(editing)/draft/p/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { isAuthorizedUserAdmin, isContentCreator } from "@/lib/utils";
 import { getDroplets } from "@/lib/requests/droplet";
 import { PlaylistForm } from "@/components/playlists/playlist-form";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getPlaylistBySlug } from "@/lib/requests/playlist";
 
 interface Props {
@@ -21,7 +21,7 @@ export default async function EditPlaylistPage({ params }: Props) {
   )
     return notFound();
 
-  const authUser = await getAuthorizedUserByEmail(user.email);
+  const authUser = await getCachedUser(user.email);
 
   const p = await params;
   const playlist = await getPlaylistBySlug(p.slug, {

--- a/frontend/app/(general)/creation-request/page.tsx
+++ b/frontend/app/(general)/creation-request/page.tsx
@@ -2,7 +2,7 @@ import { ContentCreatorRequestForm } from "@/components/requests/content-creatio
 import { PendingRequestCard } from "@/components/requests/pending-request-card";
 import { GradientBackground } from "@/components/gradient-bg";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { fetchCreationRequestByUser } from "@/lib/actions";
 import { notFound } from "next/navigation";
 
@@ -10,7 +10,7 @@ export default async function RequestContentCreatorRole() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return notFound();
 
-  const authUser = await getAuthorizedUserByEmail(user?.email);
+  const authUser = await getCachedUser(user?.email);
   if (!authUser) return notFound();
 
   // Check if user already has a pending creation request

--- a/frontend/app/(general)/dashboard/page.tsx
+++ b/frontend/app/(general)/dashboard/page.tsx
@@ -13,8 +13,7 @@ import {
   playlistSorting,
   sorting,
 } from "@/lib/globals";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { USER_POPULATES } from "@/lib/requests/user-populates";
+import { getCachedUserDashboard } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { getUserGroups } from "@/lib/requests/groups";
 import { notFound } from "next/navigation";
@@ -35,10 +34,7 @@ export default async function DashboardRoute({ searchParams }: Props) {
     return notFound();
   }
   const { sortKey } = sorting.find((item) => item.slug === sort) || defaultSort;
-  const authorizedUser = await getAuthorizedUserByEmail(
-    user.email,
-    USER_POPULATES.dashboard,
-  );
+  const authorizedUser = await getCachedUserDashboard(user.email);
   const archivedPlaylists = authorizedUser.playlists?.filter((playlist) =>
     playlist.users_archived?.some((user) => user.id === authorizedUser.id),
   );

--- a/frontend/app/(general)/feed/page.tsx
+++ b/frontend/app/(general)/feed/page.tsx
@@ -2,8 +2,7 @@ import { Metadata } from "next";
 import { FeedContainer } from "@/components/feed/feed-container";
 import { notFound } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { USER_POPULATES } from "@/lib/requests/user-populates";
+import { getCachedUserSocial } from "@/lib/requests/cached";
 
 export const metadata: Metadata = {
   title: "Feed",
@@ -14,10 +13,7 @@ export const revalidate = 0;
 export default async function FeedPage() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return notFound();
-  const authUser = await getAuthorizedUserByEmail(
-    user.email,
-    USER_POPULATES.social,
-  );
+  const authUser = await getCachedUserSocial(user.email);
 
   return (
     <>

--- a/frontend/app/(general)/my-content/page.tsx
+++ b/frontend/app/(general)/my-content/page.tsx
@@ -14,8 +14,7 @@ import { DropletsSkeleton } from "@/components/explore/droplets-skeleton";
 import { Separator } from "@/components/ui/separator";
 import { Metadata } from "next";
 import { PlaylistCard } from "@/components/playlists/playlist-card";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { USER_POPULATES } from "@/lib/requests/user-populates";
+import { getCachedUserCreation } from "@/lib/requests/cached";
 
 export const metadata: Metadata = {
   title: "Create",
@@ -32,10 +31,7 @@ export default async function CreateRoute() {
       !isAuthorizedUserFaculty(user.roles))
   )
     redirect("/unauthorized");
-  const authorizedUser = await getAuthorizedUserByEmail(
-    user.email,
-    USER_POPULATES.creation,
-  );
+  const authorizedUser = await getCachedUserCreation(user.email);
 
   const playlists = authorizedUser.created_playlists;
 

--- a/frontend/app/(general)/prof/[username]/page.tsx
+++ b/frontend/app/(general)/prof/[username]/page.tsx
@@ -1,5 +1,6 @@
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
 import { USER_POPULATES } from "@/lib/requests/user-populates";
+import { getCachedUserSocial } from "@/lib/requests/cached";
 import { AuthorizedUser, Enrollment } from "@/types";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { fetchFriends } from "@/lib/requests/friends";
@@ -57,10 +58,7 @@ export default async function PublicProfilePage({
 
     if (currentUser?.email) {
       try {
-        const maybeUserData = await getAuthorizedUserByEmail(
-          currentUser.email,
-          USER_POPULATES.social,
-        );
+        const maybeUserData = await getCachedUserSocial(currentUser.email);
         if (!maybeUserData || typeof maybeUserData.id !== "number") {
           throw new Error("Current user data is missing a valid id");
         }

--- a/frontend/app/(general)/settings/friends/page.tsx
+++ b/frontend/app/(general)/settings/friends/page.tsx
@@ -3,11 +3,8 @@ import { FriendSuggestions } from "@/components/friends/friend-suggestions";
 import { Friends } from "@/components/friends/friends";
 import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
-import {
-  fetchAuthorizedUsers,
-  getAuthorizedUserByEmail,
-} from "@/lib/requests/authorized-user";
-import { USER_POPULATES } from "@/lib/requests/user-populates";
+import { fetchAuthorizedUsers } from "@/lib/requests/authorized-user";
+import { getCachedUserSocial } from "@/lib/requests/cached";
 import { FriendSentRequests } from "@/components/friends/friend-sent-requests";
 import { FriendSearch } from "@/components/friends/friend-search";
 import {
@@ -30,10 +27,7 @@ export default async function AuthorProfileSettings({
   const user = await getCurrentUser();
   if (!user?.email) return notFound();
 
-  const authorizedUser = await getAuthorizedUserByEmail(
-    user.email,
-    USER_POPULATES.social,
-  );
+  const authorizedUser = await getCachedUserSocial(user.email);
   if (!authorizedUser) return notFound();
 
   const sentRequests = await getSentRequestIds(authorizedUser);

--- a/frontend/app/(general)/settings/notes/page.tsx
+++ b/frontend/app/(general)/settings/notes/page.tsx
@@ -2,9 +2,9 @@ import { getDropletBySlug } from "@/lib/requests/droplet";
 import { Droplet } from "@/types";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
-import { getServerSession } from "next-auth";
+import { getCurrentUser } from "@/lib/auth/session";
 import { getNotesByDroplet } from "@/lib/requests/notes";
 import { getHighlightsByDroplet } from "@/lib/requests/highlights";
 import { PDFDocument } from "pdf-lib";
@@ -58,9 +58,9 @@ export default async function DropletRecapRoute({ params }: Props) {
     return notFound();
   }
 
-  const session = await getServerSession();
-  if (session?.user?.email) {
-    const user = await getAuthorizedUserByEmail(session.user.email);
+  const currentUser = await getCurrentUser();
+  if (currentUser?.email) {
+    const user = await getCachedUser(currentUser.email);
     const enrollments = await getEnrollmentsByAuthorizedUser(user.id, {
       populate: {
         viewedLessons: {
@@ -83,7 +83,7 @@ export default async function DropletRecapRoute({ params }: Props) {
       },
     });
 
-    const authUser = await getAuthorizedUserByEmail(user.email);
+    const authUser = await getCachedUser(user.email);
 
     const defined = <T,>(v: T | null | undefined): v is T => v != null;
 

--- a/frontend/app/(general)/settings/page.tsx
+++ b/frontend/app/(general)/settings/page.tsx
@@ -12,18 +12,14 @@ import {
 import { getCurrentUser } from "@/lib/auth/session";
 import { getInitials, condenseRoleTitles } from "@/lib/utils";
 import { User2Icon } from "lucide-react";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { USER_POPULATES } from "@/lib/requests/user-populates";
+import { getCachedUser } from "@/lib/requests/cached";
 import { AuthorizedUser } from "@/types";
 
 export default async function Settings() {
   const user = await getCurrentUser();
   let authorizedUser: AuthorizedUser | null = null;
   if (user?.email) {
-    authorizedUser = (await getAuthorizedUserByEmail(
-      user.email,
-      USER_POPULATES.profile,
-    )) as AuthorizedUser;
+    authorizedUser = (await getCachedUser(user.email)) as AuthorizedUser;
     if (!authorizedUser?.id) {
       throw new Error("Authorized user not found");
     }

--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { USER_POPULATES } from "@/lib/requests/user-populates";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getGroupBySlugV2 } from "@/lib/requests/groups";
 import { notFound } from "next/navigation";
 import { MemberList } from "@/components/group/member-list";
@@ -29,10 +28,7 @@ export default async function GroupDetailPage({ params }: Props) {
   const user = await getCurrentUser();
   if (!user?.email) return null;
 
-  const authorizedUser = await getAuthorizedUserByEmail(
-    user.email,
-    USER_POPULATES.profile,
-  );
+  const authorizedUser = await getCachedUser(user.email);
   if (!authorizedUser) return null;
 
   const p = await params;

--- a/frontend/app/(groups)/g/dashboard/page.tsx
+++ b/frontend/app/(groups)/g/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getUserGroups } from "@/lib/requests/groups";
 import { Group } from "@/types";
 import { GroupsSelector } from "./group-selector";
@@ -35,7 +35,7 @@ export default async function GroupsPage({ searchParams }: Props) {
     redirect("/unauthorized");
   }
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getCachedUser(user.email);
   if (!authorizedUser) {
     redirect("/unauthorized");
   }

--- a/frontend/app/(groups)/g/due-dates/page.tsx
+++ b/frontend/app/(groups)/g/due-dates/page.tsx
@@ -1,5 +1,5 @@
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { notFound, redirect } from "next/navigation";
 import { getGroupBySlugV2 } from "@/lib/requests/groups";
 import { isAuthorizedUserAdmin } from "@/lib/utils";
@@ -13,7 +13,7 @@ export default async function GroupDueDatesPage({ searchParams }: Props) {
   const user = await getCurrentUser();
   if (!user?.email) redirect("/");
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getCachedUser(user.email);
   if (!authorizedUser) redirect("/");
 
   const p = await searchParams;

--- a/frontend/app/(groups)/g/management/page.tsx
+++ b/frontend/app/(groups)/g/management/page.tsx
@@ -1,5 +1,5 @@
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { notFound } from "next/navigation";
 import { GroupManagementForm } from "@/components/group/group-management-form";
 import { getGroupBySlugV2 } from "@/lib/requests/groups";
@@ -25,7 +25,7 @@ export default async function GroupManagementPage({ searchParams }: Props) {
   )
     return notFound();
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getCachedUser(user.email);
   if (!authorizedUser) return notFound();
 
   const p = await searchParams;

--- a/frontend/app/(playlists)/p/[slug]/page.tsx
+++ b/frontend/app/(playlists)/p/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { getPlaylistBySlug } from "@/lib/requests/playlist";
 import { notFound } from "next/navigation";
 import { DropletTile } from "@/components/droplets/droplet-tile";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
@@ -70,7 +70,7 @@ export default async function PlaylistPage({ params }: Props) {
   let isEnrolled = false;
 
   if (user?.email) {
-    const authorizedUser = await getAuthorizedUserByEmail(user.email);
+    const authorizedUser = await getCachedUser(user.email);
     const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
     enrolledDropletIds = enrollments.map((e) => e.droplet.id);
 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -8,8 +8,7 @@ import { Lato } from "next/font/google";
 import "./globals.css";
 import { FirstVisitPopup } from "@/components/first-time/first-visit-popup";
 import { getCurrentUser } from "../lib/auth/session";
-import { getAuthorizedUserByEmail } from "../lib/requests/authorized-user";
-import { USER_POPULATES } from "../lib/requests/user-populates";
+import { getCachedUser } from "../lib/requests/cached";
 import { ThemeClientProvider } from "@/components/theme.client.provider";
 import AccessRequestBanner from "@/components/requests/access-request-banner";
 import { EnvironmentBanner } from "@/components/debug/environmentBanner";
@@ -42,10 +41,7 @@ export default async function RootLayout({
 
   if (user?.email) {
     try {
-      authorizedUser = await getAuthorizedUserByEmail(
-        user.email,
-        USER_POPULATES.profile,
-      );
+      authorizedUser = await getCachedUser(user.email);
     } catch (error) {
       console.error("Error fetching authorized user:", error);
     }

--- a/frontend/app/no-access.tsx
+++ b/frontend/app/no-access.tsx
@@ -8,13 +8,11 @@ import { Button } from "@/components/ui/button";
 import { ArrowRightIcon } from "lucide-react";
 import Link from "next/link";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 
 export default async function CantAccessRoute() {
   const user = await getCurrentUser();
-  const authorizedUser = user?.email
-    ? await getAuthorizedUserByEmail(user.email)
-    : null;
+  const authorizedUser = user?.email ? await getCachedUser(user.email) : null;
 
   if (!user) {
     return (

--- a/frontend/components/dashboard/archived-droplets-grid.tsx
+++ b/frontend/components/dashboard/archived-droplets-grid.tsx
@@ -4,7 +4,7 @@ import {
   MessageHeader,
 } from "@/components/message";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { EnrolledDropletsGridClient } from "./enrolled-droplets-grid-client";
 
@@ -18,7 +18,7 @@ export async function ArchivedDropletsGrid({ sortKey }: { sortKey?: string }) {
   const user = await getCurrentUser();
   if (!user?.email) return null;
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getCachedUser(user.email);
   const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
 
   const filteredEnrollments = enrollments.filter((e) => e.isArchived === true);

--- a/frontend/components/dashboard/enrolled-droplets-grid.tsx
+++ b/frontend/components/dashboard/enrolled-droplets-grid.tsx
@@ -4,7 +4,7 @@ import {
   MessageHeader,
 } from "@/components/message";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { EnrolledDropletsGridClient } from "./enrolled-droplets-grid-client";
 import { getUserDueDates } from "@/lib/requests/groups";
@@ -29,7 +29,7 @@ export async function EnrolledDropletsGrid({
   const user = await getCurrentUser();
   if (!user?.email) return null;
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getCachedUser(user.email);
   const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
 
   const filteredEnrollments = enrollments.filter((e) => e.isArchived !== true);

--- a/frontend/components/dashboard/enrollments.tsx
+++ b/frontend/components/dashboard/enrollments.tsx
@@ -1,5 +1,5 @@
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { notFound } from "next/navigation";
 import { DropletTile } from "../droplets/droplet-tile";
@@ -8,7 +8,7 @@ export async function Enrollments() {
   const user = await getCurrentUser();
   if (!user?.email) return notFound();
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getCachedUser(user.email);
   const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id, {
     populate: {
       droplet: {

--- a/frontend/components/dashboard/favorited-droplet-grid.tsx
+++ b/frontend/components/dashboard/favorited-droplet-grid.tsx
@@ -4,7 +4,7 @@ import {
   MessageHeader,
 } from "@/components/message";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { EnrolledDropletsGridClient } from "./enrolled-droplets-grid-client";
 import { Lesson } from "@/types";
@@ -13,7 +13,7 @@ export async function FavoriteDropletsGrid({ sortKey }: { sortKey?: string }) {
   const user = await getCurrentUser();
   if (!user?.email) return null;
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getCachedUser(user.email);
   const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
 
   // Fixed: Added return and compare IDs instead of objects

--- a/frontend/components/dashboard/my-content.tsx
+++ b/frontend/components/dashboard/my-content.tsx
@@ -2,7 +2,7 @@ import { getCurrentUser } from "@/lib/auth/session";
 import { EnrolledDropletsGrid } from "./enrolled-droplets-grid";
 import { UserPlaylistsGrid } from "./user-playlists-grid";
 import { ArchivedDropletsGrid } from "./archived-droplets-grid";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { notFound } from "next/navigation";
 import { getUserGroups } from "@/lib/requests/groups";
 import {
@@ -31,7 +31,7 @@ export async function MyContent({
     return notFound();
   }
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const authorizedUser = await getCachedUser(user.email);
   const allGroups = (await getUserGroups(authorizedUser.id)).filter((group) =>
     group.members?.some((member) => member.id === authorizedUser.id),
   );

--- a/frontend/components/explore/droplets-grid.tsx
+++ b/frontend/components/explore/droplets-grid.tsx
@@ -4,7 +4,7 @@ import {
   MessageHeader,
 } from "@/components/message";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { DropletTile } from "../droplets/droplet-tile";
 import { SortedDropletsGrid } from "./sorted-droplets-grid";
@@ -35,7 +35,7 @@ export async function DropletsGrid({
   let dueDates: DueDate[] = [];
 
   if (user?.email) {
-    const authorizedUser = await getAuthorizedUserByEmail(user.email);
+    const authorizedUser = await getCachedUser(user.email);
     enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
 
     enrolledDropletIds = enrollments.map((e) => e.droplet.id);

--- a/frontend/components/explore/playlists-grid.tsx
+++ b/frontend/components/explore/playlists-grid.tsx
@@ -1,5 +1,5 @@
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import {
   Message,
@@ -38,9 +38,7 @@ export async function PlaylistsGrid({
   let dueDates: DueDate[] = [];
 
   if (user?.email) {
-    authorizedUser = (await getAuthorizedUserByEmail(
-      user.email,
-    )) as AuthorizedUser;
+    authorizedUser = (await getCachedUser(user.email)) as AuthorizedUser;
     const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
     completedLessonIds = enrollments.flatMap(
       (enrollment) =>

--- a/frontend/components/friends/blocked-users.tsx
+++ b/frontend/components/friends/blocked-users.tsx
@@ -1,5 +1,4 @@
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { USER_POPULATES } from "@/lib/requests/user-populates";
+import { getCachedUserSocial } from "@/lib/requests/cached";
 import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
 import { BlockedUsersBlock } from "./blocked-users-block";
@@ -7,10 +6,7 @@ import { BlockedUsersBlock } from "./blocked-users-block";
 export async function BlockedUsers() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return notFound();
-  const authUser = await getAuthorizedUserByEmail(
-    user.email,
-    USER_POPULATES.social,
-  );
+  const authUser = await getCachedUserSocial(user.email);
   const blockedUsers = authUser.blocked;
 
   return (

--- a/frontend/components/friends/friend-sent-requests.tsx
+++ b/frontend/components/friends/friend-sent-requests.tsx
@@ -1,5 +1,4 @@
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { USER_POPULATES } from "@/lib/requests/user-populates";
+import { getCachedUserSocial } from "@/lib/requests/cached";
 import { FriendSentRequestsBlock } from "./friend-sent-requests-block";
 import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
@@ -7,10 +6,7 @@ import { notFound } from "next/navigation";
 export async function FriendSentRequests() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return notFound();
-  const authUser = await getAuthorizedUserByEmail(
-    user.email,
-    USER_POPULATES.social,
-  );
+  const authUser = await getCachedUserSocial(user.email);
   const sentRequests = authUser.sent_requests
     .filter(
       (friend) =>

--- a/frontend/components/friends/friends.tsx
+++ b/frontend/components/friends/friends.tsx
@@ -1,4 +1,4 @@
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { FriendBlock } from "./friend-block";
 import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
@@ -7,7 +7,7 @@ import { fetchFriends } from "@/lib/requests/friends";
 export async function Friends() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return notFound();
-  const authUser = await getAuthorizedUserByEmail(user.email);
+  const authUser = await getCachedUser(user.email);
 
   const friends = await fetchFriends(authUser);
 

--- a/frontend/components/header/header-wrapper.tsx
+++ b/frontend/components/header/header-wrapper.tsx
@@ -1,7 +1,6 @@
 import { getCurrentUser } from "@/lib/auth/session";
 import { AuthorizedUser } from "@/types";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { USER_POPULATES } from "@/lib/requests/user-populates";
+import { getCachedUser } from "@/lib/requests/cached";
 import { Header } from "./index";
 
 export async function HeaderWrapper() {
@@ -9,10 +8,7 @@ export async function HeaderWrapper() {
 
   let authorizedUser: AuthorizedUser | null = null;
   if (user?.email) {
-    authorizedUser = (await getAuthorizedUserByEmail(
-      user.email,
-      USER_POPULATES.profile,
-    )) as AuthorizedUser;
+    authorizedUser = (await getCachedUser(user.email)) as AuthorizedUser;
   }
 
   return <Header user={user} authorizedUser={authorizedUser} />;

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -67,6 +67,7 @@ jest.mock("react-dom", () => ({
 jest.mock("react", () => ({
   ...jest.requireActual("react"),
   useActionState: () => [{ ok: false, error: null }, jest.fn(), false],
+  cache: (fn: Function) => fn,
 }));
 // Mock the flat package
 jest.mock("flat", () => ({

--- a/frontend/lib/auth/session.ts
+++ b/frontend/lib/auth/session.ts
@@ -1,7 +1,8 @@
+import { cache } from "react";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "./options";
 
-export async function getCurrentUser() {
+export const getCurrentUser = cache(async () => {
   const session = await getServerSession(authOptions);
   return session?.user;
-}
+});

--- a/frontend/lib/requests/cached.ts
+++ b/frontend/lib/requests/cached.ts
@@ -1,0 +1,19 @@
+import { cache } from "react";
+import { getAuthorizedUserByEmail } from "./authorized-user";
+import { USER_POPULATES } from "./user-populates";
+
+export const getCachedUser = cache((email: string) =>
+  getAuthorizedUserByEmail(email, USER_POPULATES.profile),
+);
+
+export const getCachedUserSocial = cache((email: string) =>
+  getAuthorizedUserByEmail(email, USER_POPULATES.social),
+);
+
+export const getCachedUserDashboard = cache((email: string) =>
+  getAuthorizedUserByEmail(email, USER_POPULATES.dashboard),
+);
+
+export const getCachedUserCreation = cache((email: string) =>
+  getAuthorizedUserByEmail(email, USER_POPULATES.creation),
+);

--- a/frontend/tests/components/dashboard/archived-droplets-grid.test.tsx
+++ b/frontend/tests/components/dashboard/archived-droplets-grid.test.tsx
@@ -59,9 +59,7 @@ describe("ArchivedDropletsGrid", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getCachedUser as jest.Mock).mockResolvedValue(
-      mockAuthorizedUser,
-    );
+    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
   });
 
   it("displays a message when no archived droplets are found", async () => {
@@ -81,9 +79,7 @@ describe("ArchivedDropletsGrid", () => {
     const mockEnrollments = [] as Enrollment[];
 
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getCachedUser as jest.Mock).mockResolvedValue(
-      mockAuthorizedUser,
-    );
+    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
     (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );

--- a/frontend/tests/components/dashboard/archived-droplets-grid.test.tsx
+++ b/frontend/tests/components/dashboard/archived-droplets-grid.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { ArchivedDropletsGrid } from "@/components/dashboard/archived-droplets-grid";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { Enrollment } from "@/types";
 
@@ -9,8 +9,8 @@ jest.mock("@/lib/auth/session", () => ({
   getCurrentUser: jest.fn(),
 }));
 
-jest.mock("@/lib/requests/authorized-user", () => ({
-  getAuthorizedUserByEmail: jest.fn(),
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedUser: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/enrollment", () => ({
@@ -59,7 +59,7 @@ describe("ArchivedDropletsGrid", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
+    (getCachedUser as jest.Mock).mockResolvedValue(
       mockAuthorizedUser,
     );
   });
@@ -81,7 +81,7 @@ describe("ArchivedDropletsGrid", () => {
     const mockEnrollments = [] as Enrollment[];
 
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
+    (getCachedUser as jest.Mock).mockResolvedValue(
       mockAuthorizedUser,
     );
     (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
@@ -165,7 +165,7 @@ describe("ArchivedDropletsGrid", () => {
     beforeEach(() => {
       jest.clearAllMocks();
       (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-      (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockUser);
+      (getCachedUser as jest.Mock).mockResolvedValue(mockUser);
       (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
         mockEnrollments,
       );
@@ -188,7 +188,7 @@ describe("ArchivedDropletsGrid", () => {
       beforeEach(() => {
         jest.clearAllMocks();
         (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-        (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockUser);
+        (getCachedUser as jest.Mock).mockResolvedValue(mockUser);
       });
 
       it("should calculate 100% completion when all lessons are completed", async () => {

--- a/frontend/tests/components/dashboard/enrolled-droplets-grid.test.tsx
+++ b/frontend/tests/components/dashboard/enrolled-droplets-grid.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { EnrolledDropletsGrid } from "@/components/dashboard/enrolled-droplets-grid";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { getUserDueDates } from "@/lib/requests/groups";
 import { Enrollment } from "@/types";
@@ -10,8 +10,8 @@ jest.mock("@/lib/auth/session", () => ({
   getCurrentUser: jest.fn(),
 }));
 
-jest.mock("@/lib/requests/authorized-user", () => ({
-  getAuthorizedUserByEmail: jest.fn(),
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedUser: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/enrollment", () => ({
@@ -60,7 +60,7 @@ describe("EnrolledDropletsGrid", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
+    (getCachedUser as jest.Mock).mockResolvedValue(
       mockAuthorizedUser,
     );
     (getUserDueDates as jest.Mock).mockResolvedValue([]);
@@ -83,7 +83,7 @@ describe("EnrolledDropletsGrid", () => {
     const mockEnrollments = [] as Enrollment[];
 
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
+    (getCachedUser as jest.Mock).mockResolvedValue(
       mockAuthorizedUser,
     );
     (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(

--- a/frontend/tests/components/dashboard/enrolled-droplets-grid.test.tsx
+++ b/frontend/tests/components/dashboard/enrolled-droplets-grid.test.tsx
@@ -60,9 +60,7 @@ describe("EnrolledDropletsGrid", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getCachedUser as jest.Mock).mockResolvedValue(
-      mockAuthorizedUser,
-    );
+    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
     (getUserDueDates as jest.Mock).mockResolvedValue([]);
   });
 
@@ -83,9 +81,7 @@ describe("EnrolledDropletsGrid", () => {
     const mockEnrollments = [] as Enrollment[];
 
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getCachedUser as jest.Mock).mockResolvedValue(
-      mockAuthorizedUser,
-    );
+    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
     (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );

--- a/frontend/tests/components/dashboard/enrollments.test.tsx
+++ b/frontend/tests/components/dashboard/enrollments.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Enrollments } from "@/components/dashboard/enrollments";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { notFound } from "next/navigation";
 import { Enrollment } from "@/types";
@@ -10,8 +10,8 @@ jest.mock("@/lib/auth/session", () => ({
   getCurrentUser: jest.fn(),
 }));
 
-jest.mock("@/lib/requests/authorized-user", () => ({
-  getAuthorizedUserByEmail: jest.fn(),
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedUser: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/enrollment", () => ({
@@ -41,7 +41,7 @@ describe("Enrollments", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
+    (getCachedUser as jest.Mock).mockResolvedValue(
       mockAuthorizedUser,
     );
   });

--- a/frontend/tests/components/dashboard/enrollments.test.tsx
+++ b/frontend/tests/components/dashboard/enrollments.test.tsx
@@ -41,9 +41,7 @@ describe("Enrollments", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getCachedUser as jest.Mock).mockResolvedValue(
-      mockAuthorizedUser,
-    );
+    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
   });
 
   it("renders a list of enrolled droplets", async () => {

--- a/frontend/tests/components/dashboard/my-content.test.tsx
+++ b/frontend/tests/components/dashboard/my-content.test.tsx
@@ -124,9 +124,7 @@ describe("MyContent", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getCachedUser as jest.Mock).mockResolvedValue(
-      mockAuthorizedUser,
-    );
+    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
     (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue([]);
     (getUserGroups as jest.Mock).mockResolvedValue(mockGroups);
   });

--- a/frontend/tests/components/dashboard/my-content.test.tsx
+++ b/frontend/tests/components/dashboard/my-content.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { MyContent } from "@/components/dashboard/my-content";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { notFound } from "next/navigation";
 import { getUserGroups } from "@/lib/requests/groups";
@@ -10,8 +10,8 @@ jest.mock("@/lib/auth/session", () => ({
   getCurrentUser: jest.fn(),
 }));
 
-jest.mock("@/lib/requests/authorized-user", () => ({
-  getAuthorizedUserByEmail: jest.fn(),
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedUser: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/enrollment", () => ({
@@ -124,7 +124,7 @@ describe("MyContent", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
+    (getCachedUser as jest.Mock).mockResolvedValue(
       mockAuthorizedUser,
     );
     (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue([]);
@@ -151,7 +151,7 @@ describe("MyContent", () => {
     it("fetches authorized user by email", async () => {
       await MyContent({ searchParams: {} });
 
-      expect(getAuthorizedUserByEmail).toHaveBeenCalledWith("test@example.com");
+      expect(getCachedUser).toHaveBeenCalledWith("test@example.com");
     });
 
     it("fetches user groups", async () => {

--- a/frontend/tests/components/explore/playlists-grid.test.tsx
+++ b/frontend/tests/components/explore/playlists-grid.test.tsx
@@ -145,9 +145,7 @@ describe("PlaylistsGrid", () => {
       render(component);
 
       expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
-      expect(mockGetCachedUser).toHaveBeenCalledWith(
-        "test@example.com",
-      );
+      expect(mockGetCachedUser).toHaveBeenCalledWith("test@example.com");
       expect(mockGetEnrollmentsByAuthorizedUser).toHaveBeenCalledWith(1);
       expect(mockGetUserDueDates).toHaveBeenCalledWith(1);
     });

--- a/frontend/tests/components/explore/playlists-grid.test.tsx
+++ b/frontend/tests/components/explore/playlists-grid.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { PlaylistsGrid } from "@/components/explore/playlists-grid";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { getUserDueDates } from "@/lib/requests/groups";
 import { Playlist, DueDate } from "@/types";
@@ -10,8 +10,8 @@ jest.mock("@/lib/auth/session", () => ({
   getCurrentUser: jest.fn(),
 }));
 
-jest.mock("@/lib/requests/authorized-user", () => ({
-  getAuthorizedUserByEmail: jest.fn(),
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedUser: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/enrollment", () => ({
@@ -39,7 +39,7 @@ jest.mock("@/components/explore/sorted-playlists-grid", () => ({
 
 describe("PlaylistsGrid", () => {
   const mockGetCurrentUser = getCurrentUser as jest.Mock;
-  const mockGetAuthorizedUserByEmail = getAuthorizedUserByEmail as jest.Mock;
+  const mockGetCachedUser = getCachedUser as jest.Mock;
   const mockGetEnrollmentsByAuthorizedUser =
     getEnrollmentsByAuthorizedUser as jest.Mock;
   const mockGetUserDueDates = getUserDueDates as jest.Mock;
@@ -70,7 +70,7 @@ describe("PlaylistsGrid", () => {
 
       expect(screen.getByText("Test Playlist")).toBeInTheDocument();
       expect(screen.getByText("Completion: 0.0%")).toBeInTheDocument();
-      expect(mockGetAuthorizedUserByEmail).not.toHaveBeenCalled();
+      expect(mockGetCachedUser).not.toHaveBeenCalled();
       expect(mockGetEnrollmentsByAuthorizedUser).not.toHaveBeenCalled();
     });
 
@@ -124,7 +124,7 @@ describe("PlaylistsGrid", () => {
 
     beforeEach(() => {
       mockGetCurrentUser.mockResolvedValue(mockUser);
-      mockGetAuthorizedUserByEmail.mockResolvedValue(mockAuthorizedUser);
+      mockGetCachedUser.mockResolvedValue(mockAuthorizedUser);
       mockGetEnrollmentsByAuthorizedUser.mockResolvedValue([]);
       mockGetUserDueDates.mockResolvedValue([]);
     });
@@ -145,7 +145,7 @@ describe("PlaylistsGrid", () => {
       render(component);
 
       expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
-      expect(mockGetAuthorizedUserByEmail).toHaveBeenCalledWith(
+      expect(mockGetCachedUser).toHaveBeenCalledWith(
         "test@example.com",
       );
       expect(mockGetEnrollmentsByAuthorizedUser).toHaveBeenCalledWith(1);
@@ -464,7 +464,7 @@ describe("PlaylistsGrid", () => {
       };
 
       mockGetCurrentUser.mockResolvedValue(mockUser);
-      mockGetAuthorizedUserByEmail.mockResolvedValue(mockAuthorizedUser);
+      mockGetCachedUser.mockResolvedValue(mockAuthorizedUser);
       mockGetUserDueDates.mockResolvedValue([]);
 
       const mockPlaylists: any[] = [
@@ -538,7 +538,7 @@ describe("PlaylistsGrid", () => {
       };
 
       mockGetCurrentUser.mockResolvedValue(mockUser);
-      mockGetAuthorizedUserByEmail.mockResolvedValue(mockAuthorizedUser);
+      mockGetCachedUser.mockResolvedValue(mockAuthorizedUser);
       mockGetUserDueDates.mockResolvedValue([]);
 
       const mockPlaylists: any[] = [
@@ -704,7 +704,7 @@ describe("PlaylistsGrid", () => {
       };
 
       mockGetCurrentUser.mockResolvedValue(mockUser);
-      mockGetAuthorizedUserByEmail.mockResolvedValue(mockAuthorizedUser);
+      mockGetCachedUser.mockResolvedValue(mockAuthorizedUser);
       mockGetUserDueDates.mockResolvedValue([]);
 
       const mockPlaylists: any[] = [
@@ -789,7 +789,7 @@ describe("PlaylistsGrid", () => {
       const component = await PlaylistsGrid({ playlists: mockPlaylists });
       render(component);
 
-      expect(mockGetAuthorizedUserByEmail).not.toHaveBeenCalled();
+      expect(mockGetCachedUser).not.toHaveBeenCalled();
       expect(screen.getByText("Test Playlist")).toBeInTheDocument();
     });
 

--- a/frontend/tests/components/friends/blocked-users.test.tsx
+++ b/frontend/tests/components/friends/blocked-users.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { BlockedUsers } from "@/components/friends/blocked-users";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUserSocial } from "@/lib/requests/cached";
 import { notFound } from "next/navigation";
 
 jest.mock("@/lib/auth/session", () => ({
@@ -12,8 +12,8 @@ jest.mock("next/navigation", () => ({
   notFound: jest.fn(),
 }));
 
-jest.mock("@/lib/requests/authorized-user", () => ({
-  getAuthorizedUserByEmail: jest.fn(),
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedUserSocial: jest.fn(),
 }));
 
 describe("BlockedUsers", () => {
@@ -34,7 +34,7 @@ describe("BlockedUsers", () => {
         },
       ],
     };
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockAuthUser);
+    (getCachedUserSocial as jest.Mock).mockResolvedValue(mockAuthUser);
 
     const { container } = await render(await BlockedUsers());
     expect(container.querySelector("ul")).toBeInTheDocument();
@@ -42,7 +42,7 @@ describe("BlockedUsers", () => {
 
   it("shows empty state message when no blocked users", async () => {
     const mockAuthUser = { blocked: [] };
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockAuthUser);
+    (getCachedUserSocial as jest.Mock).mockResolvedValue(mockAuthUser);
 
     await render(await BlockedUsers());
     expect(screen.getByText("You have no blocked users")).toBeInTheDocument();

--- a/frontend/tests/components/friends/friend-sent-requests.test.tsx
+++ b/frontend/tests/components/friends/friend-sent-requests.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import { FriendSentRequests } from "@/components/friends/friend-sent-requests";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUserSocial } from "@/lib/requests/cached";
 
 jest.mock("@/lib/auth/session", () => ({
   getCurrentUser: jest.fn(),
 }));
 
-jest.mock("@/lib/requests/authorized-user", () => ({
-  getAuthorizedUserByEmail: jest.fn(),
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedUserSocial: jest.fn(),
 }));
 
 describe("FriendSentRequests", () => {
@@ -26,7 +26,7 @@ describe("FriendSentRequests", () => {
       blocked: [],
       was_blocked: [],
     };
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockAuthUser);
+    (getCachedUserSocial as jest.Mock).mockResolvedValue(mockAuthUser);
 
     const { container } = await render(await FriendSentRequests());
     expect(container.querySelector("ul")).toBeInTheDocument();
@@ -38,7 +38,7 @@ describe("FriendSentRequests", () => {
       blocked: [],
       was_blocked: [],
     };
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockAuthUser);
+    (getCachedUserSocial as jest.Mock).mockResolvedValue(mockAuthUser);
 
     await render(await FriendSentRequests());
     expect(screen.getByText("You have no sent requests")).toBeInTheDocument();
@@ -61,7 +61,7 @@ describe("FriendSentRequests", () => {
       };
 
       (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-      (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockAuthUser);
+      (getCachedUserSocial as jest.Mock).mockResolvedValue(mockAuthUser);
 
       const Component = await FriendSentRequests();
       const { container } = render(Component);

--- a/frontend/tests/components/friends/friends.test.tsx
+++ b/frontend/tests/components/friends/friends.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Friends } from "@/components/friends/friends";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
+import { getCachedUser } from "@/lib/requests/cached";
 import { fetchFriends } from "@/lib/requests/friends";
 import { notFound } from "next/navigation";
 
@@ -13,8 +13,8 @@ jest.mock("next/navigation", () => ({
   notFound: jest.fn(),
 }));
 
-jest.mock("@/lib/requests/authorized-user", () => ({
-  getAuthorizedUserByEmail: jest.fn(),
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedUser: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/friends", () => ({
@@ -45,7 +45,7 @@ describe("Friends", () => {
       },
     ];
 
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockAuthUser);
+    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthUser);
     (fetchFriends as jest.Mock).mockResolvedValue(mockFriends);
 
     const { container } = await render(await Friends());
@@ -69,7 +69,7 @@ describe("Friends", () => {
       email: "test@example.com",
     };
 
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockAuthUser);
+    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthUser);
     (fetchFriends as jest.Mock).mockResolvedValue([]);
 
     await render(await Friends());
@@ -82,7 +82,7 @@ describe("Friends", () => {
       email: "test@example.com",
     };
 
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockAuthUser);
+    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthUser);
     (fetchFriends as jest.Mock).mockResolvedValue([]);
 
     await render(await Friends());


### PR DESCRIPTION

## Description
Wrapped getCurrentUser() and getAuthorizedUserByEmail() with React.cache so they only fire once per render instead of 3-5+ times. getServerSession() is a NextAuth SDK call, not a fetch(), so React's built-in fetch dedup doesn't cover it.          

- Added React.cache to getCurrentUser()
- Created lib/requests/cached.ts with cached wrappers for each populate preset (profile, social, dashboard, creation)
- Updated 33 server component callsites to use the cached versions
- Left server actions and custom populates alone since they don't benefit from dedup
- Also fixed settings/notes/page.tsx which was calling getServerSession() directly instead of going through getCurrentUser()
- Added React.cache passthrough in jest setup so tests don't break

## Motivation and Context

Pages like the dashboard were hitting Strapi ~13 times per render because the layout, header, page, and child components all independently fetch the same user. With caching, that drops to about 3 calls (one per populate preset). Builds on ODY-302's populate presets.

## Screenshots (if appropriate):


## Checklist:


- [X] My code follows the code style of this project.
- [X] I have moved the ticket to "In Review"
- [X] I have added reviewers to this PR
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.