### PR TITLE
ODY-311: Batch friend-of-friend lookups in fetchSuggestionsById

### DIFF
--- a/frontend/lib/requests/friends.ts
+++ b/frontend/lib/requests/friends.ts
@@ -508,6 +508,70 @@ export async function fetchFriendshipsById(
   }
 }
 
+/**
+ * Batch-fetches all friendships where any of the given user IDs is a member.
+ * Paginates automatically for large friend networks.
+ */
+export async function fetchFriendshipsByUserIds(
+  userIds: number[],
+): Promise<Friendship[]> {
+  if (userIds.length === 0) return [];
+
+  const pageSize = 250;
+  let page = 1;
+  let allFriendships: Friendship[] = [];
+
+  while (true) {
+    const query = qs.stringify({
+      filters: {
+        authorized_users: {
+          id: { $in: userIds },
+        },
+      },
+      populate: {
+        authorized_users: {
+          fields: [
+            "id",
+            "email",
+            "firstName",
+            "lastName",
+            "bio",
+            "github",
+            "linkedin",
+            "profilePhoto",
+            "website",
+          ],
+          populate: {
+            blocked: { fields: ["id"] },
+            was_blocked: { fields: ["id"] },
+            received_requests: { fields: ["id"] },
+          },
+        },
+      },
+      pagination: { pageSize, page },
+    });
+
+    const response = await fetch(
+      NEXT_PUBLIC_STRAPI_API_URL + "/api/friendships?" + query,
+      {
+        headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
+        cache: "no-store",
+      },
+    );
+    const data = await response.json();
+    const friendships = flattenAttributes(data.data);
+
+    if (!friendships || friendships.length === 0) break;
+
+    allFriendships = allFriendships.concat(friendships);
+
+    if (friendships.length < pageSize) break;
+    page++;
+  }
+
+  return allFriendships;
+}
+
 export async function fetchSuggestionsById(
   userId: number,
 ): Promise<AuthorizedUser[]> {
@@ -528,36 +592,29 @@ export async function fetchSuggestionsById(
       ),
     );
 
-    const friendsOfFriends = await Promise.all(
-      directFriends.map(async (friend) => {
-        // Get all friendships for each direct friend
-        const friendFriendships = await fetchFriendshipsById(friend.id);
+    const friendIds = directFriends.map((f) => f.id);
+    const directFriendIdSet = new Set(friendIds);
 
-        // Return all users from these friendships except the direct friend and original user
-        return friendFriendships
-          .flatMap((friendship) =>
-            friendship.authorized_users.filter(
-              (user) =>
-                user.id !== friend.id &&
-                user.id !== userId &&
-                !directFriends.some(
-                  (newUser: AuthorizedUser) => newUser.id === user.id,
-                ) &&
-                !user.was_blocked.some(
-                  (blockedUser: AuthorizedUser) => blockedUser.id === userId,
-                ) &&
-                !user.received_requests.some(
-                  (otherUser: AuthorizedUser) => otherUser.id === userId,
-                ),
+    const allFriendFriendships = await fetchFriendshipsByUserIds(friendIds);
+
+    const friendsOfFriends = allFriendFriendships
+      .flatMap((friendship) =>
+        friendship.authorized_users.filter(
+          (user) =>
+            user.id !== userId &&
+            !directFriendIdSet.has(user.id) &&
+            !user.was_blocked.some(
+              (blockedUser: AuthorizedUser) => blockedUser.id === userId,
+            ) &&
+            !user.received_requests.some(
+              (otherUser: AuthorizedUser) => otherUser.id === userId,
             ),
-          )
-          .sort((a, b) => a.lastName?.localeCompare(b.lastName));
-      }),
-    );
+        ),
+      )
+      .sort((a, b) => a.lastName?.localeCompare(b.lastName));
 
-    // Flatten the array and remove duplicates based on user ID
     const uniqueFriendsOfFriends = Array.from(
-      new Map(friendsOfFriends.flat().map((user) => [user.id, user])).values(),
+      new Map(friendsOfFriends.map((user) => [user.id, user])).values(),
     );
 
     return uniqueFriendsOfFriends;

--- a/frontend/testing/requests/friends.test.js
+++ b/frontend/testing/requests/friends.test.js
@@ -10,6 +10,8 @@ const {
   sendFriendRequest,
   removeFriend,
   fetchFriendshipsById,
+  fetchFriendshipsByUserIds,
+  fetchSuggestionsById,
 } = require("../../lib/requests/friends");
 
 jest.mock("../../lib/utils", () => ({
@@ -1199,6 +1201,434 @@ describe("Friends tests", () => {
     it("should throw error for null user ID", async () => {
       await expect(fetchFriendshipsById(null)).rejects.toThrow(
         "Failed to fetch friendships",
+      );
+    });
+  });
+
+  describe("fetchFriendshipsByUserIds", () => {
+    beforeEach(() => {
+      global.fetch.mockReset();
+    });
+
+    it("should return empty array for empty user IDs", async () => {
+      const result = await fetchFriendshipsByUserIds([]);
+
+      expect(result).toEqual([]);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should fetch friendships for multiple user IDs in a single query", async () => {
+      const userIds = [6, 7];
+
+      const mockFriendships = [
+        {
+          id: 10,
+          attributes: {
+            authorized_users: {
+              data: [
+                {
+                  id: 6,
+                  attributes: {
+                    firstName: "A",
+                    lastName: "One",
+                    email: "a@test.com",
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+                {
+                  id: 8,
+                  attributes: {
+                    firstName: "C",
+                    lastName: "Three",
+                    email: "c@test.com",
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        {
+          id: 11,
+          attributes: {
+            authorized_users: {
+              data: [
+                {
+                  id: 7,
+                  attributes: {
+                    firstName: "B",
+                    lastName: "Two",
+                    email: "b@test.com",
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+                {
+                  id: 9,
+                  attributes: {
+                    firstName: "D",
+                    lastName: "Four",
+                    email: "d@test.com",
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ];
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: mockFriendships }),
+      });
+
+      flattenAttributes.mockImplementationOnce((data) =>
+        data.map((f) => ({
+          id: f.id,
+          authorized_users: f.attributes.authorized_users.data.map((u) => ({
+            id: u.id,
+            ...u.attributes,
+            blocked: u.attributes.blocked.data,
+            was_blocked: u.attributes.was_blocked.data,
+            received_requests: u.attributes.received_requests.data,
+          })),
+        })),
+      );
+
+      const result = await fetchFriendshipsByUserIds(userIds);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(2);
+
+      const callUrl = global.fetch.mock.calls[0][0];
+      expect(callUrl).toMatch(/filters/);
+      expect(callUrl).toMatch(/%24in/);
+    });
+
+    it("should handle fetch errors", async () => {
+      global.fetch.mockRejectedValueOnce(new Error("Network error"));
+
+      await expect(fetchFriendshipsByUserIds([6])).rejects.toThrow();
+    });
+
+    it("should paginate when first page is full", async () => {
+      const userIds = [6];
+
+      const fullPage = Array.from({ length: 250 }, (_, i) => ({
+        id: i + 1,
+        attributes: {
+          authorized_users: { data: [] },
+        },
+      }));
+      const partialPage = [
+        { id: 251, attributes: { authorized_users: { data: [] } } },
+      ];
+
+      flattenAttributes
+        .mockImplementationOnce((data) =>
+          data.map((f) => ({ id: f.id, authorized_users: [] })),
+        )
+        .mockImplementationOnce((data) =>
+          data.map((f) => ({ id: f.id, authorized_users: [] })),
+        );
+
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: fullPage }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: partialPage }),
+        });
+
+      const result = await fetchFriendshipsByUserIds(userIds);
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(result).toHaveLength(251);
+    });
+  });
+
+  describe("fetchSuggestionsById", () => {
+    beforeEach(() => {
+      global.fetch.mockReset();
+    });
+
+    function makeFlatFriendship(id, users) {
+      return { id, authorized_users: users };
+    }
+
+    function makeUser(id, firstName, lastName, overrides = {}) {
+      return {
+        id,
+        firstName,
+        lastName,
+        email: `${firstName.toLowerCase()}@test.com`,
+        blocked: [],
+        was_blocked: [],
+        received_requests: [],
+        ...overrides,
+      };
+    }
+
+    it("should return friend-of-friend suggestions using 2 queries", async () => {
+      const userId = 1;
+      const user = makeUser(1, "Me", "User");
+      const friendA = makeUser(2, "Friend", "A");
+      const friendB = makeUser(3, "Friend", "B");
+      const suggestion = makeUser(4, "Suggested", "Person");
+
+      // Query 1: fetchFriendshipsById(userId) — user's friendships
+      const userFriendshipsRaw = [
+        {
+          id: 100,
+          attributes: {
+            authorized_users: {
+              data: [
+                {
+                  id: 1,
+                  attributes: {
+                    ...user,
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+                {
+                  id: 2,
+                  attributes: {
+                    ...friendA,
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        {
+          id: 101,
+          attributes: {
+            authorized_users: {
+              data: [
+                {
+                  id: 1,
+                  attributes: {
+                    ...user,
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+                {
+                  id: 3,
+                  attributes: {
+                    ...friendB,
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ];
+
+      // Query 2: fetchFriendshipsByUserIds([2, 3]) — friends' friendships
+      const friendFriendshipsRaw = [
+        {
+          id: 200,
+          attributes: {
+            authorized_users: {
+              data: [
+                {
+                  id: 2,
+                  attributes: {
+                    ...friendA,
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+                {
+                  id: 4,
+                  attributes: {
+                    ...suggestion,
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ];
+
+      const flattenImpl = (data) =>
+        data.map((f) => ({
+          id: f.id,
+          authorized_users: f.attributes.authorized_users.data.map((u) => ({
+            id: u.id,
+            ...u.attributes,
+            blocked: u.attributes.blocked.data,
+            was_blocked: u.attributes.was_blocked.data,
+            received_requests: u.attributes.received_requests.data,
+          })),
+        }));
+
+      flattenAttributes
+        .mockImplementationOnce(flattenImpl)
+        .mockImplementationOnce(flattenImpl);
+
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: userFriendshipsRaw }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: friendFriendshipsRaw }),
+        });
+
+      const result = await fetchSuggestionsById(userId);
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(4);
+      expect(result[0].firstName).toBe("Suggested");
+    });
+
+    it("should exclude users who blocked the caller", async () => {
+      const userId = 1;
+      const user = makeUser(1, "Me", "User");
+      const friendA = makeUser(2, "Friend", "A");
+      const blockerUser = makeUser(4, "Blocker", "Person", {
+        was_blocked: [{ id: 1 }],
+      });
+
+      const userFriendshipsRaw = [
+        {
+          id: 100,
+          attributes: {
+            authorized_users: {
+              data: [
+                {
+                  id: 1,
+                  attributes: {
+                    ...user,
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+                {
+                  id: 2,
+                  attributes: {
+                    ...friendA,
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ];
+
+      const friendFriendshipsRaw = [
+        {
+          id: 200,
+          attributes: {
+            authorized_users: {
+              data: [
+                {
+                  id: 2,
+                  attributes: {
+                    ...friendA,
+                    blocked: { data: [] },
+                    was_blocked: { data: [] },
+                    received_requests: { data: [] },
+                  },
+                },
+                {
+                  id: 4,
+                  attributes: {
+                    ...blockerUser,
+                    blocked: { data: [] },
+                    was_blocked: { data: [{ id: 1 }] },
+                    received_requests: { data: [] },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ];
+
+      const flattenImpl = (data) =>
+        data.map((f) => ({
+          id: f.id,
+          authorized_users: f.attributes.authorized_users.data.map((u) => ({
+            id: u.id,
+            ...u.attributes,
+            blocked: u.attributes.blocked.data,
+            was_blocked: u.attributes.was_blocked.data,
+            received_requests: u.attributes.received_requests.data,
+          })),
+        }));
+
+      flattenAttributes
+        .mockImplementationOnce(flattenImpl)
+        .mockImplementationOnce(flattenImpl);
+
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: userFriendshipsRaw }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: friendFriendshipsRaw }),
+        });
+
+      const result = await fetchSuggestionsById(userId);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("should return empty array when user has no friends", async () => {
+      const userFriendshipsRaw = [];
+
+      flattenAttributes.mockImplementationOnce(() => []);
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: userFriendshipsRaw }),
+      });
+
+      const result = await fetchSuggestionsById(1);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([]);
+    });
+
+    it("should handle errors", async () => {
+      global.fetch.mockRejectedValueOnce(new Error("Network error"));
+
+      await expect(fetchSuggestionsById(1)).rejects.toThrow(
+        "Failed to fetch friend suggestions",
       );
     });
   });


### PR DESCRIPTION
## Description

Replaces the N+1 query pattern in `fetchSuggestionsById` where each direct friend triggered a separate `fetchFriendshipsById` call. Now uses a single batched Strapi query with `$in` filter on all direct friend IDs, then filters and deduplicates in JavaScript.

### Changes

- **`friends.ts`** — Added `fetchFriendshipsByUserIds(userIds)`, a paginated batch query that fetches all friendships where any of the given user IDs is a member using `authorized_users.id: { $in: userIds }`.
- **`friends.ts`** — Rewrote `fetchSuggestionsById` to:
  1. Fetch user's own friendships (1 query)
  2. Extract direct friend IDs
  3. Batch-fetch all friends' friendships in 1 query via `fetchFriendshipsByUserIds`
  4. Filter out self, direct friends, blocked users, and pending requests in a single flat pass using a `Set` for O(1) lookups
- **`friends.test.js`** — Added 8 new tests covering `fetchFriendshipsByUserIds` (empty input, batched `$in` query, error handling, pagination) and `fetchSuggestionsById` (correct 2-query flow, blocked user exclusion, empty friends, error propagation).

**Before:** A user with 20 friends triggered 21 Strapi queries (1 + 20).
**After:** Always 2 Strapi queries regardless of friend count.

## Motivation and Context

Part of ODY-294 (Performance). `fetchSuggestionsById` is called on the friend suggestions page. The per-friend query loop caused latency that scaled linearly with friend count. This reduces it to constant-time API overhead.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.