### PR TITLE
ODY-310: Batch user lookup in ensureAuthorizedUsers 

### DIFF
--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -136,6 +136,33 @@ export async function getAuthorizedUserByEmail<
   );
 }
 
+/**
+ * Batch-fetches authorized users whose email is in the given list.
+ * Returns only `id` and `email` — designed for membership resolution, not
+ * full profile loads.
+ */
+export async function getAuthorizedUsersByEmails(
+  emails: string[],
+): Promise<Array<{ id: number; email: string }>> {
+  if (emails.length === 0) return [];
+
+  const path = `/authorized-users`;
+  const urlParams = {
+    filters: {
+      email: { $in: emails },
+    },
+    fields: ["id", "email"],
+    pagination: {
+      pageSize: emails.length,
+      page: 1,
+    },
+  };
+
+  return await fetchAPI<Array<{ id: number; email: string }>>(path, {
+    urlParams,
+  });
+}
+
 export async function fetchAuthorizedUsers(): Promise<AuthorizedUser[]> {
   try {
     let page = 1;

--- a/frontend/lib/requests/groups.ts
+++ b/frontend/lib/requests/groups.ts
@@ -3,13 +3,16 @@
 import { Group } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
 import { fetchAPI } from "@/lib/utils";
-import { getAuthorizedUserByEmail } from "./authorized-user";
+import {
+  getAuthorizedUserByEmail,
+  getAuthorizedUsersByEmails,
+  createAuthorizedUser,
+} from "./authorized-user";
 import type { Droplet, DueDate, Playlist } from "@/types";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { enrollInPlaylist } from "./playlist-enrollment";
 import { getCurrentUser } from "../auth/session";
 import { createEnrollmentFromEmail } from "./enrollment";
-import { createAuthorizedUser } from "./authorized-user";
 
 const STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -552,29 +555,36 @@ export async function updateGroup(
 async function ensureAuthorizedUsers(
   emails: string[],
 ): Promise<Array<{ id: number; email: string }>> {
-  const results = [];
+  if (emails.length === 0) return [];
 
-  for (const email of emails) {
-    try {
-      const existingUser = await getAuthorizedUserByEmail(email);
-      if (existingUser) {
-        results.push({ id: existingUser.id, email });
-      } else {
-        const formData = new FormData();
-        formData.append("email", email);
-        formData.append("isEnabled", "true");
-        const newUser = await createAuthorizedUser(formData);
-        const newUserData = await getAuthorizedUserByEmail(email);
-        if (newUser.ok && newUserData) {
-          results.push({ id: newUserData.id, email });
+  const existingUsers = await getAuthorizedUsersByEmails(emails);
+
+  const existingEmailSet = new Set(
+    existingUsers.map((u) => u.email.toLowerCase()),
+  );
+  const missingEmails = emails.filter(
+    (e) => !existingEmailSet.has(e.toLowerCase()),
+  );
+
+  if (missingEmails.length > 0) {
+    await Promise.all(
+      missingEmails.map(async (email) => {
+        try {
+          const formData = new FormData();
+          formData.append("email", email);
+          formData.append("isEnabled", "true");
+          await createAuthorizedUser(formData);
+        } catch (error) {
+          console.error(`Failed to create user: ${email}`, error);
         }
-      }
-    } catch (error) {
-      console.error(`Failed to process email: ${email}`, error);
-    }
+      }),
+    );
+
+    const newUsers = await getAuthorizedUsersByEmails(missingEmails);
+    existingUsers.push(...newUsers);
   }
 
-  return results;
+  return existingUsers.map((u) => ({ id: u.id, email: u.email }));
 }
 
 export async function enrollUsers(group: Group) {

--- a/frontend/testing/requests/authorized-users.test.js
+++ b/frontend/testing/requests/authorized-users.test.js
@@ -1,5 +1,6 @@
 const {
   getAuthorizedUserByEmail,
+  getAuthorizedUsersByEmails,
   fetchAuthorizedUsers,
   fetchAuthorizedUsersMetadata,
   fetchIsAuthorizedUser,
@@ -124,6 +125,80 @@ describe("Authorized User Tests", () => {
           }),
         }),
       });
+    });
+  });
+
+  describe("getAuthorizedUsersByEmails", () => {
+    it("should return matching users for a list of emails", async () => {
+      const emails = ["a@test.com", "b@test.com", "c@test.com"];
+      const mockUsers = [
+        { id: 1, email: "a@test.com" },
+        { id: 2, email: "b@test.com" },
+        { id: 3, email: "c@test.com" },
+      ];
+      fetchAPI.mockResolvedValueOnce(mockUsers);
+
+      const result = await getAuthorizedUsersByEmails(emails);
+
+      expect(result).toEqual(mockUsers);
+      expect(fetchAPI).toHaveBeenCalledTimes(1);
+    });
+
+    it("should send $in filter with all provided emails", async () => {
+      const emails = ["a@test.com", "b@test.com"];
+      fetchAPI.mockResolvedValueOnce([]);
+
+      await getAuthorizedUsersByEmails(emails);
+
+      const callArgs = fetchAPI.mock.calls[0];
+      expect(callArgs[0]).toBe("/authorized-users");
+      expect(callArgs[1].urlParams.filters).toEqual({
+        email: { $in: emails },
+      });
+    });
+
+    it("should only request id and email fields", async () => {
+      fetchAPI.mockResolvedValueOnce([]);
+
+      await getAuthorizedUsersByEmails(["a@test.com"]);
+
+      const { fields } = fetchAPI.mock.calls[0][1].urlParams;
+      expect(fields).toEqual(["id", "email"]);
+    });
+
+    it("should set pageSize to the number of emails", async () => {
+      const emails = ["a@test.com", "b@test.com", "c@test.com"];
+      fetchAPI.mockResolvedValueOnce([]);
+
+      await getAuthorizedUsersByEmails(emails);
+
+      const { pagination } = fetchAPI.mock.calls[0][1].urlParams;
+      expect(pagination).toEqual({ pageSize: 3, page: 1 });
+    });
+
+    it("should return empty array for empty email list without calling API", async () => {
+      const result = await getAuthorizedUsersByEmails([]);
+
+      expect(result).toEqual([]);
+      expect(fetchAPI).not.toHaveBeenCalled();
+    });
+
+    it("should return partial results when only some emails match", async () => {
+      const emails = ["exists@test.com", "missing@test.com"];
+      fetchAPI.mockResolvedValueOnce([{ id: 1, email: "exists@test.com" }]);
+
+      const result = await getAuthorizedUsersByEmails(emails);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].email).toBe("exists@test.com");
+    });
+
+    it("should handle fetch errors", async () => {
+      fetchAPI.mockRejectedValueOnce(new Error("API Error"));
+
+      await expect(
+        getAuthorizedUsersByEmails(["a@test.com"]),
+      ).rejects.toThrow("API Error");
     });
   });
 

--- a/frontend/testing/requests/authorized-users.test.js
+++ b/frontend/testing/requests/authorized-users.test.js
@@ -196,9 +196,9 @@ describe("Authorized User Tests", () => {
     it("should handle fetch errors", async () => {
       fetchAPI.mockRejectedValueOnce(new Error("API Error"));
 
-      await expect(
-        getAuthorizedUsersByEmails(["a@test.com"]),
-      ).rejects.toThrow("API Error");
+      await expect(getAuthorizedUsersByEmails(["a@test.com"])).rejects.toThrow(
+        "API Error",
+      );
     });
   });
 

--- a/frontend/testing/requests/groups.test.js
+++ b/frontend/testing/requests/groups.test.js
@@ -25,6 +25,8 @@ const {
 const { fetchAPI } = require("../../lib/utils");
 const {
   getAuthorizedUserByEmail,
+  getAuthorizedUsersByEmails,
+  createAuthorizedUser,
 } = require("../../lib/requests/authorized-user");
 const { createEnrollmentFromEmail } = require("../../lib/requests/enrollment");
 const { enrollInPlaylist } = require("../../lib/requests/playlist-enrollment");
@@ -49,6 +51,8 @@ jest.mock("../../lib/utils", () => ({
 
 jest.mock("../../lib/requests/authorized-user", () => ({
   getAuthorizedUserByEmail: jest.fn(),
+  getAuthorizedUsersByEmails: jest.fn(),
+  createAuthorizedUser: jest.fn(),
 }));
 
 jest.mock("../../lib/requests/enrollment", () => ({
@@ -777,14 +781,10 @@ describe("Groups Tests", () => {
         playlists: [3, 4],
       };
 
-      getAuthorizedUserByEmail.mockResolvedValueOnce({
-        id: 20,
-        email: "member1@northeastern.edu",
-      });
-      getAuthorizedUserByEmail.mockResolvedValueOnce({
-        id: 21,
-        email: "member2@northeastern.edu",
-      });
+      getAuthorizedUsersByEmails.mockResolvedValueOnce([
+        { id: 20, email: "member1@northeastern.edu" },
+        { id: 21, email: "member2@northeastern.edu" },
+      ]);
 
       const mockCreatedGroup = {
         id: 123,
@@ -799,6 +799,11 @@ describe("Groups Tests", () => {
       const result = await createGroup(authorizedUserId, groupData);
 
       expect(result).toEqual(mockCreatedGroup);
+
+      expect(getAuthorizedUsersByEmails).toHaveBeenCalledWith([
+        "member1@northeastern.edu",
+        "member2@northeastern.edu",
+      ]);
 
       expect(fetchAPI).toHaveBeenCalledWith("/groups", {
         options: {
@@ -867,30 +872,36 @@ describe("Groups Tests", () => {
         },
       };
 
-      getAuthorizedUserByEmail.mockResolvedValueOnce({
-        id: 30,
-        email: "existing@northeastern.edu",
-      });
+      // First batch lookup returns only the existing user
+      getAuthorizedUsersByEmails.mockResolvedValueOnce([
+        { id: 30, email: "existing@northeastern.edu" },
+      ]);
 
-      getAuthorizedUserByEmail.mockResolvedValueOnce(null);
+      // createAuthorizedUser succeeds for the missing email
+      createAuthorizedUser.mockResolvedValueOnce({ ok: true });
 
-      global.fetch = jest.fn().mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ data: { id: 31 } }),
-      });
+      // Second batch lookup (for newly created users) returns the new user
+      getAuthorizedUsersByEmails.mockResolvedValueOnce([
+        { id: 31, email: "new@northeastern.edu" },
+      ]);
 
       fetchAPI.mockResolvedValueOnce({ id: 125, groupName: "Test Group" });
 
       await createGroup(authorizedUserId, groupData);
 
-      expect(getAuthorizedUserByEmail).toHaveBeenCalledWith(
+      expect(getAuthorizedUsersByEmails).toHaveBeenCalledWith([
         "existing@northeastern.edu",
-      );
-      expect(getAuthorizedUserByEmail).toHaveBeenCalledWith(
         "new@northeastern.edu",
-      );
+      ]);
+      expect(createAuthorizedUser).toHaveBeenCalled();
+      expect(getAuthorizedUsersByEmails).toHaveBeenCalledWith([
+        "new@northeastern.edu",
+      ]);
 
       const requestBody = JSON.parse(fetchAPI.mock.calls[0][1].options.body);
+      expect(requestBody.data.members.set).toEqual(
+        expect.arrayContaining([{ id: 30 }, { id: 31 }]),
+      );
     });
 
     it("should handle errors during group creation", async () => {
@@ -1077,14 +1088,10 @@ describe("Groups Tests", () => {
         ],
       };
 
-      getAuthorizedUserByEmail.mockResolvedValueOnce({
-        id: 20,
-        email: "member1@northeastern.edu",
-      });
-      getAuthorizedUserByEmail.mockResolvedValueOnce({
-        id: 21,
-        email: "member2@northeastern.edu",
-      });
+      getAuthorizedUsersByEmails.mockResolvedValueOnce([
+        { id: 20, email: "member1@northeastern.edu" },
+        { id: 21, email: "member2@northeastern.edu" },
+      ]);
 
       const mockUpdatedGroup = {
         id: 1,
@@ -1099,6 +1106,11 @@ describe("Groups Tests", () => {
       const result = await updateGroup(groupId, updateData);
 
       expect(result).toEqual(mockUpdatedGroup);
+
+      expect(getAuthorizedUsersByEmails).toHaveBeenCalledWith([
+        "member1@northeastern.edu",
+        "member2@northeastern.edu",
+      ]);
 
       expect(fetchAPI).toHaveBeenCalledWith(`/groups/${groupId}`, {
         options: {
@@ -1180,14 +1192,10 @@ describe("Groups Tests", () => {
         ],
       };
 
-      getAuthorizedUserByEmail.mockResolvedValueOnce({
-        id: 101,
-        email: "email1@northeastern.edu",
-      });
-      getAuthorizedUserByEmail.mockResolvedValueOnce({
-        id: 102,
-        email: "email2@northeastern.edu",
-      });
+      getAuthorizedUsersByEmails.mockResolvedValueOnce([
+        { id: 101, email: "email1@northeastern.edu" },
+        { id: 102, email: "email2@northeastern.edu" },
+      ]);
 
       fetchAPI.mockResolvedValueOnce({ id: 1 });
 


### PR DESCRIPTION
## Description

Replaces the sequential per-email `getAuthorizedUserByEmail` loop inside `ensureAuthorizedUsers` with a single batched Strapi query using `$in` filters, and creates missing users in parallel via `Promise.all`.

## Motivation and Context

- **`authorized-user.ts`** — Added `getAuthorizedUsersByEmails(emails)`, a lean batch lookup that sends one query with `email: { $in: emails }` and only requests `id` + `email` fields (no friendship/playlist/group populates).
- **`groups.ts`** — Rewrote `ensureAuthorizedUsers` to:
  1. Batch-fetch all existing users in 1 query
  2. Diff to find missing emails
  3. Create missing users in parallel with `Promise.all`
  4. Batch-fetch newly created users in 1 query (only if any were missing)
- **Updated imports** in `groups.ts` to use the new consolidated import from `authorized-user`.

**Before:** A group with 30 members triggered 30–60 sequential Strapi queries (each with full default populates).
**After:** 1–2 lean queries total regardless of member count.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.