### PR TITLE
ODY-314: Replace full user list fetch with debounced search

### DIFF
--- a/frontend/app/(general)/settings/friends/page.tsx
+++ b/frontend/app/(general)/settings/friends/page.tsx
@@ -3,10 +3,6 @@ import { FriendSuggestions } from "@/components/friends/friend-suggestions";
 import { Friends } from "@/components/friends/friends";
 import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
-import {
-  getAuthorizedUserByEmail,
-} from "@/lib/requests/authorized-user";
-import { fetchAuthorizedUsers } from "@/lib/requests/authorized-user";
 import { getCachedUserSocial } from "@/lib/requests/cached";
 import { FriendSentRequests } from "@/components/friends/friend-sent-requests";
 import { FriendSearch } from "@/components/friends/friend-search";

--- a/frontend/app/(general)/settings/friends/page.tsx
+++ b/frontend/app/(general)/settings/friends/page.tsx
@@ -4,7 +4,6 @@ import { Friends } from "@/components/friends/friends";
 import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
 import {
-  fetchAuthorizedUsers,
   getAuthorizedUserByEmail,
 } from "@/lib/requests/authorized-user";
 import { FriendSentRequests } from "@/components/friends/friend-sent-requests";
@@ -24,8 +23,6 @@ export default async function AuthorProfileSettings({
 }) {
   const tab = (await searchParams)?.tab || "friends";
 
-  const authorizedUsers = await fetchAuthorizedUsers();
-
   const user = await getCurrentUser();
   if (!user?.email) return notFound();
 
@@ -34,13 +31,6 @@ export default async function AuthorProfileSettings({
 
   const sentRequests = await getSentRequestIds(authorizedUser);
   const friends = (await fetchFriends(authorizedUser)).map((user) => user.id);
-
-  const requestedAuthUsers = authorizedUsers
-    .filter((user) => !sentRequests.includes(user.id))
-    .map((user) => user.id);
-  const friendedAuthUsers = authorizedUsers
-    .filter((user) => !friends.includes(user.id))
-    .map((user) => user.id);
 
   const friendsList = await fetchFriends(authorizedUser);
   const friendsLength = friendsList.length;
@@ -54,10 +44,9 @@ export default async function AuthorProfileSettings({
   return (
     <div className="flex flex-col">
       <FriendSearch
-        authUsers={authorizedUsers}
         curUser={authorizedUser}
-        requestIds={requestedAuthUsers}
-        friendIds={friendedAuthUsers}
+        requestIds={sentRequests}
+        friendIds={friends}
       ></FriendSearch>
 
       <div className="flex flex-col">

--- a/frontend/components/friends/friend-search.tsx
+++ b/frontend/components/friends/friend-search.tsx
@@ -1,22 +1,20 @@
 "use client";
 
 import { Input } from "@/components/ui/input";
-import { useState } from "react";
-import { ChangeEvent } from "react";
+import { useState, useEffect, ChangeEvent } from "react";
 import { AuthorizedUser } from "@/types";
 import { FriendSuggestionsBlock } from "./friend-suggestions-block";
 import { FriendBlock } from "./friend-block";
 import { cn } from "@/lib/utils";
+import { searchAuthorizedUsers } from "@/lib/requests/authorized-user";
 
 interface FriendSearchProps {
-  authUsers: AuthorizedUser[];
   curUser: AuthorizedUser;
   requestIds: number[];
   friendIds: number[];
 }
 
 export function FriendSearch({
-  authUsers,
   curUser,
   requestIds,
   friendIds,
@@ -25,40 +23,45 @@ export function FriendSearch({
   const [isHovered, setIsHovered] = useState(false);
   const [searchResults, setSearchResults] = useState<AuthorizedUser[]>([]);
   const [focused, setFocused] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const delayDebounceFn = setTimeout(async () => {
+      if (searchTerm.trim()) {
+        try {
+          setIsLoading(true);
+          const results = await searchAuthorizedUsers(searchTerm);
+          if (Array.isArray(results)) {
+            const filtered = results.filter(
+              (user) =>
+                !curUser.blocked.some(
+                  (blockedUser) => blockedUser.id === user.id,
+                ) &&
+                !curUser.was_blocked.some(
+                  (blockedUser) => blockedUser.id === user.id,
+                ),
+            );
+            setSearchResults(filtered);
+          } else {
+            setSearchResults([]);
+          }
+        } catch (error) {
+          console.error("Search failed:", error);
+          setSearchResults([]);
+        } finally {
+          setIsLoading(false);
+        }
+      } else {
+        setSearchResults([]);
+        setIsLoading(false);
+      }
+    }, 300);
+
+    return () => clearTimeout(delayDebounceFn);
+  }, [searchTerm, curUser.blocked, curUser.was_blocked]);
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const searchTerm = e.target.value;
-    setSearchItem(searchTerm);
-
-    if (!searchTerm.trim()) {
-      setSearchResults([]);
-      return;
-    }
-
-    const filtered = authUsers.filter(
-      (user) =>
-        !curUser.blocked.some((blockedUser) => blockedUser.id === user.id) &&
-        !curUser.was_blocked.some(
-          (blockedUser) => blockedUser.id === user.id,
-        ) &&
-        (user.firstName?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          user.lastName?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          user.email
-            ?.split("@")[0]
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase()) ||
-          (
-            user.firstName?.toLowerCase() +
-            " " +
-            user.lastName?.toLowerCase()
-          ).includes(searchTerm.toLowerCase())),
-    );
-
-    if (filtered?.length === 0) {
-      setSearchResults([]);
-    } else {
-      setSearchResults(filtered);
-    }
+    setSearchItem(e.target.value);
   };
 
   return (
@@ -87,10 +90,12 @@ export function FriendSearch({
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
           >
-            {searchResults.length > 0 ? (
+            {isLoading ? (
+              <div className="p-4 text-center text-sm text-gray-500">Searching...</div>
+            ) : searchResults.length > 0 ? (
               <ul className="p-4 md:space-y-4">
                 {searchResults.slice(0, 10).map((user, index) => {
-                  if (!friendIds.includes(user.id)) {
+                  if (friendIds.includes(user.id)) {
                     return (
                       <FriendBlock
                         user={curUser}
@@ -99,7 +104,7 @@ export function FriendSearch({
                         data-testid={`user-item-${index + 1}`}
                       />
                     );
-                  } else if (requestIds.includes(user.id)) {
+                  } else if (!requestIds.includes(user.id)) {
                     return (
                       <FriendSuggestionsBlock
                         suggUser={user}
@@ -125,7 +130,7 @@ export function FriendSearch({
                 })}
               </ul>
             ) : (
-              <p className="p-1" data-testid="no-results">
+              <p className="p-4 text-center text-sm text-gray-500" data-testid="no-results">
                 No users found.
               </p>
             )}

--- a/frontend/components/friends/friend-search.tsx
+++ b/frontend/components/friends/friend-search.tsx
@@ -34,6 +34,7 @@ export function FriendSearch({
           if (Array.isArray(results)) {
             const filtered = results.filter(
               (user) =>
+                user.id !== curUser.id &&
                 !curUser.blocked.some(
                   (blockedUser) => blockedUser.id === user.id,
                 ) &&
@@ -91,7 +92,9 @@ export function FriendSearch({
             onMouseLeave={() => setIsHovered(false)}
           >
             {isLoading ? (
-              <div className="p-4 text-center text-sm text-gray-500">Searching...</div>
+              <div className="p-4 text-center text-sm text-gray-500">
+                Searching...
+              </div>
             ) : searchResults.length > 0 ? (
               <ul className="p-4 md:space-y-4">
                 {searchResults.slice(0, 10).map((user, index) => {
@@ -130,7 +133,10 @@ export function FriendSearch({
                 })}
               </ul>
             ) : (
-              <p className="p-4 text-center text-sm text-gray-500" data-testid="no-results">
+              <p
+                className="p-4 text-center text-sm text-gray-500"
+                data-testid="no-results"
+              >
                 No users found.
               </p>
             )}

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -191,6 +191,22 @@ export async function fetchAuthorizedUsers(): Promise<AuthorizedUser[]> {
   }
 }
 
+export async function searchAuthorizedUsers(query: string) {
+  return fetchAPI<AuthorizedUser[]>("/authorized-users", {
+    urlParams: {
+      filters: {
+        $or: [
+          { email: { $containsi: query } },
+          { firstName: { $containsi: query } },
+          { lastName: { $containsi: query } },
+        ],
+      },
+      fields: ["id", "email", "firstName", "lastName", "profilePhoto"],
+      pagination: { pageSize: 20, page: 1 },
+    },
+  });
+}
+
 // Gets just one enrollment but also returns the response metadata to get pagination data
 export async function fetchAuthorizedUsersMetadata({
   sort,
@@ -567,8 +583,8 @@ export async function updateUserInfo(
     } = updates;
     const roleIds = roles
       ? await Promise.all(
-          roles.map((role) => getAuthorizedUserRoleIdByTitle(role)),
-        )
+        roles.map((role) => getAuthorizedUserRoleIdByTitle(role)),
+      )
       : [];
 
     const data: any = {};

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -522,8 +522,8 @@ export async function updateUserInfo(
     } = updates;
     const roleIds = roles
       ? await Promise.all(
-        roles.map((role) => getAuthorizedUserRoleIdByTitle(role)),
-      )
+          roles.map((role) => getAuthorizedUserRoleIdByTitle(role)),
+        )
       : [];
 
     const data: any = {};


### PR DESCRIPTION
## Description

Instead of fetching every user on the platform, we use a debounced user input so that after the user is done typing, the autocomplete users show up by only querying them.

## Motivation and Context

This change will reduce latency as the user base grows.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.