### PR TITLE
  ODY-306 & ODY-307: Eliminates duplicate Strapi calls across dashboard and droplet pages by unifying cached functions and parallelizing independent fetches.

### DIFF
--- a/frontend/app/(droplets)/d/[slug]/[lessonSlug]/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/[lessonSlug]/page.tsx
@@ -1,14 +1,14 @@
 import { Metadata } from "next";
-import { getCachedUser } from "@/lib/requests/cached";
+import {
+  getCachedUser,
+  getCachedEnrollmentsWithLessonIds,
+  getCachedDropletBySlug,
+} from "@/lib/requests/cached";
 import { updateCompletionDate } from "@/lib/requests/enrollment";
-import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
-import { getDropletBySlug } from "@/lib/requests/droplet";
 import { getLessonBySlug } from "@/lib/requests/lesson";
 import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
 import { DropletLessonWrapper } from "@/components/droplets/lessons/droplet-lesson-wrapper";
-
-export const dynamic = "force-dynamic";
 
 type Props = {
   params: Promise<Params>;
@@ -33,41 +33,33 @@ export default async function Page({ params }: Props) {
   const p = await params;
   const { slug, lessonSlug } = p;
 
-  const droplet = await getDropletBySlug(slug, {
-    populate: {
-      authorized_users: { populate: "*" },
-      lessons: {
-        sort: ["orderIndex:asc"],
-      },
-    },
-  });
+  const [droplet, lesson, currentUser] = await Promise.all([
+    getCachedDropletBySlug(slug),
+    getLessonBySlug(lessonSlug),
+    getCurrentUser(),
+  ]);
 
-  const lesson = await getLessonBySlug(lessonSlug);
-  const currentUser = await getCurrentUser();
   let completedLessonIds: number[] = [];
   let enrollmentId: string | undefined;
 
-  if (currentUser?.email) {
-    const user = await getCachedUser(currentUser.email);
-    const enrollments = await getCachedEnrollmentsWithLessonIds(user.id);
+  if (!currentUser || !currentUser?.email) return notFound();
 
-    const enrollment = enrollments.find((e) => e.droplet.id === droplet.id);
+  const authUser = await getCachedUser(currentUser.email);
+  const enrollments = await getCachedEnrollmentsWithLessonIds(authUser.id);
 
-    if (enrollment) {
-      enrollmentId = enrollment.id;
-      completedLessonIds =
-        enrollment.viewedLessons?.map((l: { id: number }) => l.id) || [];
-      if (
-        completedLessonIds.length === enrollment.droplet.lessons?.length &&
-        !enrollment.completionDate
-      ) {
-        await updateCompletionDate(enrollment.id);
-      }
+  const enrollment = enrollments.find((e) => e.droplet.id === droplet.id);
+
+  if (enrollment) {
+    enrollmentId = enrollment.id;
+    completedLessonIds =
+      enrollment.viewedLessons?.map((l: { id: number }) => l.id) || [];
+    if (
+      completedLessonIds.length === enrollment.droplet.lessons?.length &&
+      !enrollment.completionDate
+    ) {
+      await updateCompletionDate(enrollment.id);
     }
   }
-
-  if (!currentUser || !currentUser?.email) return notFound();
-  const authUser = await getCachedUser(currentUser.email);
 
   const isAuthor =
     droplet.authorized_users &&

--- a/frontend/app/(droplets)/d/[slug]/layout.tsx
+++ b/frontend/app/(droplets)/d/[slug]/layout.tsx
@@ -1,7 +1,10 @@
 import Sidebar from "@/components/droplets/sidebar";
-import { getCachedUser } from "@/lib/requests/cached";
+import {
+  getCachedUser,
+  getCachedEnrollmentsWithLessonIds,
+  getCachedDropletBySlug,
+} from "@/lib/requests/cached";
 import { getDropletBySlug } from "@/lib/requests/droplet";
-import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
 import { Metadata } from "next/types";
 import { AuthorizedUser, Droplet } from "@/types";
 import { getCurrentUser } from "@/lib/auth/session";
@@ -35,9 +38,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function RootLayout({ params, children }: Props) {
   const { slug } = await params;
-  const user = await getCurrentUser();
+  const [user, droplet] = await Promise.all([
+    getCurrentUser(),
+    getCachedDropletBySlug(slug),
+  ]);
 
   if (!user) return notFound();
+  if (!droplet) return notFound();
 
   let completedLessonIds: number[] = [];
   let authorizedUser: AuthorizedUser | null = null;
@@ -45,26 +52,9 @@ export default async function RootLayout({ params, children }: Props) {
 
   if (user?.email) {
     authorizedUser = (await getCachedUser(user.email)) as AuthorizedUser;
-  }
-
-  // Fetch droplet first
-  const droplet = await getDropletBySlug<Droplet>(slug, {
-    fields: ["*"],
-    populate: {
-      authorized_users: { populate: "*" },
-      learningObjectives: { populate: "*" },
-      lessons: { populate: "*" },
-      tags: { populate: "*" },
-      prerequisites: { populate: ["id", "name", "slug"] },
-      postrequisites: { populate: ["id", "name", "slug"] },
-    },
-  });
-
-  if (!droplet) return notFound();
-
-  if (user?.email) {
-    const sessionUser = await getCachedUser(user.email);
-    const enrollments = await getCachedEnrollmentsWithLessonIds(sessionUser.id);
+    const enrollments = await getCachedEnrollmentsWithLessonIds(
+      authorizedUser.id,
+    );
 
     const currentEnrollment = enrollments.find(
       (enrollment) => enrollment.droplet?.id === droplet.id,

--- a/frontend/app/(droplets)/d/[slug]/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/page.tsx
@@ -2,7 +2,6 @@ import { DropletTile } from "@/components/droplets/droplet-tile";
 import { EnrollButton } from "@/components/droplets/enroll-button";
 import { GradientBackground } from "@/components/gradient-bg";
 import { Badge } from "@/components/ui/badge";
-import { getDropletBySlug } from "@/lib/requests/droplet";
 import { stripHtmlTags, uppercaseFirstChar } from "@/lib/utils";
 import { Droplet } from "@/types";
 import {
@@ -14,7 +13,11 @@ import {
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getCachedUser, getCachedEnrollments } from "@/lib/requests/cached";
+import {
+  getCachedUser,
+  getCachedEnrollmentsWithLessonIds,
+  getCachedDropletBySlug,
+} from "@/lib/requests/cached";
 import { StarRating } from "@/components/ui/rating-stars";
 import { AuthorCard } from "@/components/droplets/author-block";
 
@@ -41,26 +44,20 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function DropletRoute({ params }: Props) {
   const p = await params;
-  const droplet = await getDropletBySlug<Droplet>(p.slug, {
-    fields: ["*"],
-    populate: {
-      learningObjectives: { populate: "*" },
-      lessons: { populate: "*" },
-      tags: { populate: "*" },
-      authorized_users: { populate: "*", fields: ["*"] },
-      prerequisites: { populate: ["id", "name", "slug"] },
-      postrequisites: { populate: ["id", "name", "slug"] },
-    },
-  });
+  const [droplet, user] = await Promise.all([
+    getCachedDropletBySlug(p.slug),
+    getCurrentUser(),
+  ]);
   if (!droplet) return notFound();
 
   let isEnrolled = false;
-  const user = await getCurrentUser();
 
   if (user?.email) {
     const authorizedUser = await getCachedUser(user.email);
 
-    const enrollments = await getCachedEnrollments(authorizedUser.id);
+    const enrollments = await getCachedEnrollmentsWithLessonIds(
+      authorizedUser.id,
+    );
     isEnrolled = enrollments.some((e) => e.droplet.id === droplet.id);
   }
 

--- a/frontend/app/(droplets)/d/[slug]/recap/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/recap/page.tsx
@@ -1,16 +1,17 @@
 import { DropletTile } from "@/components/droplets/droplet-tile";
-import { getDropletBySlug, getDroplets } from "@/lib/requests/droplet";
+import { getDroplets } from "@/lib/requests/droplet";
 import { Droplet } from "@/types";
 import { GoalIcon, Link2Icon } from "lucide-react";
 import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { StarRating } from "@/components/ui/rating-stars";
-import { getCachedUser } from "@/lib/requests/cached";
 import {
-  getEnrollmentsByAuthorizedUser,
-  updateCompletionDate,
-} from "@/lib/requests/enrollment";
+  getCachedUser,
+  getCachedEnrollmentsWithLessonIds,
+  getCachedDropletBySlug,
+} from "@/lib/requests/cached";
+import { updateCompletionDate } from "@/lib/requests/enrollment";
 import { getCurrentUser } from "@/lib/auth/session";
 import { CompletedDropletBlock } from "@/components/droplets/completed-droplet-block";
 import { getNotesByDroplet } from "@/lib/requests/notes";
@@ -30,17 +31,7 @@ type Params = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const p = await params;
-  const droplet = await getDropletBySlug<Droplet>(p.slug, {
-    fields: ["*"],
-    populate: {
-      learningObjectives: { populate: "*" },
-      tags: { populate: "*" },
-      nextSteps: { populate: "*" },
-      lessons: {
-        fields: ["id", "name", "slug"],
-      },
-    },
-  });
+  const droplet = await getCachedDropletBySlug(p.slug);
 
   if (!droplet) {
     return notFound();
@@ -53,14 +44,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function DropletRecapRoute({ params }: Props) {
   const p = await params;
-  const droplet = await getDropletBySlug<Droplet>(p.slug, {
-    fields: ["*"],
-    populate: {
-      learningObjectives: { populate: "*" },
-      tags: { populate: "*" },
-      nextSteps: { populate: "*" },
-    },
-  });
+  const [droplet, currentUser] = await Promise.all([
+    getCachedDropletBySlug(p.slug),
+    getCurrentUser(),
+  ]);
   if (!droplet) {
     return notFound();
   }
@@ -85,31 +72,16 @@ export default async function DropletRecapRoute({ params }: Props) {
     populate: { tags: { populate: "*" } },
   });
 
-  const currentUser = await getCurrentUser();
-
   if (currentUser?.email) {
-    const user = await getCachedUser(currentUser.email);
+    const authUser = await getCachedUser(currentUser.email);
 
-    const enrollments = await getEnrollmentsByAuthorizedUser(user.id, {
-      populate: {
-        viewedLessons: {
-          fields: ["id", "name", "slug"],
-        },
+    const [enrollments, highlights, notes] = await Promise.all([
+      getCachedEnrollmentsWithLessonIds(authUser.id),
+      getHighlightsByDroplet(authUser.id, droplet.id),
+      getNotesByDroplet(authUser.id, droplet.id),
+    ]);
 
-        droplet: {
-          populate: {
-            lessons: {
-              fields: ["id", "name", "slug"],
-            },
-          },
-        },
-      },
-    });
-
-    const authUser = await getCachedUser(user.email);
     let enrollID: string = "";
-    const highlights = await getHighlightsByDroplet(authUser.id, droplet.id);
-    const notes = await getNotesByDroplet(authUser.id, droplet.id);
     const filteredHighlights = highlights.filter(
       (highlight) =>
         !notes.some((lesson) => lesson.highlight?.id === highlight.id),

--- a/frontend/app/(general)/dashboard/page.tsx
+++ b/frontend/app/(general)/dashboard/page.tsx
@@ -14,10 +14,10 @@ import {
   sorting,
 } from "@/lib/globals";
 import {
-  getCachedUserDashboard,
+  getCachedUserDashboardFull,
   getCachedEnrollmentsFavorites,
+  getCachedUserGroups,
 } from "@/lib/requests/cached";
-import { getUserGroups } from "@/lib/requests/groups";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
@@ -36,14 +36,14 @@ export default async function DashboardRoute({ searchParams }: Props) {
     return notFound();
   }
   const { sortKey } = sorting.find((item) => item.slug === sort) || defaultSort;
-  const authorizedUser = await getCachedUserDashboard(user.email);
+  const authorizedUser = await getCachedUserDashboardFull(user.email);
   const archivedPlaylists = authorizedUser.playlists?.filter((playlist) =>
     playlist.users_archived?.some((user) => user.id === authorizedUser.id),
   );
   const allEnrollments = await getCachedEnrollmentsFavorites(authorizedUser.id);
   const allPlaylists = authorizedUser.playlists?.length || 0;
-  const allGroups = (await getUserGroups(authorizedUser.id)).filter((group) =>
-    group.members?.some((member) => member.id === authorizedUser.id),
+  const allGroups = (await getCachedUserGroups(authorizedUser.id)).filter(
+    (group) => group.members?.some((member) => member.id === authorizedUser.id),
   );
   const activeGroups = allGroups.filter(
     (group) =>

--- a/frontend/components/dashboard/archived-droplets-grid.tsx
+++ b/frontend/components/dashboard/archived-droplets-grid.tsx
@@ -4,8 +4,10 @@ import {
   MessageHeader,
 } from "@/components/message";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getCachedUser } from "@/lib/requests/cached";
-import { getCachedEnrollmentsDashboard } from "@/lib/requests/cached";
+import {
+  getCachedUserDashboardFull,
+  getCachedEnrollmentsFavorites,
+} from "@/lib/requests/cached";
 import { EnrolledDropletsGridClient } from "./enrolled-droplets-grid-client";
 
 interface Lesson {
@@ -18,8 +20,8 @@ export async function ArchivedDropletsGrid({ sortKey }: { sortKey?: string }) {
   const user = await getCurrentUser();
   if (!user?.email) return null;
 
-  const authorizedUser = await getCachedUser(user.email);
-  const enrollments = await getCachedEnrollmentsDashboard(authorizedUser.id);
+  const authorizedUser = await getCachedUserDashboardFull(user.email);
+  const enrollments = await getCachedEnrollmentsFavorites(authorizedUser.id);
 
   const filteredEnrollments = enrollments.filter((e) => e.isArchived === true);
 

--- a/frontend/components/dashboard/archived-playlists-grid.tsx
+++ b/frontend/components/dashboard/archived-playlists-grid.tsx
@@ -1,12 +1,14 @@
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
+import {
+  getCachedUserDashboardFull,
+  getCachedEnrollmentsFavorites,
+  getCachedUserDueDates,
+} from "@/lib/requests/cached";
 import {
   Message,
   MessageDescription,
   MessageHeader,
 } from "@/components/message";
-import { getUserDueDates } from "@/lib/requests/groups";
 import { UserPlaylistsClient } from "./user-playlists-client";
 import { Lesson, Playlist } from "@/types";
 
@@ -14,36 +16,9 @@ export async function ArchivedPlaylistsGrid({ sortKey }: { sortKey?: string }) {
   const user = await getCurrentUser();
   if (!user?.email) return null;
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email, {
-    populate: {
-      playlists: {
-        populate: {
-          droplets: {
-            populate: {
-              lessons: {
-                fields: ["*"],
-              },
-            },
-          },
-          users_archived: {
-            fields: ["*"],
-          },
-        },
-      },
-      groups: {
-        populate: {
-          playlists: {
-            fields: ["id"],
-          },
-        },
-        fields: ["id", "playlistDueDates"],
-      },
-    },
-  });
+  const authorizedUser = await getCachedUserDashboardFull(user.email);
 
-  const enrollments = await getCachedEnrollmentsWithLessonIds(
-    authorizedUser.id,
-  );
+  const enrollments = await getCachedEnrollmentsFavorites(authorizedUser.id);
   const completedLessonIds = enrollments.flatMap(
     (enrollment) =>
       enrollment.viewedLessons?.map((lesson: Lesson) => lesson.id) || [],
@@ -85,7 +60,7 @@ export async function ArchivedPlaylistsGrid({ sortKey }: { sortKey?: string }) {
     );
   }
 
-  const dueDates = await getUserDueDates(authorizedUser.id);
+  const dueDates = await getCachedUserDueDates(authorizedUser.id);
   if (sortKey) {
     const [field, direction] = sortKey.split(":");
     if (field === "name") {

--- a/frontend/components/dashboard/enrolled-droplets-grid.tsx
+++ b/frontend/components/dashboard/enrolled-droplets-grid.tsx
@@ -4,10 +4,12 @@ import {
   MessageHeader,
 } from "@/components/message";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getCachedUser } from "@/lib/requests/cached";
-import { getCachedEnrollmentsDashboard } from "@/lib/requests/cached";
+import {
+  getCachedUserDashboardFull,
+  getCachedEnrollmentsFavorites,
+  getCachedUserDueDates,
+} from "@/lib/requests/cached";
 import { EnrolledDropletsGridClient } from "./enrolled-droplets-grid-client";
-import { getUserDueDates } from "@/lib/requests/groups";
 
 interface Lesson {
   id: number;
@@ -29,8 +31,8 @@ export async function EnrolledDropletsGrid({
   const user = await getCurrentUser();
   if (!user?.email) return null;
 
-  const authorizedUser = await getCachedUser(user.email);
-  const enrollments = await getCachedEnrollmentsDashboard(authorizedUser.id);
+  const authorizedUser = await getCachedUserDashboardFull(user.email);
+  const enrollments = await getCachedEnrollmentsFavorites(authorizedUser.id);
 
   const filteredEnrollments = enrollments.filter((e) => e.isArchived !== true);
 
@@ -71,7 +73,7 @@ export async function EnrolledDropletsGrid({
     );
   }
 
-  const dueDates = await getUserDueDates(authorizedUser.id);
+  const dueDates = await getCachedUserDueDates(authorizedUser.id);
 
   return (
     <EnrolledDropletsGridClient

--- a/frontend/components/dashboard/favorited-droplet-grid.tsx
+++ b/frontend/components/dashboard/favorited-droplet-grid.tsx
@@ -4,8 +4,10 @@ import {
   MessageHeader,
 } from "@/components/message";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getCachedUser } from "@/lib/requests/cached";
-import { getCachedEnrollmentsFavorites } from "@/lib/requests/cached";
+import {
+  getCachedUserDashboardFull,
+  getCachedEnrollmentsFavorites,
+} from "@/lib/requests/cached";
 import { EnrolledDropletsGridClient } from "./enrolled-droplets-grid-client";
 import { Lesson } from "@/types";
 
@@ -13,7 +15,7 @@ export async function FavoriteDropletsGrid({ sortKey }: { sortKey?: string }) {
   const user = await getCurrentUser();
   if (!user?.email) return null;
 
-  const authorizedUser = await getCachedUser(user.email);
+  const authorizedUser = await getCachedUserDashboardFull(user.email);
   const enrollments = await getCachedEnrollmentsFavorites(authorizedUser.id);
 
   // Fixed: Added return and compare IDs instead of objects

--- a/frontend/components/dashboard/my-content.tsx
+++ b/frontend/components/dashboard/my-content.tsx
@@ -2,9 +2,11 @@ import { getCurrentUser } from "@/lib/auth/session";
 import { EnrolledDropletsGrid } from "./enrolled-droplets-grid";
 import { UserPlaylistsGrid } from "./user-playlists-grid";
 import { ArchivedDropletsGrid } from "./archived-droplets-grid";
-import { getCachedUser } from "@/lib/requests/cached";
+import {
+  getCachedUserDashboardFull,
+  getCachedUserGroups,
+} from "@/lib/requests/cached";
 import { notFound } from "next/navigation";
-import { getUserGroups } from "@/lib/requests/groups";
 import {
   Message,
   MessageDescription,
@@ -31,9 +33,9 @@ export async function MyContent({
     return notFound();
   }
 
-  const authorizedUser = await getCachedUser(user.email);
-  const allGroups = (await getUserGroups(authorizedUser.id)).filter((group) =>
-    group.members?.some((member) => member.id === authorizedUser.id),
+  const authorizedUser = await getCachedUserDashboardFull(user.email);
+  const allGroups = (await getCachedUserGroups(authorizedUser.id)).filter(
+    (group) => group.members?.some((member) => member.id === authorizedUser.id),
   );
   const activeGroups = allGroups.filter(
     (group) =>

--- a/frontend/components/dashboard/user-playlists-grid.tsx
+++ b/frontend/components/dashboard/user-playlists-grid.tsx
@@ -1,12 +1,14 @@
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
+import {
+  getCachedUserDashboardFull,
+  getCachedEnrollmentsFavorites,
+  getCachedUserDueDates,
+} from "@/lib/requests/cached";
 import {
   Message,
   MessageDescription,
   MessageHeader,
 } from "@/components/message";
-import { getUserDueDates } from "@/lib/requests/groups";
 import { UserPlaylistsClient } from "./user-playlists-client";
 import { Lesson, Playlist } from "@/types";
 
@@ -14,36 +16,9 @@ export async function UserPlaylistsGrid({ sortKey }: { sortKey?: string }) {
   const user = await getCurrentUser();
   if (!user?.email) return null;
 
-  const authorizedUser = await getAuthorizedUserByEmail(user.email, {
-    populate: {
-      playlists: {
-        populate: {
-          droplets: {
-            populate: {
-              lessons: {
-                fields: ["id", "name", "slug"],
-              },
-            },
-          },
-          users_archived: {
-            fields: ["*"],
-          },
-        },
-      },
-      groups: {
-        populate: {
-          playlists: {
-            fields: ["id"],
-          },
-        },
-        fields: ["id", "playlistDueDates"],
-      },
-    },
-  });
+  const authorizedUser = await getCachedUserDashboardFull(user.email);
 
-  const enrollments = await getCachedEnrollmentsWithLessonIds(
-    authorizedUser.id,
-  );
+  const enrollments = await getCachedEnrollmentsFavorites(authorizedUser.id);
   const completedLessonIds = enrollments.flatMap(
     (enrollment) =>
       enrollment.viewedLessons?.map((lesson: Lesson) => lesson.id) || [],
@@ -90,7 +65,7 @@ export async function UserPlaylistsGrid({ sortKey }: { sortKey?: string }) {
     );
   }
 
-  const dueDates = await getUserDueDates(authorizedUser.id);
+  const dueDates = await getCachedUserDueDates(authorizedUser.id);
   if (sortKey) {
     const [field, direction] = sortKey.split(":");
     if (field === "name") {

--- a/frontend/lib/requests/cached.ts
+++ b/frontend/lib/requests/cached.ts
@@ -1,7 +1,9 @@
 import { cache } from "react";
 import { getAuthorizedUserByEmail } from "./authorized-user";
+import { getDropletBySlug } from "./droplet";
 import { getEnrollmentsByAuthorizedUser } from "./enrollment";
 import { ENROLLMENT_POPULATES } from "./enrollment-populates";
+import { getUserGroups, getUserDueDates } from "./groups";
 import { USER_POPULATES } from "./user-populates";
 
 export const getCachedUser = cache((email: string) =>
@@ -10,10 +12,6 @@ export const getCachedUser = cache((email: string) =>
 
 export const getCachedUserSocial = cache((email: string) =>
   getAuthorizedUserByEmail(email, USER_POPULATES.social),
-);
-
-export const getCachedUserDashboard = cache((email: string) =>
-  getAuthorizedUserByEmail(email, USER_POPULATES.dashboard),
 );
 
 export const getCachedUserCreation = cache((email: string) =>
@@ -40,5 +38,31 @@ export const getCachedEnrollmentsDashboard = cache((authorizedUserId: number) =>
 export const getCachedEnrollmentsFavorites = cache((authorizedUserId: number) =>
   getEnrollmentsByAuthorizedUser(authorizedUserId, {
     populate: ENROLLMENT_POPULATES.favorites,
+  }),
+);
+
+export const getCachedUserDashboardFull = cache((email: string) =>
+  getAuthorizedUserByEmail(email, USER_POPULATES.dashboardFull),
+);
+
+export const getCachedUserGroups = cache((authorizedUserId: number) =>
+  getUserGroups(authorizedUserId),
+);
+
+export const getCachedUserDueDates = cache((authorizedUserId: number) =>
+  getUserDueDates(authorizedUserId),
+);
+
+export const getCachedDropletBySlug = cache((slug: string) =>
+  getDropletBySlug(slug, {
+    populate: {
+      authorized_users: { populate: "*" },
+      learningObjectives: { populate: "*" },
+      lessons: { populate: "*" },
+      tags: { populate: "*" },
+      prerequisites: { populate: ["id", "name", "slug"] },
+      postrequisites: { populate: ["id", "name", "slug"] },
+      nextSteps: { populate: "*" },
+    },
   }),
 );

--- a/frontend/lib/requests/user-populates.ts
+++ b/frontend/lib/requests/user-populates.ts
@@ -66,6 +66,20 @@ export const USER_POPULATES = {
       },
     },
   },
+  dashboardFull: {
+    fields: PROFILE_FIELDS,
+    populate: {
+      playlists: {
+        populate: {
+          droplets: {
+            populate: { lessons: { fields: ["id", "name", "slug"] } },
+          },
+          users_archived: { fields: ["id"] },
+        },
+      },
+      groups: { fields: ["id"] },
+    },
+  },
   creation: {
     fields: PROFILE_FIELDS,
     populate: {

--- a/frontend/tests/components/dashboard/archived-droplets-grid.test.tsx
+++ b/frontend/tests/components/dashboard/archived-droplets-grid.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { ArchivedDropletsGrid } from "@/components/dashboard/archived-droplets-grid";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getCachedUser } from "@/lib/requests/cached";
-import { getCachedEnrollmentsDashboard } from "@/lib/requests/cached";
+import {
+  getCachedUserDashboardFull,
+  getCachedEnrollmentsFavorites,
+} from "@/lib/requests/cached";
 import { Enrollment } from "@/types";
 
 jest.mock("@/lib/auth/session", () => ({
@@ -10,8 +12,8 @@ jest.mock("@/lib/auth/session", () => ({
 }));
 
 jest.mock("@/lib/requests/cached", () => ({
-  getCachedUser: jest.fn(),
-  getCachedEnrollmentsDashboard: jest.fn(),
+  getCachedUserDashboardFull: jest.fn(),
+  getCachedEnrollmentsFavorites: jest.fn(),
 }));
 
 jest.mock("@/components/dashboard/enrolled-droplets-grid-client", () => ({
@@ -55,11 +57,13 @@ describe("ArchivedDropletsGrid", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
+    (getCachedUserDashboardFull as jest.Mock).mockResolvedValue(
+      mockAuthorizedUser,
+    );
   });
 
   it("displays a message when no archived droplets are found", async () => {
-    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue([]);
+    (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue([]);
 
     render(await ArchivedDropletsGrid({}));
 
@@ -75,8 +79,10 @@ describe("ArchivedDropletsGrid", () => {
     const mockEnrollments = [] as Enrollment[];
 
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
-    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+    (getCachedUserDashboardFull as jest.Mock).mockResolvedValue(
+      mockAuthorizedUser,
+    );
+    (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -101,7 +107,7 @@ describe("ArchivedDropletsGrid", () => {
       },
     ];
 
-    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -145,8 +151,8 @@ describe("ArchivedDropletsGrid", () => {
     beforeEach(() => {
       jest.clearAllMocks();
       (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-      (getCachedUser as jest.Mock).mockResolvedValue(mockUser);
-      (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+      (getCachedUserDashboardFull as jest.Mock).mockResolvedValue(mockUser);
+      (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
         mockEnrollments,
       );
     });
@@ -168,7 +174,7 @@ describe("ArchivedDropletsGrid", () => {
       beforeEach(() => {
         jest.clearAllMocks();
         (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-        (getCachedUser as jest.Mock).mockResolvedValue(mockUser);
+        (getCachedUserDashboardFull as jest.Mock).mockResolvedValue(mockUser);
       });
 
       it("should calculate 100% completion when all lessons are completed", async () => {
@@ -183,7 +189,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -203,7 +209,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -223,7 +229,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -243,7 +249,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -262,7 +268,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -281,7 +287,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 
@@ -290,7 +296,7 @@ describe("ArchivedDropletsGrid", () => {
       });
 
       it("should show no archived droplets message when no archived enrollments", async () => {
-        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue([]);
+        (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue([]);
 
         render(await ArchivedDropletsGrid({}));
         expect(screen.getByText("No Archived Droplets")).toBeInTheDocument();
@@ -316,7 +322,7 @@ describe("ArchivedDropletsGrid", () => {
           },
         ];
 
-        (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+        (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
           mockEnrollments,
         );
 

--- a/frontend/tests/components/dashboard/enrolled-droplets-grid.test.tsx
+++ b/frontend/tests/components/dashboard/enrolled-droplets-grid.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import { EnrolledDropletsGrid } from "@/components/dashboard/enrolled-droplets-grid";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getCachedUser } from "@/lib/requests/cached";
-import { getCachedEnrollmentsDashboard } from "@/lib/requests/cached";
-import { getUserDueDates } from "@/lib/requests/groups";
+import {
+  getCachedUserDashboardFull,
+  getCachedEnrollmentsFavorites,
+  getCachedUserDueDates,
+} from "@/lib/requests/cached";
 import { Enrollment } from "@/types";
 
 jest.mock("@/lib/auth/session", () => ({
@@ -11,12 +13,9 @@ jest.mock("@/lib/auth/session", () => ({
 }));
 
 jest.mock("@/lib/requests/cached", () => ({
-  getCachedUser: jest.fn(),
-  getCachedEnrollmentsDashboard: jest.fn(),
-}));
-
-jest.mock("@/lib/requests/groups", () => ({
-  getUserDueDates: jest.fn(),
+  getCachedUserDashboardFull: jest.fn(),
+  getCachedEnrollmentsFavorites: jest.fn(),
+  getCachedUserDueDates: jest.fn(),
 }));
 
 jest.mock("@/components/dashboard/enrolled-droplets-grid-client", () => ({
@@ -56,12 +55,14 @@ describe("EnrolledDropletsGrid", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
-    (getUserDueDates as jest.Mock).mockResolvedValue([]);
+    (getCachedUserDashboardFull as jest.Mock).mockResolvedValue(
+      mockAuthorizedUser,
+    );
+    (getCachedUserDueDates as jest.Mock).mockResolvedValue([]);
   });
 
   it("displays a message when no enrolled droplets are found", async () => {
-    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue([]);
+    (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue([]);
 
     render(await EnrolledDropletsGrid({}));
 
@@ -77,8 +78,10 @@ describe("EnrolledDropletsGrid", () => {
     const mockEnrollments = [] as Enrollment[];
 
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
-    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+    (getCachedUserDashboardFull as jest.Mock).mockResolvedValue(
+      mockAuthorizedUser,
+    );
+    (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -103,7 +106,7 @@ describe("EnrolledDropletsGrid", () => {
       },
     ];
 
-    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -133,13 +136,13 @@ describe("EnrolledDropletsGrid", () => {
       },
     ];
 
-    (getCachedEnrollmentsDashboard as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
     await EnrolledDropletsGrid({});
 
-    expect(getUserDueDates).toHaveBeenCalledWith(1);
+    expect(getCachedUserDueDates).toHaveBeenCalledWith(1);
   });
 
   describe("EnrolledDropletsGrid", () => {

--- a/frontend/tests/components/dashboard/my-content.test.tsx
+++ b/frontend/tests/components/dashboard/my-content.test.tsx
@@ -1,20 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import { MyContent } from "@/components/dashboard/my-content";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getCachedUser } from "@/lib/requests/cached";
+import {
+  getCachedUserDashboardFull,
+  getCachedUserGroups,
+} from "@/lib/requests/cached";
 import { notFound } from "next/navigation";
-import { getUserGroups } from "@/lib/requests/groups";
 
 jest.mock("@/lib/auth/session", () => ({
   getCurrentUser: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/cached", () => ({
-  getCachedUser: jest.fn(),
-}));
-
-jest.mock("@/lib/requests/groups", () => ({
-  getUserGroups: jest.fn(),
+  getCachedUserDashboardFull: jest.fn(),
+  getCachedUserGroups: jest.fn(),
 }));
 
 jest.mock("next/navigation", () => ({
@@ -118,8 +117,10 @@ describe("MyContent", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
-    (getUserGroups as jest.Mock).mockResolvedValue(mockGroups);
+    (getCachedUserDashboardFull as jest.Mock).mockResolvedValue(
+      mockAuthorizedUser,
+    );
+    (getCachedUserGroups as jest.Mock).mockResolvedValue(mockGroups);
   });
 
   describe("Authentication", () => {
@@ -142,13 +143,15 @@ describe("MyContent", () => {
     it("fetches authorized user by email", async () => {
       await MyContent({ searchParams: {} });
 
-      expect(getCachedUser).toHaveBeenCalledWith("test@example.com");
+      expect(getCachedUserDashboardFull).toHaveBeenCalledWith(
+        "test@example.com",
+      );
     });
 
     it("fetches user groups", async () => {
       await MyContent({ searchParams: {} });
 
-      expect(getUserGroups).toHaveBeenCalledWith(1);
+      expect(getCachedUserGroups).toHaveBeenCalledWith(1);
     });
   });
 
@@ -244,7 +247,7 @@ describe("MyContent", () => {
         },
       ];
 
-      (getUserGroups as jest.Mock).mockResolvedValue(groupsWithNonMember);
+      (getCachedUserGroups as jest.Mock).mockResolvedValue(groupsWithNonMember);
 
       render(await MyContent({ searchParams: { contentType: "groups" } }));
 
@@ -286,7 +289,7 @@ describe("MyContent", () => {
         },
       ];
 
-      (getUserGroups as jest.Mock).mockResolvedValue(multipleGroups);
+      (getCachedUserGroups as jest.Mock).mockResolvedValue(multipleGroups);
 
       render(await MyContent({ searchParams: { contentType: "groups" } }));
 
@@ -297,7 +300,7 @@ describe("MyContent", () => {
 
   describe("Empty States", () => {
     it("shows no groups message when no active groups", async () => {
-      (getUserGroups as jest.Mock).mockResolvedValue([]);
+      (getCachedUserGroups as jest.Mock).mockResolvedValue([]);
 
       render(await MyContent({ searchParams: { contentType: "groups" } }));
 
@@ -308,7 +311,7 @@ describe("MyContent", () => {
     });
 
     it("shows no archived groups message when no archived groups", async () => {
-      (getUserGroups as jest.Mock).mockResolvedValue([]);
+      (getCachedUserGroups as jest.Mock).mockResolvedValue([]);
 
       render(await MyContent({ searchParams: { contentType: "archived" } }));
 
@@ -428,7 +431,7 @@ describe("MyContent", () => {
     });
 
     it("handles groups with undefined members", async () => {
-      (getUserGroups as jest.Mock).mockResolvedValue([
+      (getCachedUserGroups as jest.Mock).mockResolvedValue([
         {
           id: 1,
           groupName: "Group Without Members",
@@ -445,7 +448,7 @@ describe("MyContent", () => {
     });
 
     it("handles groups with undefined users_archived", async () => {
-      (getUserGroups as jest.Mock).mockResolvedValue([
+      (getCachedUserGroups as jest.Mock).mockResolvedValue([
         {
           id: 1,
           groupName: "Group",
@@ -463,7 +466,7 @@ describe("MyContent", () => {
     });
 
     it("handles groups with null members", async () => {
-      (getUserGroups as jest.Mock).mockResolvedValue([
+      (getCachedUserGroups as jest.Mock).mockResolvedValue([
         {
           id: 1,
           groupName: "Group With Null Members",
@@ -480,7 +483,7 @@ describe("MyContent", () => {
     });
 
     it("handles empty members array", async () => {
-      (getUserGroups as jest.Mock).mockResolvedValue([
+      (getCachedUserGroups as jest.Mock).mockResolvedValue([
         {
           id: 1,
           groupName: "Group With Empty Members",
@@ -516,7 +519,9 @@ describe("MyContent", () => {
         },
       ];
 
-      (getUserGroups as jest.Mock).mockResolvedValue(multipleActiveGroups);
+      (getCachedUserGroups as jest.Mock).mockResolvedValue(
+        multipleActiveGroups,
+      );
 
       render(await MyContent({ searchParams: { contentType: "groups" } }));
 

--- a/frontend/tests/components/dashboard/user-playlist-grid.test.tsx
+++ b/frontend/tests/components/dashboard/user-playlist-grid.test.tsx
@@ -1,24 +1,20 @@
 import { render, screen } from "@testing-library/react";
 import { UserPlaylistsGrid } from "@/components/dashboard/user-playlists-grid";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
-import { getUserDueDates } from "@/lib/requests/groups";
+import {
+  getCachedUserDashboardFull,
+  getCachedEnrollmentsFavorites,
+  getCachedUserDueDates,
+} from "@/lib/requests/cached";
 
 jest.mock("@/lib/auth/session", () => ({
   getCurrentUser: jest.fn(),
 }));
 
-jest.mock("@/lib/requests/authorized-user", () => ({
-  getAuthorizedUserByEmail: jest.fn(),
-}));
-
 jest.mock("@/lib/requests/cached", () => ({
-  getCachedEnrollmentsWithLessonIds: jest.fn(),
-}));
-
-jest.mock("@/lib/requests/groups", () => ({
-  getUserDueDates: jest.fn(),
+  getCachedUserDashboardFull: jest.fn(),
+  getCachedEnrollmentsFavorites: jest.fn(),
+  getCachedUserDueDates: jest.fn(),
 }));
 
 jest.mock("@/components/playlists/playlist-card", () => ({
@@ -54,11 +50,11 @@ describe("UserPlaylistsGrid", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
+    (getCachedUserDashboardFull as jest.Mock).mockResolvedValue(
       mockAuthorizedUser,
     );
-    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValue([]);
-    (getUserDueDates as jest.Mock).mockResolvedValue([]);
+    (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue([]);
+    (getCachedUserDueDates as jest.Mock).mockResolvedValue([]);
   });
 
   it("displays a message when no playlists are found", async () => {
@@ -89,7 +85,7 @@ describe("UserPlaylistsGrid", () => {
       playlists: mockPlaylists,
     };
 
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
+    (getCachedUserDashboardFull as jest.Mock).mockResolvedValue(
       mockUserWithPlaylists,
     );
 
@@ -116,7 +112,7 @@ describe("UserPlaylistsGrid", () => {
       playlists: mockPlaylists,
     };
 
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
+    (getCachedUserDashboardFull as jest.Mock).mockResolvedValue(
       mockUserWithPlaylists,
     );
 
@@ -154,10 +150,10 @@ describe("UserPlaylistsGrid", () => {
       },
     ];
 
-    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue(
+    (getCachedUserDashboardFull as jest.Mock).mockResolvedValue(
       mockUserWithPlaylists,
     );
-    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValue(
+    (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue(
       mockEnrollments,
     );
 
@@ -197,12 +193,12 @@ describe("UserPlaylistsGrid", () => {
     beforeEach(() => {
       jest.clearAllMocks();
       (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
-      (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue({
+      (getCachedUserDashboardFull as jest.Mock).mockResolvedValue({
         ...mockUser,
         playlists: mockPlaylists,
       });
-      (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValue([]);
-      (getUserDueDates as jest.Mock).mockResolvedValue([]);
+      (getCachedEnrollmentsFavorites as jest.Mock).mockResolvedValue([]);
+      (getCachedUserDueDates as jest.Mock).mockResolvedValue([]);
     });
 
     it("should render public and private playlists correctly", async () => {


### PR DESCRIPTION

## Description
- Components now share cache keys instead of using different ones, so React.cache() actually deduplicates. The exact call count reduction depends on which tab is active.
Droplet pages:
- Promise.all runs independent fetches in parallel instead of sequentially — the speedup depends on actual network latency to Strapi
- Duplicate calls were removed (2 -> 1 user calls, shared droplet/enrollment cache across layout + page)
- force-dynamic was removed from lesson page








## Checklist:


- [X] My code follows the code style of this project.
- [X] I have moved the ticket to "In Review"
- [X] I have added reviewers to this PR
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.