### PR TITLE
ODY-304, ODY-305: Lean explore queries + enrollment populate presets

### DIFF
--- a/frontend/app/(droplets)/d/[slug]/[lessonSlug]/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/[lessonSlug]/page.tsx
@@ -1,9 +1,7 @@
 import { Metadata } from "next";
 import { getCachedUser } from "@/lib/requests/cached";
-import {
-  getEnrollmentsByAuthorizedUser,
-  updateCompletionDate,
-} from "@/lib/requests/enrollment";
+import { updateCompletionDate } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import { getDropletBySlug } from "@/lib/requests/droplet";
 import { getLessonBySlug } from "@/lib/requests/lesson";
 import { getCurrentUser } from "@/lib/auth/session";
@@ -51,7 +49,7 @@ export default async function Page({ params }: Props) {
 
   if (currentUser?.email) {
     const user = await getCachedUser(currentUser.email);
-    const enrollments = await getEnrollmentsByAuthorizedUser(user.id);
+    const enrollments = await getCachedEnrollmentsWithLessonIds(user.id);
 
     const enrollment = enrollments.find((e) => e.droplet.id === droplet.id);
 

--- a/frontend/app/(droplets)/d/[slug]/layout.tsx
+++ b/frontend/app/(droplets)/d/[slug]/layout.tsx
@@ -1,7 +1,7 @@
 import Sidebar from "@/components/droplets/sidebar";
 import { getCachedUser } from "@/lib/requests/cached";
 import { getDropletBySlug } from "@/lib/requests/droplet";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import { Metadata } from "next/types";
 import { AuthorizedUser, Droplet } from "@/types";
 import { getCurrentUser } from "@/lib/auth/session";
@@ -64,7 +64,7 @@ export default async function RootLayout({ params, children }: Props) {
 
   if (user?.email) {
     const sessionUser = await getCachedUser(user.email);
-    const enrollments = await getEnrollmentsByAuthorizedUser(sessionUser.id);
+    const enrollments = await getCachedEnrollmentsWithLessonIds(sessionUser.id);
 
     const currentEnrollment = enrollments.find(
       (enrollment) => enrollment.droplet?.id === droplet.id,

--- a/frontend/app/(droplets)/d/[slug]/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/page.tsx
@@ -14,8 +14,7 @@ import {
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedUser, getCachedEnrollments } from "@/lib/requests/cached";
 import { StarRating } from "@/components/ui/rating-stars";
 import { AuthorCard } from "@/components/droplets/author-block";
 
@@ -61,7 +60,7 @@ export default async function DropletRoute({ params }: Props) {
   if (user?.email) {
     const authorizedUser = await getCachedUser(user.email);
 
-    const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+    const enrollments = await getCachedEnrollments(authorizedUser.id);
     isEnrolled = enrollments.some((e) => e.droplet.id === droplet.id);
   }
 

--- a/frontend/app/(general)/dashboard/page.tsx
+++ b/frontend/app/(general)/dashboard/page.tsx
@@ -13,8 +13,10 @@ import {
   playlistSorting,
   sorting,
 } from "@/lib/globals";
-import { getCachedUserDashboard } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import {
+  getCachedUserDashboard,
+  getCachedEnrollmentsFavorites,
+} from "@/lib/requests/cached";
 import { getUserGroups } from "@/lib/requests/groups";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
@@ -38,7 +40,7 @@ export default async function DashboardRoute({ searchParams }: Props) {
   const archivedPlaylists = authorizedUser.playlists?.filter((playlist) =>
     playlist.users_archived?.some((user) => user.id === authorizedUser.id),
   );
-  const allEnrollments = await getEnrollmentsByAuthorizedUser(
+  const allEnrollments = await getCachedEnrollmentsFavorites(
     authorizedUser.id,
   );
   const allPlaylists = authorizedUser.playlists?.length || 0;

--- a/frontend/app/(general)/dashboard/page.tsx
+++ b/frontend/app/(general)/dashboard/page.tsx
@@ -40,9 +40,7 @@ export default async function DashboardRoute({ searchParams }: Props) {
   const archivedPlaylists = authorizedUser.playlists?.filter((playlist) =>
     playlist.users_archived?.some((user) => user.id === authorizedUser.id),
   );
-  const allEnrollments = await getCachedEnrollmentsFavorites(
-    authorizedUser.id,
-  );
+  const allEnrollments = await getCachedEnrollmentsFavorites(authorizedUser.id);
   const allPlaylists = authorizedUser.playlists?.length || 0;
   const allGroups = (await getUserGroups(authorizedUser.id)).filter((group) =>
     group.members?.some((member) => member.id === authorizedUser.id),

--- a/frontend/app/(general)/explore/page.tsx
+++ b/frontend/app/(general)/explore/page.tsx
@@ -37,102 +37,70 @@ export default async function ExplorePage({
     contentType = "droplets",
   } = (await searchParams) as { [key: string]: string };
   const { sortKey } = sorting.find((item) => item.slug === sort) || defaultSort;
-  const droplets = await getDroplets({
-    filters: {
-      $and: [
-        { status: { $eq: "published" } },
-        { isHidden: false },
-        type
-          ? { $or: type.split(",").map((val) => ({ type: { $eq: val } })) }
-          : {},
-        focusArea
-          ? {
-              $or: focusArea
-                .split(",")
-                .map((val) => ({ focusArea: { $eq: val } })),
-            }
-          : {},
-        tags
-          ? {
-              $or: tags
-                .split(",")
-                .map((val) => ({ tags: { slug: { $eq: val } } })),
-            }
-          : {},
-      ],
-    },
-    populate: {
-      lessons: {
-        fields: ["*"],
-        populate: {
-          blocks: {
-            on: {
-              "droplets.generic": {
-                populate: "*",
-              },
-              "droplets.expandable": {
-                populate: "*",
-              },
-              "droplets.callout": {
-                populate: "*",
-              },
-              "droplets.video": {
-                populate: "*",
-              },
-              "droplets.quiz": {
-                populate: {
-                  questions: {
-                    populate: {
-                      answerOptions: true,
-                    },
-                  },
-                },
-              },
-              "droplets.open-ended-quiz": {
-                populate: {
-                  questions: true,
+  const droplets =
+    contentType === "droplets"
+      ? await getDroplets({
+          filters: {
+            $and: [
+              { status: { $eq: "published" } },
+              { isHidden: false },
+              type
+                ? {
+                    $or: type.split(",").map((val) => ({ type: { $eq: val } })),
+                  }
+                : {},
+              focusArea
+                ? {
+                    $or: focusArea
+                      .split(",")
+                      .map((val) => ({ focusArea: { $eq: val } })),
+                  }
+                : {},
+              tags
+                ? {
+                    $or: tags
+                      .split(",")
+                      .map((val) => ({ tags: { slug: { $eq: val } } })),
+                  }
+                : {},
+            ],
+          },
+          populate: {
+            lessons: { fields: ["id"] },
+            tags: { fields: ["id", "name", "slug"] },
+            authorized_users: { fields: ["id", "firstName", "lastName"] },
+          },
+          fields: [
+            "id",
+            "name",
+            "slug",
+            "type",
+            "focusArea",
+            "averageRating",
+            "description",
+            "isHidden",
+            "status",
+          ],
+        })
+      : [];
+
+  const playlists =
+    contentType === "playlists"
+      ? await getPlaylists({
+          filters: {
+            $and: [{ isPublic: true }],
+          },
+          populate: {
+            droplets: {
+              populate: {
+                lessons: {
+                  fields: ["id", "name", "slug"],
                 },
               },
             },
           },
-        },
-      },
-      tags: {
-        fields: ["*"],
-      },
-      authorized_users: {
-        fields: ["firstName", "lastName", "email"],
-      },
-      learningObjectives: {
-        fields: ["objective"],
-      },
-      nextSteps: {
-        fields: ["label", "url"],
-      },
-      prerequisites: {
-        fields: ["name"],
-      },
-      postrequisites: {
-        fields: ["name"],
-      },
-    },
-    fields: ["*"],
-  });
-
-  const playlists = await getPlaylists({
-    filters: {
-      $and: [{ isPublic: true }],
-    },
-    populate: {
-      droplets: {
-        populate: {
-          lessons: {
-            fields: ["id", "name", "slug"],
-          },
-        },
-      },
-    },
-  });
+        })
+      : [];
 
   return (
     <SearchProvider>
@@ -143,8 +111,10 @@ export default async function ExplorePage({
       <div className="mx-auto mt-4 mb-8 w-full max-w-7xl px-4 xl:p-0">
         <div className="flex flex-col gap-4 rounded-md border border-slate-200 bg-slate-50 p-4 dark:border-slate-500 dark:bg-slate-800">
           <ContentTypeSelector
-            droplets={droplets.length}
-            playlists={playlists.length}
+            droplets={contentType === "droplets" ? droplets.length : undefined}
+            playlists={
+              contentType === "playlists" ? playlists.length : undefined
+            }
           />
 
           <div className="flex flex-col gap-2 md:flex-row md:items-center">

--- a/frontend/app/(playlists)/p/[slug]/page.tsx
+++ b/frontend/app/(playlists)/p/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { DropletTile } from "@/components/droplets/droplet-tile";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
@@ -71,7 +71,9 @@ export default async function PlaylistPage({ params }: Props) {
 
   if (user?.email) {
     const authorizedUser = await getCachedUser(user.email);
-    const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+    const enrollments = await getCachedEnrollmentsWithLessonIds(
+      authorizedUser.id,
+    );
     enrolledDropletIds = enrollments.map((e) => e.droplet.id);
 
     completedLessonIds = enrollments.flatMap(

--- a/frontend/components/admin/progress/student-progress.tsx
+++ b/frontend/components/admin/progress/student-progress.tsx
@@ -1,5 +1,5 @@
 import { getCurrentUser } from "@/lib/auth/session";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import { StudentProgressList } from "./student-progress-list";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
 
@@ -42,7 +42,7 @@ export async function StudentProgress() {
     playlists.map(async (playlist) => {
       const usersWithProgress = await Promise.all(
         (playlist.authorized_users || []).map(async (user: AuthorizedUser) => {
-          const enrollments = await getEnrollmentsByAuthorizedUser(user.id);
+          const enrollments = await getCachedEnrollmentsWithLessonIds(user.id);
           const completedLessonIds = enrollments.flatMap(
             (enrollment) =>
               enrollment.viewedLessons?.map((lesson: Lesson) => lesson.id) ||

--- a/frontend/components/dashboard/archived-droplets-grid.tsx
+++ b/frontend/components/dashboard/archived-droplets-grid.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/components/message";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsDashboard } from "@/lib/requests/cached";
 import { EnrolledDropletsGridClient } from "./enrolled-droplets-grid-client";
 
 interface Lesson {
@@ -19,7 +19,7 @@ export async function ArchivedDropletsGrid({ sortKey }: { sortKey?: string }) {
   if (!user?.email) return null;
 
   const authorizedUser = await getCachedUser(user.email);
-  const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+  const enrollments = await getCachedEnrollmentsDashboard(authorizedUser.id);
 
   const filteredEnrollments = enrollments.filter((e) => e.isArchived === true);
 

--- a/frontend/components/dashboard/archived-playlists-grid.tsx
+++ b/frontend/components/dashboard/archived-playlists-grid.tsx
@@ -1,6 +1,6 @@
 import { getCurrentUser } from "@/lib/auth/session";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import {
   Message,
   MessageDescription,
@@ -41,7 +41,9 @@ export async function ArchivedPlaylistsGrid({ sortKey }: { sortKey?: string }) {
     },
   });
 
-  const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+  const enrollments = await getCachedEnrollmentsWithLessonIds(
+    authorizedUser.id,
+  );
   const completedLessonIds = enrollments.flatMap(
     (enrollment) =>
       enrollment.viewedLessons?.map((lesson: Lesson) => lesson.id) || [],

--- a/frontend/components/dashboard/enrolled-droplets-grid.tsx
+++ b/frontend/components/dashboard/enrolled-droplets-grid.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/components/message";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsDashboard } from "@/lib/requests/cached";
 import { EnrolledDropletsGridClient } from "./enrolled-droplets-grid-client";
 import { getUserDueDates } from "@/lib/requests/groups";
 
@@ -30,7 +30,7 @@ export async function EnrolledDropletsGrid({
   if (!user?.email) return null;
 
   const authorizedUser = await getCachedUser(user.email);
-  const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+  const enrollments = await getCachedEnrollmentsDashboard(authorizedUser.id);
 
   const filteredEnrollments = enrollments.filter((e) => e.isArchived !== true);
 

--- a/frontend/components/dashboard/enrollments.tsx
+++ b/frontend/components/dashboard/enrollments.tsx
@@ -1,6 +1,6 @@
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsDashboard } from "@/lib/requests/cached";
 import { notFound } from "next/navigation";
 import { DropletTile } from "../droplets/droplet-tile";
 
@@ -9,21 +9,7 @@ export async function Enrollments() {
   if (!user?.email) return notFound();
 
   const authorizedUser = await getCachedUser(user.email);
-  const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id, {
-    populate: {
-      droplet: {
-        populate: {
-          tags: true,
-          lessons: {
-            fields: ["id", "name", "slug"],
-          },
-        },
-      },
-      viewedLessons: {
-        fields: ["id", "name", "slug"],
-      },
-    },
-  });
+  const enrollments = await getCachedEnrollmentsDashboard(authorizedUser.id);
 
   return (
     <ul className="grid grid-flow-row grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">

--- a/frontend/components/dashboard/favorited-droplet-grid.tsx
+++ b/frontend/components/dashboard/favorited-droplet-grid.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/components/message";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsFavorites } from "@/lib/requests/cached";
 import { EnrolledDropletsGridClient } from "./enrolled-droplets-grid-client";
 import { Lesson } from "@/types";
 
@@ -14,7 +14,7 @@ export async function FavoriteDropletsGrid({ sortKey }: { sortKey?: string }) {
   if (!user?.email) return null;
 
   const authorizedUser = await getCachedUser(user.email);
-  const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+  const enrollments = await getCachedEnrollmentsFavorites(authorizedUser.id);
 
   // Fixed: Added return and compare IDs instead of objects
   const filteredEnrollments = enrollments.filter((e) =>

--- a/frontend/components/dashboard/user-playlists-grid.tsx
+++ b/frontend/components/dashboard/user-playlists-grid.tsx
@@ -1,6 +1,6 @@
 import { getCurrentUser } from "@/lib/auth/session";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import {
   Message,
   MessageDescription,
@@ -41,7 +41,9 @@ export async function UserPlaylistsGrid({ sortKey }: { sortKey?: string }) {
     },
   });
 
-  const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+  const enrollments = await getCachedEnrollmentsWithLessonIds(
+    authorizedUser.id,
+  );
   const completedLessonIds = enrollments.flatMap(
     (enrollment) =>
       enrollment.viewedLessons?.map((lesson: Lesson) => lesson.id) || [],

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -12,7 +12,11 @@ import { toast } from "sonner";
 import { Archive, ArchiveRestore, Clock, Download } from "lucide-react";
 import { getDueDateBadgeColor } from "@/lib/utils";
 import { DateTime } from "luxon";
-import { archiveDroplet, favoriteDroplet } from "@/lib/requests/droplet";
+import {
+  archiveDroplet,
+  favoriteDroplet,
+  getDropletBySlug,
+} from "@/lib/requests/droplet";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 
@@ -157,42 +161,73 @@ export function DropletTile({
   }
 
   async function exportDropletMarkdown() {
-    // mock markdown content
-    const contentMeta = `# ${droplet.name}
+    const fullDroplet = await getDropletBySlug(droplet.slug, {
+      populate: {
+        authorized_users: { fields: ["firstName", "lastName"] },
+        learningObjectives: { fields: ["objective"] },
+        nextSteps: { fields: ["label", "url"] },
+        prerequisites: { fields: ["name"] },
+        postrequisites: { fields: ["name"] },
+        tags: { fields: ["name"] },
+        lessons: {
+          fields: ["*"],
+          populate: {
+            blocks: {
+              on: {
+                "droplets.generic": { populate: "*" },
+                "droplets.expandable": { populate: "*" },
+                "droplets.callout": { populate: "*" },
+                "droplets.video": { populate: "*" },
+                "droplets.quiz": {
+                  populate: {
+                    questions: { populate: { answerOptions: true } },
+                  },
+                },
+                "droplets.open-ended-quiz": {
+                  populate: { questions: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const contentMeta = `# ${fullDroplet.name}
 
 ## **Metadata**
 
-Type: ${droplet.type}
-Focus Area: ${droplet.focusArea}
+Type: ${fullDroplet.type}
+Focus Area: ${fullDroplet.focusArea}
 
 ### Tags
-${droplet.tags?.map((tag) => `* ${tag.name}`).join("\n") || "No tags"}
+${fullDroplet.tags?.map((tag) => `* ${tag.name}`).join("\n") || "No tags"}
 
 ### Authors
-${droplet.authorized_users?.map((user) => `* ${user.firstName} ${user.lastName}`).join("\n") || "No authors"}
+${fullDroplet.authorized_users?.map((user) => `* ${user.firstName} ${user.lastName}`).join("\n") || "No authors"}
 
 ### Description
-${droplet.description ? droplet.description.concat("\n") : "No description"} 
+${fullDroplet.description ? fullDroplet.description.concat("\n") : "No description"}
 
 ### Overview
-${droplet.overview ? droplet.overview.concat("\n") : "No overview"}
+${fullDroplet.overview ? fullDroplet.overview.concat("\n") : "No overview"}
 
 ### Learning Objectives
-${droplet.learningObjectives?.map((objective) => `* ${objective.objective}`).join("\n") || "No objectives"}
+${fullDroplet.learningObjectives?.map((objective) => `* ${objective.objective}`).join("\n") || "No objectives"}
 
 ### Next Steps
-${droplet.nextSteps?.map((resource) => `* ${resource.label} linked to: ${resource.url}`).join("\n") || "No next steps"}
+${fullDroplet.nextSteps?.map((resource) => `* ${resource.label} linked to: ${resource.url}`).join("\n") || "No next steps"}
 
 ### Prerequisites
-${droplet.prerequisites?.map((prereq) => `* ${prereq.name}`).join("\n") || "No prereqs"}
+${fullDroplet.prerequisites?.map((prereq) => `* ${prereq.name}`).join("\n") || "No prereqs"}
 
 ### Postrequisites
-${droplet.postrequisites?.map((postreq) => `* ${postreq.name}`).join("\n") || "No postreqs"}`;
+${fullDroplet.postrequisites?.map((postreq) => `* ${postreq.name}`).join("\n") || "No postreqs"}`;
 
     const contentLessons = `
 ## **Lessons**
 ${
-  droplet.lessons
+  fullDroplet.lessons
     ?.map(
       (lesson) => `
 ### ${lesson.name}
@@ -267,7 +302,7 @@ ${
 
     const link = document.createElement("a");
     link.href = url;
-    link.download = `${droplet.name}.md`;
+    link.download = `${fullDroplet.name}.md`;
 
     document.body.appendChild(link);
     link.click();

--- a/frontend/components/explore/content-type-selector.tsx
+++ b/frontend/components/explore/content-type-selector.tsx
@@ -7,12 +7,18 @@ export function ContentTypeSelector({
   droplets,
   playlists,
 }: {
-  droplets: number;
-  playlists: number;
+  droplets?: number;
+  playlists?: number;
 }) {
   const contentTypes = [
-    { name: `Droplets (${droplets})`, value: "droplets" },
-    { name: `Playlists (${playlists})`, value: "playlists" },
+    {
+      name: droplets !== undefined ? `Droplets (${droplets})` : "Droplets",
+      value: "droplets",
+    },
+    {
+      name: playlists !== undefined ? `Playlists (${playlists})` : "Playlists",
+      value: "playlists",
+    },
   ];
   const router = useRouter();
   const pathname = usePathname();

--- a/frontend/components/explore/droplets-grid.tsx
+++ b/frontend/components/explore/droplets-grid.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/components/message";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import { DropletTile } from "../droplets/droplet-tile";
 import { SortedDropletsGrid } from "./sorted-droplets-grid";
 import { Droplet, DueDate, Enrollment } from "@/types";
@@ -36,7 +36,7 @@ export async function DropletsGrid({
 
   if (user?.email) {
     const authorizedUser = await getCachedUser(user.email);
-    enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+    enrollments = await getCachedEnrollmentsWithLessonIds(authorizedUser.id);
 
     enrolledDropletIds = enrollments.map((e) => e.droplet.id);
     completedLessonIds = enrollments.flatMap(

--- a/frontend/components/explore/playlists-grid.tsx
+++ b/frontend/components/explore/playlists-grid.tsx
@@ -1,6 +1,8 @@
 import { getCurrentUser } from "@/lib/auth/session";
-import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import {
+  getCachedUser,
+  getCachedEnrollmentsWithLessonIds,
+} from "@/lib/requests/cached";
 import {
   Message,
   MessageDescription,
@@ -39,7 +41,9 @@ export async function PlaylistsGrid({
 
   if (user?.email) {
     authorizedUser = (await getCachedUser(user.email)) as AuthorizedUser;
-    const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+    const enrollments = await getCachedEnrollmentsWithLessonIds(
+      authorizedUser.id,
+    );
     completedLessonIds = enrollments.flatMap(
       (enrollment) =>
         enrollment.viewedLessons?.map((lesson: Lesson) => lesson.id) || [],

--- a/frontend/components/friends/friend-completed-droplets.tsx
+++ b/frontend/components/friends/friend-completed-droplets.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { AuthorizedUser, Droplet } from "@/types";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import { FriendCompletedDropletsList } from "./friend-completed-droplets-list";
 
 export function FriendCompletedDroplets({
@@ -16,7 +16,7 @@ export function FriendCompletedDroplets({
 
   useEffect(() => {
     async function fetchCompletedDroplets() {
-      const enrollments = await getEnrollmentsByAuthorizedUser(friend.id);
+      const enrollments = await getCachedEnrollmentsWithLessonIds(friend.id);
       if (enrollments) {
         const completed = enrollments
           .filter((e) => e.viewedLessons.length === e.droplet.lessons?.length)

--- a/frontend/lib/requests/cached.ts
+++ b/frontend/lib/requests/cached.ts
@@ -1,5 +1,7 @@
 import { cache } from "react";
 import { getAuthorizedUserByEmail } from "./authorized-user";
+import { getEnrollmentsByAuthorizedUser } from "./enrollment";
+import { ENROLLMENT_POPULATES } from "./enrollment-populates";
 import { USER_POPULATES } from "./user-populates";
 
 export const getCachedUser = cache((email: string) =>
@@ -16,4 +18,27 @@ export const getCachedUserDashboard = cache((email: string) =>
 
 export const getCachedUserCreation = cache((email: string) =>
   getAuthorizedUserByEmail(email, USER_POPULATES.creation),
+);
+
+export const getCachedEnrollments = cache((authorizedUserId: number) =>
+  getEnrollmentsByAuthorizedUser(authorizedUserId),
+);
+
+export const getCachedEnrollmentsWithLessonIds = cache(
+  (authorizedUserId: number) =>
+    getEnrollmentsByAuthorizedUser(authorizedUserId, {
+      populate: ENROLLMENT_POPULATES.withLessonIds,
+    }),
+);
+
+export const getCachedEnrollmentsDashboard = cache((authorizedUserId: number) =>
+  getEnrollmentsByAuthorizedUser(authorizedUserId, {
+    populate: ENROLLMENT_POPULATES.dashboard,
+  }),
+);
+
+export const getCachedEnrollmentsFavorites = cache((authorizedUserId: number) =>
+  getEnrollmentsByAuthorizedUser(authorizedUserId, {
+    populate: ENROLLMENT_POPULATES.favorites,
+  }),
 );

--- a/frontend/lib/requests/droplet.ts
+++ b/frontend/lib/requests/droplet.ts
@@ -61,12 +61,19 @@ export async function getDropletBySlug<T extends Partial<Droplet> = Droplet>(
   }: StrapiRequestParams = {},
 ): Promise<T> {
   const path = `/droplets`;
+  const resolvedPopulate =
+    typeof populate === "object" ? populate : { populate: "*" };
+  const existingLessons =
+    resolvedPopulate && typeof resolvedPopulate === "object"
+      ? (resolvedPopulate as Record<string, any>).lessons ?? {}
+      : {};
   const urlParams = {
     sort,
     filters: { ...filters, slug },
     populate: {
-      ...(typeof populate === "object" ? populate : { populate: "*" }),
+      ...resolvedPopulate,
       lessons: {
+        ...(typeof existingLessons === "object" ? existingLessons : {}),
         sort: ["orderIndex:asc"],
       },
     },

--- a/frontend/lib/requests/enrollment-populates.ts
+++ b/frontend/lib/requests/enrollment-populates.ts
@@ -1,0 +1,54 @@
+export const ENROLLMENT_POPULATES = {
+  /** Just droplet.id + viewedLessons ids — covers ~15 callsites */
+  minimal: {
+    droplet: { fields: ["id"] },
+    viewedLessons: { fields: ["id"] },
+  },
+  /** droplet.id + lesson ids + viewedLessons — for progress tracking */
+  withLessonIds: {
+    droplet: {
+      populate: { lessons: { fields: ["id"] } },
+      fields: ["id"],
+    },
+    viewedLessons: { fields: ["id"] },
+  },
+  /** Full droplet display data + tags + viewedLessons — for dashboard grids */
+  dashboard: {
+    droplet: {
+      populate: {
+        lessons: { fields: ["id", "name", "slug"] },
+        tags: { fields: ["id", "name", "slug"] },
+      },
+      fields: [
+        "id",
+        "name",
+        "slug",
+        "type",
+        "focusArea",
+        "averageRating",
+        "description",
+      ],
+    },
+    viewedLessons: { fields: ["id", "name", "slug"] },
+  },
+  /** Dashboard + usersFavorited — only for favorites grid */
+  favorites: {
+    droplet: {
+      populate: {
+        lessons: { fields: ["id", "name", "slug"] },
+        tags: { fields: ["id", "name", "slug"] },
+        usersFavorited: { fields: ["id"] },
+      },
+      fields: [
+        "id",
+        "name",
+        "slug",
+        "type",
+        "focusArea",
+        "averageRating",
+        "description",
+      ],
+    },
+    viewedLessons: { fields: ["id", "name", "slug"] },
+  },
+};

--- a/frontend/lib/requests/enrollment.ts
+++ b/frontend/lib/requests/enrollment.ts
@@ -3,6 +3,7 @@
 import { Enrollment, Lesson } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
 import { fetchAPI } from "../utils";
+import { ENROLLMENT_POPULATES } from "./enrollment-populates";
 
 import { getCurrentUser } from "@/lib/auth/session";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
@@ -25,25 +26,7 @@ export async function getEnrollmentsByAuthorizedUser(
     sort,
     filters,
     pagination = { pageSize: 250, page: 1 },
-    populate = {
-      droplet: {
-        populate: {
-          lessons: {
-            fields: ["id", "name", "slug"],
-          },
-          tags: {
-            fields: ["*"],
-          },
-          usersFavorited: {
-            fields: "*",
-          },
-        },
-        fields: ["id", "*"],
-      },
-      viewedLessons: {
-        fields: ["id", "name", "slug"],
-      },
-    },
+    populate = ENROLLMENT_POPULATES.minimal,
     fields = [
       "id",
       "rating",
@@ -70,7 +53,7 @@ export async function getEnrollmentsByAuthorizedUser(
   };
   return await fetchAPI<Enrollment[]>(path, {
     urlParams,
-    cache: "no-store",
+    next: { tags: ["enrollments"], revalidate: 0 },
   });
 }
 
@@ -112,7 +95,6 @@ export async function getEnrollmentsForGroupMembers(
     const enrollmentsPage = await fetchAPI<Enrollment[]>(path, {
       urlParams,
       next: { tags: ["enrollments"], revalidate: 0 },
-      cache: "no-store",
     });
 
     if (!enrollmentsPage || enrollmentsPage.length === 0) break;

--- a/frontend/tests/components/admin/student-progress.test.tsx
+++ b/frontend/tests/components/admin/student-progress.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { StudentProgress } from "@/components/admin/progress/student-progress";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 
 jest.mock("@/lib/auth/session", () => ({
   getCurrentUser: jest.fn(),
@@ -12,8 +12,8 @@ jest.mock("@/lib/requests/authorized-user", () => ({
   getAuthorizedUserByEmail: jest.fn(),
 }));
 
-jest.mock("@/lib/requests/enrollment", () => ({
-  getEnrollmentsByAuthorizedUser: jest.fn(),
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedEnrollmentsWithLessonIds: jest.fn(),
 }));
 
 jest.mock("@/components/admin/progress/student-progress-list", () => ({
@@ -59,7 +59,7 @@ describe("StudentProgress", () => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
     (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockAuthor);
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
   });
@@ -85,7 +85,7 @@ describe("StudentProgress", () => {
   it("calculates progress correctly", async () => {
     render(await StudentProgress());
 
-    expect(getEnrollmentsByAuthorizedUser).toHaveBeenCalledWith(2);
+    expect(getCachedEnrollmentsWithLessonIds).toHaveBeenCalledWith(2);
   });
 
   it("returns null when user is not found", async () => {
@@ -125,7 +125,7 @@ describe("StudentProgress", () => {
 
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
     (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(mockAuthor);
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -156,7 +156,7 @@ describe("StudentProgress", () => {
       mockAuthorizedUser,
     );
 
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue([
+    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValue([
       {
         viewedLessons: [{ id: 1 }, { id: 2 }],
       },
@@ -190,7 +190,7 @@ describe("StudentProgress", () => {
     (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
       mockAuthorizedUser,
     );
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue([]);
+    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValue([]);
 
     const { container } = await render(await StudentProgress());
     expect(container).toHaveTextContent(/in your private playlists/i);

--- a/frontend/tests/components/dashboard/archived-droplets-grid.test.tsx
+++ b/frontend/tests/components/dashboard/archived-droplets-grid.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { ArchivedDropletsGrid } from "@/components/dashboard/archived-droplets-grid";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsDashboard } from "@/lib/requests/cached";
 import { Enrollment } from "@/types";
 
 jest.mock("@/lib/auth/session", () => ({
@@ -11,11 +11,7 @@ jest.mock("@/lib/auth/session", () => ({
 
 jest.mock("@/lib/requests/cached", () => ({
   getCachedUser: jest.fn(),
-}));
-
-jest.mock("@/lib/requests/enrollment", () => ({
-  getEnrollmentsByAuthorizedUser: jest.fn(),
-  calculateDropletAverageRating: jest.fn(),
+  getCachedEnrollmentsDashboard: jest.fn(),
 }));
 
 jest.mock("@/components/dashboard/enrolled-droplets-grid-client", () => ({
@@ -63,7 +59,7 @@ describe("ArchivedDropletsGrid", () => {
   });
 
   it("displays a message when no archived droplets are found", async () => {
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue([]);
+    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue([]);
 
     render(await ArchivedDropletsGrid({}));
 
@@ -80,7 +76,7 @@ describe("ArchivedDropletsGrid", () => {
 
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
     (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -105,7 +101,7 @@ describe("ArchivedDropletsGrid", () => {
       },
     ];
 
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -120,18 +116,6 @@ describe("ArchivedDropletsGrid", () => {
     const result = await ArchivedDropletsGrid({});
     expect(result).toBeNull();
   });
-
-  jest.mock("@/lib/auth/session", () => ({
-    getCurrentUser: jest.fn(),
-  }));
-
-  jest.mock("@/lib/requests/authorized-user", () => ({
-    getAuthorizedUserByEmail: jest.fn(),
-  }));
-
-  jest.mock("@/lib/requests/enrollment", () => ({
-    getEnrollmentsByAuthorizedUser: jest.fn(),
-  }));
 
   describe("Droplets Grid Components", () => {
     const mockUser = {
@@ -162,7 +146,7 @@ describe("ArchivedDropletsGrid", () => {
       jest.clearAllMocks();
       (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
       (getCachedUser as jest.Mock).mockResolvedValue(mockUser);
-      (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+      (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
         mockEnrollments,
       );
     });
@@ -199,7 +183,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -219,7 +203,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -239,7 +223,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -259,7 +243,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -278,7 +262,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -297,7 +281,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -306,7 +290,7 @@ describe("ArchivedDropletsGrid", () => {
       });
 
       it("should show no archived droplets message when no archived enrollments", async () => {
-        (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue([]);
+        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue([]);
 
         render(await ArchivedDropletsGrid({}));
         expect(screen.getByText("No Archived Droplets")).toBeInTheDocument();
@@ -332,7 +316,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 

--- a/frontend/tests/components/dashboard/enrolled-droplets-grid.test.tsx
+++ b/frontend/tests/components/dashboard/enrolled-droplets-grid.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { EnrolledDropletsGrid } from "@/components/dashboard/enrolled-droplets-grid";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsDashboard } from "@/lib/requests/cached";
 import { getUserDueDates } from "@/lib/requests/groups";
 import { Enrollment } from "@/types";
 
@@ -12,11 +12,7 @@ jest.mock("@/lib/auth/session", () => ({
 
 jest.mock("@/lib/requests/cached", () => ({
   getCachedUser: jest.fn(),
-}));
-
-jest.mock("@/lib/requests/enrollment", () => ({
-  getEnrollmentsByAuthorizedUser: jest.fn(),
-  calculateDropletAverageRating: jest.fn(),
+  getCachedEnrollmentsDashboard: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/groups", () => ({
@@ -65,7 +61,7 @@ describe("EnrolledDropletsGrid", () => {
   });
 
   it("displays a message when no enrolled droplets are found", async () => {
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue([]);
+    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue([]);
 
     render(await EnrolledDropletsGrid({}));
 
@@ -82,7 +78,7 @@ describe("EnrolledDropletsGrid", () => {
 
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
     (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -107,7 +103,7 @@ describe("EnrolledDropletsGrid", () => {
       },
     ];
 
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -137,7 +133,7 @@ describe("EnrolledDropletsGrid", () => {
       },
     ];
 
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 

--- a/frontend/tests/components/dashboard/enrollments.test.tsx
+++ b/frontend/tests/components/dashboard/enrollments.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { Enrollments } from "@/components/dashboard/enrollments";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsDashboard } from "@/lib/requests/cached";
 import { notFound } from "next/navigation";
 import { Enrollment } from "@/types";
 
@@ -12,10 +12,7 @@ jest.mock("@/lib/auth/session", () => ({
 
 jest.mock("@/lib/requests/cached", () => ({
   getCachedUser: jest.fn(),
-}));
-
-jest.mock("@/lib/requests/enrollment", () => ({
-  getEnrollmentsByAuthorizedUser: jest.fn(),
+  getCachedEnrollmentsDashboard: jest.fn(),
 }));
 
 jest.mock("next/navigation", () => ({
@@ -67,7 +64,7 @@ describe("Enrollments", () => {
       },
     ];
 
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -85,29 +82,15 @@ describe("Enrollments", () => {
     expect(notFound).toHaveBeenCalled();
   });
 
-  it("passes the correct parameters to getEnrollmentsByAuthorizedUser", async () => {
+  it("passes the correct parameters to getCachedEnrollmentsDashboard", async () => {
     const mockEnrollments = [] as Enrollment[];
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
     await Enrollments();
 
-    expect(getEnrollmentsByAuthorizedUser).toHaveBeenCalledWith(1, {
-      populate: {
-        droplet: {
-          populate: {
-            tags: true,
-            lessons: {
-              fields: ["id", "name", "slug"],
-            },
-          },
-        },
-        viewedLessons: {
-          fields: ["id", "name", "slug"],
-        },
-      },
-    });
+    expect(getCachedEnrollmentsDashboard).toHaveBeenCalledWith(1);
   });
 
   it("calls notFound when user email is missing", async () => {
@@ -135,7 +118,7 @@ describe("Enrollments", () => {
       },
     ];
 
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -145,7 +128,7 @@ describe("Enrollments", () => {
   });
 
   it("renders correctly when there are no enrollments", async () => {
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue([]);
+    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue([]);
 
     render(await Enrollments());
 

--- a/frontend/tests/components/dashboard/my-content.test.tsx
+++ b/frontend/tests/components/dashboard/my-content.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { MyContent } from "@/components/dashboard/my-content";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { notFound } from "next/navigation";
 import { getUserGroups } from "@/lib/requests/groups";
 
@@ -12,11 +11,6 @@ jest.mock("@/lib/auth/session", () => ({
 
 jest.mock("@/lib/requests/cached", () => ({
   getCachedUser: jest.fn(),
-}));
-
-jest.mock("@/lib/requests/enrollment", () => ({
-  getEnrollmentsByAuthorizedUser: jest.fn(),
-  calculateDropletAverageRating: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/groups", () => ({
@@ -125,7 +119,6 @@ describe("MyContent", () => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
     (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue([]);
     (getUserGroups as jest.Mock).mockResolvedValue(mockGroups);
   });
 

--- a/frontend/tests/components/dashboard/user-playlist-grid.test.tsx
+++ b/frontend/tests/components/dashboard/user-playlist-grid.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { UserPlaylistsGrid } from "@/components/dashboard/user-playlists-grid";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import { getUserDueDates } from "@/lib/requests/groups";
 
 jest.mock("@/lib/auth/session", () => ({
@@ -13,8 +13,8 @@ jest.mock("@/lib/requests/authorized-user", () => ({
   getAuthorizedUserByEmail: jest.fn(),
 }));
 
-jest.mock("@/lib/requests/enrollment", () => ({
-  getEnrollmentsByAuthorizedUser: jest.fn(),
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedEnrollmentsWithLessonIds: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/groups", () => ({
@@ -57,7 +57,7 @@ describe("UserPlaylistsGrid", () => {
     (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
       mockAuthorizedUser,
     );
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue([]);
+    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValue([]);
     (getUserDueDates as jest.Mock).mockResolvedValue([]);
   });
 
@@ -157,7 +157,7 @@ describe("UserPlaylistsGrid", () => {
     (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
       mockUserWithPlaylists,
     );
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -172,22 +172,6 @@ describe("UserPlaylistsGrid", () => {
     const result = await UserPlaylistsGrid({});
     expect(result).toBeNull();
   });
-
-  jest.mock("@/lib/auth/session", () => ({
-    getCurrentUser: jest.fn(),
-  }));
-
-  jest.mock("@/lib/requests/authorized-user", () => ({
-    getAuthorizedUserByEmail: jest.fn(),
-  }));
-
-  jest.mock("@/lib/requests/enrollment", () => ({
-    getEnrollmentsByAuthorizedUser: jest.fn(),
-  }));
-
-  jest.mock("@/lib/requests/groups", () => ({
-    getUserDueDates: jest.fn(),
-  }));
 
   describe("UserPlaylistsGrid", () => {
     const mockUser = {
@@ -217,7 +201,7 @@ describe("UserPlaylistsGrid", () => {
         ...mockUser,
         playlists: mockPlaylists,
       });
-      (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValue([]);
+      (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValue([]);
       (getUserDueDates as jest.Mock).mockResolvedValue([]);
     });
 

--- a/frontend/tests/components/explore/exporting-markdown.test.tsx
+++ b/frontend/tests/components/explore/exporting-markdown.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { DropletTile } from "@/components/droplets/droplet-tile";
 import { Droplet } from "@/types";
+import { getDropletBySlug } from "@/lib/requests/droplet";
+
+jest.mock("@/lib/requests/droplet", () => ({
+  ...jest.requireActual("@/lib/requests/droplet"),
+  getDropletBySlug: jest.fn(),
+  archiveDroplet: jest.fn(),
+  favoriteDroplet: jest.fn(),
+}));
 
 // Mock URL.createObjectURL and URL.revokeObjectURL
 global.URL.createObjectURL = jest.fn(() => "blob:mock-url");
@@ -25,6 +33,17 @@ const getMarkdownContent = (blobSpy: jest.SpyInstance): string => {
   }
   return blobCall[0][0] as string;
 };
+
+/** Click export and wait for the async fetch + blob creation */
+async function clickExportAndWait(blobSpy: jest.SpyInstance) {
+  const exportButton = screen.getByRole("button", {
+    name: /export markdown/i,
+  });
+  fireEvent.click(exportButton);
+  await waitFor(() => {
+    expect(blobSpy).toHaveBeenCalled();
+  });
+}
 
 describe("Export Droplet to Markdown", () => {
   const mockDroplet: Droplet = {
@@ -147,6 +166,7 @@ describe("Export Droplet to Markdown", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (getDropletBySlug as jest.Mock).mockResolvedValue(mockDroplet);
   });
 
   describe("Button Visibility", () => {
@@ -175,15 +195,11 @@ describe("Export Droplet to Markdown", () => {
   });
 
   describe("Export Functionality", () => {
-    it("creates blob with correct markdown content", () => {
+    it("creates blob with correct markdown content", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       expect(blobSpy).toHaveBeenCalledWith(
         [expect.stringContaining("# Test Droplet")],
@@ -191,13 +207,10 @@ describe("Export Droplet to Markdown", () => {
       );
     });
 
-    it("creates and revokes object URL", () => {
+    it("creates and revokes object URL", async () => {
+      const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       expect(URL.createObjectURL).toHaveBeenCalled();
       expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
@@ -222,38 +235,29 @@ describe("Export Droplet to Markdown", () => {
   });
 
   describe("Markdown Content Structure", () => {
-    it("includes droplet name as h1", () => {
+    it("includes droplet name as h1", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("# Test Droplet");
     });
 
-    it("includes type and focus area", () => {
+    it("includes type and focus area", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("Type: skill");
       expect(markdownContent).toContain("Focus Area: technical"); // WITH SPACE!
     });
 
-    it("includes all tags", () => {
+    it("includes all tags", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("## Tags");
@@ -261,13 +265,10 @@ describe("Export Droplet to Markdown", () => {
       expect(markdownContent).toContain("* React");
     });
 
-    it("includes all authors", () => {
+    it("includes all authors", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("## Authors");
@@ -275,39 +276,30 @@ describe("Export Droplet to Markdown", () => {
       expect(markdownContent).toContain("* Jane Smith");
     });
 
-    it("includes description", () => {
+    it("includes description", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("## Description");
       expect(markdownContent).toContain("A test description");
     });
 
-    it("includes overview", () => {
+    it("includes overview", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("## Overview");
       expect(markdownContent).toContain("A test overview");
     });
 
-    it("includes all learning objectives", () => {
+    it("includes all learning objectives", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("## Learning Objectives");
@@ -315,13 +307,10 @@ describe("Export Droplet to Markdown", () => {
       expect(markdownContent).toContain("* Understand React components");
     });
 
-    it("includes next steps with links", () => {
+    it("includes next steps with links", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("### Next Steps");
@@ -333,13 +322,10 @@ describe("Export Droplet to Markdown", () => {
       );
     });
 
-    it("includes prerequisites", () => {
+    it("includes prerequisites", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("## Prerequisites");
@@ -347,38 +333,29 @@ describe("Export Droplet to Markdown", () => {
       expect(markdownContent).toContain("* CSS Fundamentals");
     });
 
-    it("includes postrequisites", () => {
+    it("includes postrequisites", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("## Postrequisites");
       expect(markdownContent).toContain("* Advanced Patterns");
     });
 
-    it("includes lessons section", () => {
+    it("includes lessons section", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("## **Lessons**");
     });
 
-    it("includes lesson names as h3", () => {
+    it("includes lesson names as h3", async () => {
       const blobSpy = jest.spyOn(global, "Blob");
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
       const markdownContent = getMarkdownContent(blobSpy);
 
       expect(markdownContent).toContain("### Introduction");
@@ -389,15 +366,11 @@ describe("Export Droplet to Markdown", () => {
   describe("Block Content Formatting", () => {
     let markdownContent: string;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={mockDroplet} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       markdownContent = getMarkdownContent(blobSpy);
     });
@@ -444,109 +417,91 @@ describe("Export Droplet to Markdown", () => {
   });
 
   describe("Edge Cases", () => {
-    it("handles droplet with no tags", () => {
+    it("handles droplet with no tags", async () => {
       const dropletNoTags = { ...mockDroplet, tags: undefined };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletNoTags);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletNoTags} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("No tags");
     });
 
-    it("handles droplet with no authors", () => {
+    it("handles droplet with no authors", async () => {
       const dropletNoAuthors = { ...mockDroplet, authorized_users: undefined };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletNoAuthors);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletNoAuthors} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("No authors");
     });
 
-    it("handles droplet with no lessons", () => {
+    it("handles droplet with no lessons", async () => {
       const dropletNoLessons = { ...mockDroplet, lessons: undefined };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletNoLessons);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletNoLessons} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("No lessons");
     });
 
-    it("handles droplet with empty learning objectives", () => {
+    it("handles droplet with empty learning objectives", async () => {
       const dropletNoObjectives = { ...mockDroplet, learningObjectives: [] };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletNoObjectives);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletNoObjectives} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("No objectives");
     });
 
-    it("handles droplet with no prerequisites", () => {
+    it("handles droplet with no prerequisites", async () => {
       const dropletNoPrereqs = { ...mockDroplet, prerequisites: undefined };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletNoPrereqs);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletNoPrereqs} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("No prereqs");
     });
 
-    it("handles droplet with no postrequisites", () => {
+    it("handles droplet with no postrequisites", async () => {
       const dropletNoPostreqs = { ...mockDroplet, postrequisites: undefined };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletNoPostreqs);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletNoPostreqs} isAdmin={true} />);
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("No postreqs");
     });
 
-    it("handles droplet with no next steps", () => {
+    it("handles droplet with no next steps", async () => {
       const dropletNoNextSteps = { ...mockDroplet, nextSteps: undefined };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletNoNextSteps);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletNoNextSteps} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("No next steps");
     });
 
-    it("handles lesson with no blocks", () => {
+    it("handles lesson with no blocks", async () => {
       const dropletEmptyBlocks = {
         ...mockDroplet,
         lessons: [
@@ -561,50 +516,41 @@ describe("Export Droplet to Markdown", () => {
           },
         ],
       };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletEmptyBlocks);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletEmptyBlocks} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("### Empty Lesson");
     });
 
-    it("handles droplet with special characters in name", () => {
+    it("handles droplet with special characters in name", async () => {
       const dropletSpecialName = {
         ...mockDroplet,
         name: 'Test & <Special> "Characters"',
       };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletSpecialName);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletSpecialName} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain('# Test & <Special> "Characters"');
     });
 
-    it("handles very long droplet content", () => {
+    it("handles very long droplet content", async () => {
       const longDroplet = {
         ...mockDroplet,
         description: "A".repeat(10000),
       };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(longDroplet);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={longDroplet} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       expect(blobSpy).toHaveBeenCalled();
       const markdownContent = getMarkdownContent(blobSpy);
@@ -613,7 +559,7 @@ describe("Export Droplet to Markdown", () => {
   });
 
   describe("Multiple Quiz Questions", () => {
-    it("handles quiz with multiple questions", () => {
+    it("handles quiz with multiple questions", async () => {
       const dropletMultiQuiz = {
         ...mockDroplet,
         lessons: [
@@ -650,14 +596,11 @@ describe("Export Droplet to Markdown", () => {
           },
         ],
       };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletMultiQuiz);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletMultiQuiz} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("1. Question 1");
@@ -666,7 +609,7 @@ describe("Export Droplet to Markdown", () => {
       expect(markdownContent).toContain("Answer D is correct");
     });
 
-    it("handles open-ended quiz with multiple questions", () => {
+    it("handles open-ended quiz with multiple questions", async () => {
       const dropletMultiOpenQuiz = {
         ...mockDroplet,
         lessons: [
@@ -697,14 +640,11 @@ describe("Export Droplet to Markdown", () => {
           },
         ],
       };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletMultiOpenQuiz);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletMultiOpenQuiz} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("1. Explain concept A");
@@ -715,7 +655,7 @@ describe("Export Droplet to Markdown", () => {
   });
 
   describe("Callout Content Variations", () => {
-    it("handles callout with multiple paragraphs", () => {
+    it("handles callout with multiple paragraphs", async () => {
       const dropletMultiParagraph = {
         ...mockDroplet,
         lessons: [
@@ -746,21 +686,18 @@ describe("Export Droplet to Markdown", () => {
           },
         ],
       };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletMultiParagraph);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletMultiParagraph} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("First paragraph");
       expect(markdownContent).toContain("Second paragraph");
     });
 
-    it("handles callout with empty content", () => {
+    it("handles callout with empty content", async () => {
       const dropletEmptyCallout = {
         ...mockDroplet,
         lessons: [
@@ -782,14 +719,11 @@ describe("Export Droplet to Markdown", () => {
           },
         ],
       };
+      (getDropletBySlug as jest.Mock).mockResolvedValue(dropletEmptyCallout);
       const blobSpy = jest.spyOn(global, "Blob");
 
       render(<DropletTile droplet={dropletEmptyCallout} isAdmin={true} />);
-
-      const exportButton = screen.getByRole("button", {
-        name: /export markdown/i,
-      });
-      fireEvent.click(exportButton);
+      await clickExportAndWait(blobSpy);
 
       const markdownContent = getMarkdownContent(blobSpy);
       expect(markdownContent).toContain("#### Callout Droplet");

--- a/frontend/tests/components/explore/playlists-grid.test.tsx
+++ b/frontend/tests/components/explore/playlists-grid.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { PlaylistsGrid } from "@/components/explore/playlists-grid";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "@/lib/requests/cached";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import { getUserDueDates } from "@/lib/requests/groups";
 import { Playlist, DueDate } from "@/types";
 
@@ -12,10 +12,7 @@ jest.mock("@/lib/auth/session", () => ({
 
 jest.mock("@/lib/requests/cached", () => ({
   getCachedUser: jest.fn(),
-}));
-
-jest.mock("@/lib/requests/enrollment", () => ({
-  getEnrollmentsByAuthorizedUser: jest.fn(),
+  getCachedEnrollmentsWithLessonIds: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/groups", () => ({
@@ -40,8 +37,8 @@ jest.mock("@/components/explore/sorted-playlists-grid", () => ({
 describe("PlaylistsGrid", () => {
   const mockGetCurrentUser = getCurrentUser as jest.Mock;
   const mockGetCachedUser = getCachedUser as jest.Mock;
-  const mockGetEnrollmentsByAuthorizedUser =
-    getEnrollmentsByAuthorizedUser as jest.Mock;
+  const mockGetCachedEnrollmentsWithLessonIds =
+    getCachedEnrollmentsWithLessonIds as jest.Mock;
   const mockGetUserDueDates = getUserDueDates as jest.Mock;
 
   beforeEach(() => {
@@ -71,7 +68,7 @@ describe("PlaylistsGrid", () => {
       expect(screen.getByText("Test Playlist")).toBeInTheDocument();
       expect(screen.getByText("Completion: 0.0%")).toBeInTheDocument();
       expect(mockGetCachedUser).not.toHaveBeenCalled();
-      expect(mockGetEnrollmentsByAuthorizedUser).not.toHaveBeenCalled();
+      expect(mockGetCachedEnrollmentsWithLessonIds).not.toHaveBeenCalled();
     });
 
     it("renders empty message when no playlists are provided", async () => {
@@ -125,7 +122,7 @@ describe("PlaylistsGrid", () => {
     beforeEach(() => {
       mockGetCurrentUser.mockResolvedValue(mockUser);
       mockGetCachedUser.mockResolvedValue(mockAuthorizedUser);
-      mockGetEnrollmentsByAuthorizedUser.mockResolvedValue([]);
+      mockGetCachedEnrollmentsWithLessonIds.mockResolvedValue([]);
       mockGetUserDueDates.mockResolvedValue([]);
     });
 
@@ -146,7 +143,7 @@ describe("PlaylistsGrid", () => {
 
       expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
       expect(mockGetCachedUser).toHaveBeenCalledWith("test@example.com");
-      expect(mockGetEnrollmentsByAuthorizedUser).toHaveBeenCalledWith(1);
+      expect(mockGetCachedEnrollmentsWithLessonIds).toHaveBeenCalledWith(1);
       expect(mockGetUserDueDates).toHaveBeenCalledWith(1);
     });
 
@@ -174,7 +171,7 @@ describe("PlaylistsGrid", () => {
         },
       ];
 
-      mockGetEnrollmentsByAuthorizedUser.mockResolvedValue([
+      mockGetCachedEnrollmentsWithLessonIds.mockResolvedValue([
         {
           id: 1,
           viewedLessons: [
@@ -212,7 +209,7 @@ describe("PlaylistsGrid", () => {
         },
       ];
 
-      mockGetEnrollmentsByAuthorizedUser.mockResolvedValue([
+      mockGetCachedEnrollmentsWithLessonIds.mockResolvedValue([
         {
           id: 1,
           viewedLessons: [
@@ -259,7 +256,7 @@ describe("PlaylistsGrid", () => {
         },
       ];
 
-      mockGetEnrollmentsByAuthorizedUser.mockResolvedValue([
+      mockGetCachedEnrollmentsWithLessonIds.mockResolvedValue([
         {
           id: 1,
           viewedLessons: [
@@ -319,7 +316,7 @@ describe("PlaylistsGrid", () => {
         },
       ];
 
-      mockGetEnrollmentsByAuthorizedUser.mockResolvedValue([
+      mockGetCachedEnrollmentsWithLessonIds.mockResolvedValue([
         {
           id: 1,
           viewedLessons: null,
@@ -505,7 +502,7 @@ describe("PlaylistsGrid", () => {
       ];
 
       // User has completed 1 lesson from Playlist 1 (50%) and 0 from Playlist 2 (0%)
-      mockGetEnrollmentsByAuthorizedUser.mockResolvedValue([
+      mockGetCachedEnrollmentsWithLessonIds.mockResolvedValue([
         {
           id: 1,
           viewedLessons: [{ id: 1, name: "Lesson 1", slug: "lesson-1" }],
@@ -579,7 +576,7 @@ describe("PlaylistsGrid", () => {
       ];
 
       // User has completed 0 lessons from Playlist 1 (0%) and 2 from Playlist 2 (100%)
-      mockGetEnrollmentsByAuthorizedUser.mockResolvedValue([
+      mockGetCachedEnrollmentsWithLessonIds.mockResolvedValue([
         {
           id: 1,
           viewedLessons: [
@@ -749,7 +746,7 @@ describe("PlaylistsGrid", () => {
         },
       ];
 
-      mockGetEnrollmentsByAuthorizedUser.mockResolvedValue([
+      mockGetCachedEnrollmentsWithLessonIds.mockResolvedValue([
         {
           id: 1,
           viewedLessons: [
@@ -813,7 +810,7 @@ describe("PlaylistsGrid", () => {
       },
     ];
 
-    mockGetEnrollmentsByAuthorizedUser.mockResolvedValue([
+    mockGetCachedEnrollmentsWithLessonIds.mockResolvedValue([
       {
         id: 1,
         viewedLessons: [{ id: 1, name: "Lesson 1", slug: "lesson-1" }],

--- a/frontend/tests/components/friends/friend-completed-droplets.test.tsx
+++ b/frontend/tests/components/friends/friend-completed-droplets.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import { FriendCompletedDroplets } from "@/components/friends/friend-completed-droplets";
 import { TimeZone } from "@/types";
 
-jest.mock("@/lib/requests/enrollment", () => ({
-  getEnrollmentsByAuthorizedUser: jest.fn(() => Promise.resolve([])),
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedEnrollmentsWithLessonIds: jest.fn(() => Promise.resolve([])),
 }));
 
 jest.mock("@/components/friends/friend-completed-droplets-list", () => ({
@@ -69,7 +69,7 @@ describe("FriendCompletedDroplets", () => {
       },
     ];
 
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValueOnce(
+    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValueOnce(
       mockEnrollments,
     );
 
@@ -83,7 +83,7 @@ describe("FriendCompletedDroplets", () => {
   });
 
   it("shows no completed droplets message when none available", async () => {
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValueOnce([]);
+    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValueOnce([]);
 
     render(<FriendCompletedDroplets friend={mockFriend} />);
 
@@ -112,7 +112,7 @@ describe("FriendCompletedDroplets", () => {
       },
     ];
 
-    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValueOnce(
+    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValueOnce(
       mockEnrollments,
     );
 


### PR DESCRIPTION

## Description

ODY-304 - The explore page was fetching way more data than it needed. Now it only grabs what's actually used for rendering tiles (lesson IDs for counts, tag names for badges, author names). Also made the data fetching conditional on which tab is selected so we're not loading playlists when looking at droplets and vice versa.

ODY-305 - Created populate presets for enrollment queries (minimal, withLessonIds, dashboard, favorites) so each callsite only asks for the fields it actually needs. Wrapped them all in React.cache so duplicate calls within the same page render only hit Strapi once. Also fixed a conflicting cache/next option on getEnrollmentsForGroupMembers.

## Motivation and Context

Pages were pulling full lesson block content, all tags, all favorited users, etc. on every request, even when they only needed an ID to check enrollment. The dashboard was especially bad since it calls enrollment queries 5+ times per render. This should noticeably cut down payload sizes and speed up page loads.



## Checklist:


- [X] My code follows the code style of this project.
- [X] I have moved the ticket to "In Review"
- [X] I have added reviewers to this PR
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.