### PR TITLE
 Migrate to centralized cache-tag invalidation and use targeted enrollment queries

### DIFF
--- a/frontend/app/(droplets)/d/[slug]/layout.tsx
+++ b/frontend/app/(droplets)/d/[slug]/layout.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const p = await params;
   const droplet = await getDropletBySlug<Pick<Droplet, "name">>(p.slug, {
     fields: ["name"],
-    populate: undefined,
+    populate: {},
   });
   if (!droplet) return {};
 

--- a/frontend/app/(droplets)/d/[slug]/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const p = await params;
   const droplet = await getDropletBySlug<Pick<Droplet, "name">>(p.slug, {
     fields: ["name"],
-    populate: undefined,
+    populate: {},
   });
   if (!droplet) return {};
 
@@ -59,7 +59,9 @@ export default async function DropletRoute({ params }: Props) {
     const enrollments = await getCachedEnrollmentsWithLessonIds(
       authorizedUser.id,
     );
-    isEnrolled = enrollments.some((e) => e.droplet.id === droplet.id);
+    isEnrolled = enrollments.some(
+      (e) => e.droplet && e.droplet.id === droplet.id,
+    );
   }
 
   return (

--- a/frontend/app/(editing)/draft/d/[slug]/[lessonSlug]/page.tsx
+++ b/frontend/app/(editing)/draft/d/[slug]/[lessonSlug]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const p = await params;
   const lesson = await getLessonBySlug<Pick<Lesson, "name">>(p.lessonSlug, {
     fields: ["name"],
-    populate: undefined,
+    populate: {},
   });
   if (!lesson) return {};
 

--- a/frontend/app/(editing)/draft/d/[slug]/page.tsx
+++ b/frontend/app/(editing)/draft/d/[slug]/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props) {
   const p = await params;
   const droplet = await getDropletBySlug<Pick<Droplet, "name">>(p.slug, {
     fields: ["name"],
-    populate: undefined,
+    populate: {},
   });
   if (!droplet) return {};
 

--- a/frontend/app/(general)/contributors/page.tsx
+++ b/frontend/app/(general)/contributors/page.tsx
@@ -6,6 +6,8 @@ import {
 } from "@/lib/requests/authorized-user";
 import { Metadata } from "next";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "Contributors",
 };

--- a/frontend/app/(general)/dashboard/loading.tsx
+++ b/frontend/app/(general)/dashboard/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/components/ui/page-spinner";

--- a/frontend/app/(general)/explore/loading.tsx
+++ b/frontend/app/(general)/explore/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/components/ui/page-spinner";

--- a/frontend/app/(general)/explore/page.tsx
+++ b/frontend/app/(general)/explore/page.tsx
@@ -22,8 +22,6 @@ export const metadata: Metadata = {
   title: "Explore",
   description: "Discover content on Khoury Odyssey.",
 };
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
 export default async function ExplorePage({
   searchParams,
 }: {

--- a/frontend/app/(general)/features/page.tsx
+++ b/frontend/app/(general)/features/page.tsx
@@ -4,6 +4,8 @@ import { getGalleryBySlug } from "@/lib/requests/galleries";
 import { Gallery } from "@/types";
 import { Metadata } from "next";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "Features",
 };

--- a/frontend/app/(general)/feed/loading.tsx
+++ b/frontend/app/(general)/feed/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/components/ui/page-spinner";

--- a/frontend/app/(general)/feed/page.tsx
+++ b/frontend/app/(general)/feed/page.tsx
@@ -8,8 +8,6 @@ export const metadata: Metadata = {
   title: "Feed",
   description: "Displays a user's feed.",
 };
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
 export default async function FeedPage() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return notFound();

--- a/frontend/app/(general)/my-content/loading.tsx
+++ b/frontend/app/(general)/my-content/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/components/ui/page-spinner";

--- a/frontend/app/(general)/prof/loading.tsx
+++ b/frontend/app/(general)/prof/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/components/ui/page-spinner";

--- a/frontend/app/(general)/settings/loading.tsx
+++ b/frontend/app/(general)/settings/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/components/ui/page-spinner";

--- a/frontend/app/(general)/settings/notes/page.tsx
+++ b/frontend/app/(general)/settings/notes/page.tsx
@@ -1,7 +1,4 @@
-import { getDropletBySlug } from "@/lib/requests/droplet";
-import { Droplet } from "@/types";
 import { Metadata } from "next";
-import { notFound } from "next/navigation";
 import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { getCurrentUser } from "@/lib/auth/session";
@@ -11,139 +8,86 @@ import { PDFDocument } from "pdf-lib";
 import { NoteSummary } from "@/components/droplets/lessons/note-taking/note-summary";
 import { NotesManager } from "@/components/droplets/notes-manager";
 
-type Props = {
-  params: Promise<Params>;
+export const metadata: Metadata = {
+  title: "Notes",
 };
 
-type Params = {
-  slug: string;
-};
+export default async function NotesPage() {
+  const currentUser = await getCurrentUser();
+  if (!currentUser?.email) return null;
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const p = await params;
-  const droplet = await getDropletBySlug<Droplet>(p.slug, {
-    fields: ["*"],
+  const user = await getCachedUser(currentUser.email);
+  const enrollments = await getEnrollmentsByAuthorizedUser(user.id, {
     populate: {
-      learningObjectives: { populate: "*" },
-      tags: { populate: "*" },
-      nextSteps: { populate: "*" },
-      lessons: {
+      droplet: {
+        populate: {
+          lessons: {
+            fields: ["id", "name", "slug"],
+          },
+        },
         fields: ["id", "name", "slug"],
       },
     },
   });
 
-  if (!droplet) {
-    console.error("not found");
-    return notFound();
-  }
+  const authUser = await getCachedUser(user.email);
 
-  return {
-    title: `Recap | ${droplet.name}`,
-  };
-}
+  const defined = <T,>(v: T | null | undefined): v is T => v != null;
 
-export default async function DropletRecapRoute({ params }: Props) {
-  const p = await params;
-  const droplet = await getDropletBySlug<Droplet>(p.slug, {
-    fields: ["*"],
-    populate: {
-      learningObjectives: { populate: "*" },
-      tags: { populate: "*" },
-      nextSteps: { populate: "*" },
-    },
-  });
-  if (!droplet) {
-    console.error("not found");
-    return notFound();
-  }
+  const allNotes = (
+    await Promise.all(
+      enrollments.map(async (enrollment) => {
+        if (!enrollment) return null;
+        const dropletNotes = await getNotesByDroplet(
+          authUser.id,
+          enrollment.droplet.id,
+        );
+        const dropletHighlights = await getHighlightsByDroplet(
+          authUser.id,
+          enrollment.droplet.id,
+        );
 
-  const currentUser = await getCurrentUser();
-  if (currentUser?.email) {
-    const user = await getCachedUser(currentUser.email);
-    const enrollments = await getEnrollmentsByAuthorizedUser(user.id, {
-      populate: {
-        viewedLessons: {
-          fields: ["id", "name", "slug"],
-        },
-        droplet: {
-          populate: {
-            lessons: {
-              fields: ["id", "name", "slug"],
-            },
-            tags: {
-              fields: ["*"],
-            },
-            usersFavorited: {
-              fields: "*",
-            },
-          },
-          fields: ["id", "*"],
-        },
-      },
+        return {
+          dropletId: enrollment.droplet.id,
+          notes: dropletNotes,
+          highlights: dropletHighlights.filter(
+            (highlight) =>
+              !dropletNotes.some(
+                (lesson) => lesson.highlight?.id === highlight.id,
+              ),
+          ),
+        };
+      }),
+    )
+  ).filter(defined);
+
+  const pdfDoc = await PDFDocument.create();
+
+  for (let i = 0; i < enrollments.length; i++) {
+    const enrollment = enrollments[i];
+    const dropletData = allNotes[i];
+    const sectionPdfBytes = await NoteSummary({
+      filteredHighlights: dropletData?.highlights || [],
+      notes: dropletData?.notes || [],
+      droplet: enrollment.droplet,
     });
 
-    const authUser = await getCachedUser(user.email);
+    const sectionPdfDoc = await PDFDocument.load(sectionPdfBytes);
+    const sectionPages = sectionPdfDoc.getPages();
 
-    const defined = <T,>(v: T | null | undefined): v is T => v != null;
-
-    const allNotes = (
-      await Promise.all(
-        enrollments.map(async (enrollment) => {
-          if (!enrollment) return null;
-          const dropletNotes = await getNotesByDroplet(
-            authUser.id,
-            enrollment.droplet.id,
-          );
-          const dropletHighlights = await getHighlightsByDroplet(
-            authUser.id,
-            enrollment.droplet.id,
-          );
-          // console.log(`Enrollment ${enrollment.id}, Droplet ${enrollment.droplet.id}: ${dropletHighlights.length} highlights found`);
-          // console.log(`Lessons in droplet: ${enrollment.droplet.lessons?.map(l => l.id).join(', ')}`);
-
-          return {
-            dropletId: enrollment.droplet.id,
-            notes: dropletNotes,
-            highlights: dropletHighlights.filter(
-              (highlight) =>
-                !dropletNotes.some(
-                  (lesson) => lesson.highlight?.id === highlight.id,
-                ),
-            ),
-          };
-        }),
-      )
-    ).filter(defined);
-
-    const pdfDoc = await PDFDocument.create();
-
-    for (let i = 0; i < enrollments.length; i++) {
-      const enrollment = enrollments[i];
-      const dropletData = allNotes[i];
-      const sectionPdfBytes = await NoteSummary({
-        filteredHighlights: dropletData?.highlights || [],
-        notes: dropletData?.notes || [],
-        droplet: enrollment.droplet,
-      });
-
-      const sectionPdfDoc = await PDFDocument.load(sectionPdfBytes);
-      const sectionPages = sectionPdfDoc.getPages();
-
-      for (let j = 0; j < sectionPages.length; j++) {
-        const [copiedPage] = await pdfDoc.copyPages(sectionPdfDoc, [j]);
-        pdfDoc.addPage(copiedPage);
-      }
+    for (let j = 0; j < sectionPages.length; j++) {
+      const [copiedPage] = await pdfDoc.copyPages(sectionPdfDoc, [j]);
+      pdfDoc.addPage(copiedPage);
     }
-
-    const initialPdfBytes = await pdfDoc.save();
-
-    return (
-      <NotesManager
-        enrollments={enrollments}
-        allNotes={allNotes ? allNotes : []}
-        initialPdfBytes={initialPdfBytes}
-      />
-    );
   }
+
+  const initialPdfBytes = await pdfDoc.save();
+
+  return (
+    <NotesManager
+      enrollments={enrollments}
+      allNotes={allNotes ? allNotes : []}
+      initialPdfBytes={initialPdfBytes}
+    />
+  );
 }

--- a/frontend/app/(general)/website-creators/page.tsx
+++ b/frontend/app/(general)/website-creators/page.tsx
@@ -3,6 +3,8 @@ import { GradientBackground } from "@/components/gradient-bg";
 import { fetchWebsiteCreators } from "@/lib/requests/authorized-user";
 import { Metadata } from "next";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "Website Creators",
 };

--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -15,9 +15,6 @@ import { getEnrollmentsForGroupMembers } from "@/lib/requests/enrollment";
 import { AuthorizedUser, DueDate } from "@/types";
 import { DateTime } from "luxon";
 
-export const fetchCache = "force-no-store";
-export const revalidate = 0;
-
 type Props = {
   params: Promise<{
     slug: string;

--- a/frontend/app/(groups)/g/loading.tsx
+++ b/frontend/app/(groups)/g/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/components/ui/page-spinner";

--- a/frontend/app/(playlists)/p/loading.tsx
+++ b/frontend/app/(playlists)/p/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/components/ui/page-spinner";

--- a/frontend/components/admin/droplets/droplet-block.tsx
+++ b/frontend/components/admin/droplets/droplet-block.tsx
@@ -20,17 +20,13 @@ export function DropletBlock({
   const handleUpdateDroplet = async () => {
     setDroplet((prev) => ({ ...prev, isHidden: !prev.isHidden }));
 
-    const result = await updateDroplet(
-      droplet.id,
-      {
-        isHidden: !droplet.isHidden,
-        name: droplet.name,
-        focusArea: droplet.focusArea,
-        type: droplet.type,
-        tagIds: droplet.tags?.map((tag) => tag.id) || [],
-      },
-      { revalidate: true },
-    );
+    const result = await updateDroplet(droplet.id, {
+      isHidden: !droplet.isHidden,
+      name: droplet.name,
+      focusArea: droplet.focusArea,
+      type: droplet.type,
+      tagIds: droplet.tags?.map((tag) => tag.id) || [],
+    });
 
     if (result.ok) {
       toast.success(

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -987,7 +987,7 @@ export function LessonRenderer({
   };
 
   const handleDeleteHighlight = async (highlightId: number) => {
-    const response = await deleteHighlight(highlightId);
+    const response = await deleteHighlight(highlightId, authUser!.id);
     if (response && !response.error) {
       setHighlights((prev) => prev.filter((h) => h.id !== highlightId));
       toast.success("Highlight removed");
@@ -1006,6 +1006,7 @@ export function LessonRenderer({
         lesson,
         enrollment,
         notePos,
+        authUser.id,
         highlight[0],
       );
       if (result.success) {

--- a/frontend/components/droplets/lessons/note-taking/note-block.tsx
+++ b/frontend/components/droplets/lessons/note-taking/note-block.tsx
@@ -17,11 +17,13 @@ import Link from "@tiptap/extension-link";
 
 export function NoteBlock({
   note,
+  authorizedUserId,
   onUpdate,
   onDelete,
   onFocus,
 }: {
   note: Note;
+  authorizedUserId: number;
   onUpdate: () => void;
   onDelete: (noteId: number) => void;
   onFocus: (focused: number | null) => void;
@@ -33,14 +35,14 @@ export function NoteBlock({
 
   const handleBlur = useCallback(async () => {
     setNoteMessage("Saving");
-    const result = await updateNoteContent(note.id, content);
+    const result = await updateNoteContent(note.id, content, authorizedUserId);
     if (!result.success) {
       console.error("Failed to update note content");
     } else {
       setNoteMessage("Saved");
       onUpdate();
     }
-  }, [content, note.id, onUpdate]);
+  }, [content, note.id, authorizedUserId, onUpdate]);
 
   function stripHtml(html: string): string {
     if (!html) return "General Note";

--- a/frontend/components/droplets/lessons/note-taking/notes-bar.tsx
+++ b/frontend/components/droplets/lessons/note-taking/notes-bar.tsx
@@ -90,7 +90,7 @@ export function NotesBar({
     try {
       const currentNote = notes.find((n) => n.id === draggedNote.id);
       if (currentNote) {
-        await updateNotePosition(draggedNote.id, currentNote.positionY);
+        await updateNotePosition(draggedNote.id, currentNote.positionY, userId);
         await fetchNotes();
       }
     } catch (error) {
@@ -186,7 +186,12 @@ export function NotesBar({
       setNotes(tempNotes);
 
       const enrollment = await getEnrollByID(String(enrollmentId));
-      const result = await createNote(lesson, enrollment, mousePositionY + 50);
+      const result = await createNote(
+        lesson,
+        enrollment,
+        mousePositionY + 50,
+        userId,
+      );
 
       if (result.success) {
         await fetchNotes();
@@ -204,7 +209,7 @@ export function NotesBar({
       // Optimistically remove the note from UI
       setNotes((currentNotes) => currentNotes.filter((note) => note.id !== id));
 
-      const result = await deleteNote(id);
+      const result = await deleteNote(id, userId);
       if (!result.ok) {
         // If delete failed, restore the notes from server
         const updatedNotes = await getNotesByAuthorizedUserAndLesson(
@@ -278,6 +283,7 @@ export function NotesBar({
             >
               <NoteBlock
                 note={note}
+                authorizedUserId={userId}
                 onUpdate={fetchNotes}
                 onDelete={handleDeleteNote}
                 onFocus={setFocused}

--- a/frontend/components/friends/friend-completed-droplets.tsx
+++ b/frontend/components/friends/friend-completed-droplets.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { AuthorizedUser, Droplet } from "@/types";
-import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
+import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
+import { ENROLLMENT_POPULATES } from "@/lib/requests/enrollment-populates";
 import { FriendCompletedDropletsList } from "./friend-completed-droplets-list";
 
 export function FriendCompletedDroplets({
@@ -16,7 +17,9 @@ export function FriendCompletedDroplets({
 
   useEffect(() => {
     async function fetchCompletedDroplets() {
-      const enrollments = await getCachedEnrollmentsWithLessonIds(friend.id);
+      const enrollments = await getEnrollmentsByAuthorizedUser(friend.id, {
+        populate: ENROLLMENT_POPULATES.withLessonIds,
+      });
       if (enrollments) {
         const completed = enrollments
           .filter((e) => e.viewedLessons.length === e.droplet.lessons?.length)

--- a/frontend/components/ui/page-spinner.tsx
+++ b/frontend/components/ui/page-spinner.tsx
@@ -1,0 +1,13 @@
+import { LoaderCircleIcon } from "lucide-react";
+
+export default function PageSpinner() {
+  return (
+    <div className="flex h-screen w-screen flex-1 items-center justify-center p-12">
+      <LoaderCircleIcon
+        role="status"
+        aria-label="Loading"
+        className="h-52 w-52 animate-spin text-slate-200"
+      />
+    </div>
+  );
+}

--- a/frontend/lib/cache-tags.ts
+++ b/frontend/lib/cache-tags.ts
@@ -1,0 +1,62 @@
+/**
+ * Centralized cache tag taxonomy.
+ *
+ * Every `next: { tags }` fetch option and every `revalidateTag()` call should
+ * reference constants from this file so invalidation stays consistent.
+ *
+ * ── Tag → Invalidated by ──────────────────────── Revalidate ────────────
+ *
+ * droplets        createDroplet, updateDroplet, deepDeleteDroplet,          900s
+ *                 publishDraftDroplet, addLesson, updateLesson,
+ *                 deleteLesson, updateDropletFunFact
+ * enrollments     Two-level tag system:                                      900s
+ *                 ↳ Per-user tag "enrollments-{userId}":
+ *                   createEnrollment, createEnrollmentFromEmail,
+ *                   deleteEnrollment, markLessonAsComplete, completeLesson,
+ *                   archiveDroplet, togglePlaylistEnrollment,
+ *                   enrollInPlaylist, changeEnrollmentRating,
+ *                   updateEnrollmentFirstTime, updateViewedLessons,
+ *                   updateCompletionDate, favoriteDroplet
+ *                 ↳ Global tag "enrollments" (sweeps all users):
+ *                   updateDroplet, deepDeleteDroplet, publishDraftDroplet,
+ *                   addLesson, deleteLesson, duplicateLessonToDroplet,
+ *                   updateDropletAverageRating
+ *                 ↳ shared by all presets: minimal, withLessonIds,
+ *                   dashboard, favorites (see enrollment-populates.ts)
+ * playlists       createPlaylist, updatePlaylist, deletePlaylist,           900s
+ *                 archivePlaylist, togglePlaylistEnrollment
+ * groups          createGroup, updateGroup, deleteGroup,                    900s
+ *                 updateGroupMembers, archiveGroup (global tag only)
+ * authors         updateDroplet, createDroplet, deepDeleteDroplet,          900s
+ *                 publishDraftDroplet, deletePlaylist, deleteGroup
+ * notes           createNote, updateNote, deleteNote, duplicateNote         900s
+ * highlights      createHighlight, deleteHighlight                          900s
+ * lesson          updateLesson                                              900s
+ * friendships     sendFriendRequest, acceptFriendRequest,                   900s
+ *                 rejectFriendRequest, cancelFriendRequest,
+ *                 removeFriend, blockUser, unblockUser
+ * announcements   createFriend/Kudos/Playlist/Group/Droplet/               900s
+ *                 SystemAnnouncement
+ * tags            createNewTag                                              3600s
+ * due-dates       assignDropletDueDate, assignPlaylistDueDate               900s
+ *                 (global tag only)
+ */
+
+export const CACHE_TAGS = {
+  // Global (shared across all users)
+  droplets: "droplets",
+  playlists: "playlists",
+  authors: "authors",
+  lesson: "lesson",
+  announcements: "announcements",
+  tags: "tags",
+  allGroups: "groups", // all group queries (getManagedGroups, getGroupBySlug, getGroupByID, getUserGroups, getGroupBySlugV2, fetchAnnouncements)
+  allDueDates: "due-dates", // all due date queries (getGroupDueDates, getUserDueDates)
+  allEnrollments: "enrollments", // global sweep for content mutations (updateDroplet, addLesson, etc.)
+
+  // Per-user (scoped to individual user)
+  enrollments: (userId: number) => `enrollments-${userId}`,
+  friendships: (userId: number) => `friendships-${userId}`,
+  notes: (userId: number) => `notes-${userId}`,
+  highlights: (userId: number) => `highlights-${userId}`,
+};

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -228,7 +228,7 @@ export async function fetchContentCreators(): Promise<AuthorizedUser[]> {
       NEXT_PUBLIC_STRAPI_API_URL + "/api/authorized-users?" + query,
       {
         headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-        cache: "no-store",
+        next: { revalidate: 3600 },
       },
     );
     const data = await response.json();
@@ -290,7 +290,7 @@ export async function fetchWebsiteCreators(): Promise<AuthorizedUser[]> {
       NEXT_PUBLIC_STRAPI_API_URL + "/api/authorized-users?" + query,
       {
         headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-        cache: "no-store",
+        next: { revalidate: 3600 },
       },
     );
 
@@ -583,7 +583,6 @@ export async function deleteAuthorizedUser(formData: FormData) {
 export async function fetchContentEditors(): Promise<AuthorizedUser[]> {
   // create a query for the backend
   const query = qs.stringify({
-    // we need filter for role by title
     filters: {
       roles: {
         title: {
@@ -591,20 +590,15 @@ export async function fetchContentEditors(): Promise<AuthorizedUser[]> {
         },
       },
     },
-    // now we need what fields necessary
     fields: ["id", "username", "email"],
-
-    populate: "*",
-    // sort in query
+    populate: {},
     sort: ["username"],
-    // set pagination -
     pagination: {
-      pageSize: 900,
+      pageSize: 100,
       page: 1,
     },
   });
 
-  // now, we can await a response with our query
   const response = await fetch(`/api/authorized-users?${query}`);
 
   // finally got response, so handle it

--- a/frontend/lib/requests/cached.ts
+++ b/frontend/lib/requests/cached.ts
@@ -56,13 +56,17 @@ export const getCachedUserDueDates = cache((authorizedUserId: number) =>
 export const getCachedDropletBySlug = cache((slug: string) =>
   getDropletBySlug(slug, {
     populate: {
-      authorized_users: { populate: "*" },
-      learningObjectives: { populate: "*" },
-      lessons: { populate: "*" },
-      tags: { populate: "*" },
-      prerequisites: { populate: ["id", "name", "slug"] },
-      postrequisites: { populate: ["id", "name", "slug"] },
-      nextSteps: { populate: "*" },
+      authorized_users: {
+        fields: ["id", "email", "firstName", "lastName", "profilePhoto"],
+      },
+      learningObjectives: { fields: ["id", "objective"] },
+      lessons: {
+        fields: ["id", "name", "slug", "orderIndex", "blocksVersion"],
+      },
+      tags: { fields: ["id", "name", "slug"] },
+      prerequisites: { fields: ["id", "name", "slug"] },
+      postrequisites: { fields: ["id", "name", "slug"] },
+      nextSteps: { fields: ["id", "label", "url"] },
     },
   }),
 );

--- a/frontend/lib/requests/data.ts
+++ b/frontend/lib/requests/data.ts
@@ -1,5 +1,6 @@
 import { AccessRequest } from "@/components/shared/access-manager/access-requests/access-requests";
 import { flattenAttributes } from "@/lib/utils";
+import { CACHE_TAGS } from "../cache-tags";
 import { Droplet, Group } from "@/types";
 import qs from "qs";
 import { Report } from "@/components/admin/reports/reports";
@@ -25,7 +26,7 @@ export async function fetchDroplets() {
         NEXT_PUBLIC_STRAPI_API_URL + "/api/droplets?" + query,
         {
           headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-          next: { tags: ["droplets"], revalidate: 0 },
+          next: { tags: [CACHE_TAGS.droplets], revalidate: 900 },
         },
       );
       const data = await response.json();

--- a/frontend/lib/requests/droplet.ts
+++ b/frontend/lib/requests/droplet.ts
@@ -3,13 +3,14 @@
 import { Droplet } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
 import { fetchAPI } from "../utils";
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { deleteLesson } from "./lesson";
 import { DropletSchema } from "../validations/droplet";
 import { z } from "zod";
 import { getCurrentUser } from "../auth/session";
 import { getAuthorizedUserByEmail } from "./authorized-user";
-import { getEnrollmentsByAuthorizedUser } from "./enrollment";
+import { getEnrollmentByUserAndDroplet } from "./enrollment";
+import { CACHE_TAGS } from "../cache-tags";
 
 const STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -41,6 +42,7 @@ export async function getDroplets({
   };
   const retVal = await fetchAPI<Droplet[]>(path, {
     urlParams,
+    next: { tags: [CACHE_TAGS.droplets], revalidate: 900 },
   });
   return retVal;
 }
@@ -86,6 +88,7 @@ export async function getDropletBySlug<T extends Partial<Droplet> = Droplet>(
 
   return await fetchAPI<T[]>(path, {
     urlParams,
+    next: { tags: [CACHE_TAGS.droplets], revalidate: 900 },
   }).then((droplets) => droplets[0]);
 }
 
@@ -112,6 +115,7 @@ export async function getDropletById<T extends Partial<Droplet> = Droplet>(
 
   return await fetchAPI<T>(path, {
     urlParams,
+    next: { tags: [CACHE_TAGS.droplets], revalidate: 900 },
   }).then((droplet) => droplet);
 }
 
@@ -152,6 +156,7 @@ export async function getRandomFunFactDroplet({
   };
   const retVal = await fetchAPI<Droplet[]>(path, {
     urlParams,
+    next: { tags: [CACHE_TAGS.droplets], revalidate: 900 },
   });
   return retVal;
 }
@@ -185,10 +190,8 @@ export async function updateDropletAverageRating(
     if (!response.ok) {
       throw new Error("Failed to update average rating");
     }
-    revalidateTag("droplets");
-    revalidatePath("/(droplets)/d/[slug]", "page");
-    revalidatePath("/(general)/dashboard", "page");
-    revalidatePath("/(playlists)/p/[slug]", "page");
+    revalidateTag(CACHE_TAGS.droplets);
+    revalidateTag(CACHE_TAGS.allEnrollments);
     return { success: true };
   } catch (error) {
     console.error("Error updating average rating:", error);
@@ -217,6 +220,7 @@ export async function updateDropletFunFact(fact: string, dropletId: number) {
     if (!response.ok) {
       throw new Error("Failed to update fun fact");
     }
+    revalidateTag(CACHE_TAGS.droplets);
     return { success: true };
   } catch (error) {
     console.error("Error updating fun fact:", error);
@@ -227,15 +231,15 @@ export async function updateDropletFunFact(fact: string, dropletId: number) {
 export async function deepDeleteDroplet(id: number) {
   try {
     const droplet = await getDropletById<Droplet>(id, {
-      fields: ["*"],
+      fields: ["id", "name", "slug"],
       populate: {
-        authorized_users: { populate: "*" },
-        learningObjectives: { populate: "*" },
-        lessons: { populate: "*" },
-        tags: { populate: "*" },
-        prerequisites: { populate: ["id", "name", "slug"] },
-        postrequisites: { populate: ["id", "name", "slug"] },
-        nextSteps: { fields: ["label", "url"] },
+        authorized_users: { fields: ["id"] },
+        learningObjectives: { fields: ["id"] },
+        lessons: { fields: ["id"] },
+        tags: { fields: ["id"] },
+        prerequisites: { fields: ["id"] },
+        postrequisites: { fields: ["id"] },
+        nextSteps: { fields: ["id"] },
       },
     });
 
@@ -259,9 +263,9 @@ export async function deepDeleteDroplet(id: number) {
       return { ok: false, error: "Failed to delete droplet.", data: null };
     }
 
-    revalidateTag("authors");
-    revalidateTag("droplets");
-    revalidatePath("(general)/my-content", "page");
+    revalidateTag(CACHE_TAGS.authors);
+    revalidateTag(CACHE_TAGS.droplets);
+    revalidateTag(CACHE_TAGS.allEnrollments);
     return { ok: true, error: null, data: data.data };
   } catch (err) {
     console.error(err);
@@ -272,9 +276,8 @@ export async function deepDeleteDroplet(id: number) {
 export async function updateDroplet(
   id: number,
   data: Partial<z.infer<typeof DropletSchema>>,
-  options: { regenerateSlug?: boolean; revalidate?: boolean } = {
+  options: { regenerateSlug?: boolean } = {
     regenerateSlug: false,
-    revalidate: false,
   },
 ) {
   try {
@@ -343,17 +346,12 @@ export async function updateDroplet(
       return { ok: false, error: errorMessage, data: null };
     }
 
-    if (
-      dataToSend.isHidden !== undefined ||
-      dataToSend.name ||
-      options.revalidate
-    ) {
-      revalidateTag("droplets");
-      revalidatePath("/admin");
-    }
+    revalidateTag(CACHE_TAGS.droplets);
+    revalidateTag(CACHE_TAGS.authors);
+    revalidateTag(CACHE_TAGS.allEnrollments);
+    revalidateTag(CACHE_TAGS.playlists);
+    revalidateTag(CACHE_TAGS.allGroups);
 
-    revalidateTag("authors");
-    revalidatePath("(general)/my-content", "page");
     return { ok: true, error: null, data: responseData.data };
   } catch (err) {
     console.error("Exception in updateDroplet:", err);
@@ -370,11 +368,13 @@ export async function archiveDroplet(droplet: Droplet, archiveState: boolean) {
     const user = await getCurrentUser();
     if (!user?.email) throw new Error("No email identified");
     const authorizedUser = await getAuthorizedUserByEmail(user.email);
-    const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
-
-    const toArchive = enrollments.filter((e) => e.droplet.id === droplet.id);
+    const enrollment = await getEnrollmentByUserAndDroplet(
+      authorizedUser.id,
+      droplet.id,
+    );
+    if (!enrollment) throw new Error("Not enrolled in this droplet");
     const response = await fetch(
-      `${STRAPI_API_URL}/api/enrollments/${toArchive[0].id}`,
+      `${STRAPI_API_URL}/api/enrollments/${enrollment.id}`,
       {
         method: "PUT",
         headers: {
@@ -392,12 +392,7 @@ export async function archiveDroplet(droplet: Droplet, archiveState: boolean) {
     if (!response.ok) {
       throw new Error("Failed to archive droplet");
     }
-    revalidateTag("dashboard");
-    revalidatePath("/");
-    revalidatePath("/draft");
-    revalidatePath(`/d/${droplet.slug}`);
-    revalidatePath("/dashboard");
-    revalidatePath("/dashboard/archived");
+    revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
     return { success: true };
   } catch (error) {
     console.error("Error archiving droplet:", error);
@@ -429,8 +424,7 @@ export async function createNewTag(tag: string) {
     const result = await response.json();
     const createdTag = result.data;
 
-    revalidatePath("/new/droplet");
-    revalidatePath("/draft/d/[slug]/[lessonSlug]", "page");
+    revalidateTag(CACHE_TAGS.tags);
     return {
       success: true,
       data: {
@@ -511,9 +505,8 @@ export async function createDroplet(data: z.infer<typeof CreateDropletSchema>) {
       const errorMessage = `${responseData.error.message} (${errorPath})`;
       return { ok: false, error: errorMessage, data: null };
     }
-    revalidateTag("authors");
-    revalidateTag("droplets");
-    revalidatePath("(general)/my-content", "page");
+    revalidateTag(CACHE_TAGS.authors);
+    revalidateTag(CACHE_TAGS.droplets);
     return { ok: true, error: null, data: responseData.data };
   } catch (err) {
     console.error(err);
@@ -721,7 +714,6 @@ export async function duplicateDroplet(dropletId: number) {
 
       return blocks.map((block, index) => {
         console.log(`Block ${index}:`, block.__component);
-
         const { id, ...blockWithoutId } = block;
 
         switch (block.__component) {
@@ -860,9 +852,8 @@ export async function duplicateDroplet(dropletId: number) {
       }
     }
 
-    revalidateTag("authors");
-    revalidateTag("droplets");
-    revalidatePath("(general)/my-content", "page");
+    revalidateTag(CACHE_TAGS.authors);
+    revalidateTag(CACHE_TAGS.droplets);
 
     return {
       ok: true,
@@ -888,6 +879,11 @@ export async function publishDraftToOriginal(
   draftDropletId: number,
   originalDropletId: number,
 ) {
+  let author: { id: number } | null = null;
+  let dbWritesStarted = false;
+  let draftEnrollments: { data?: any[] } = {};
+  let originalSlug: string | null = null;
+
   try {
     console.log("Starting publishDraftToOriginal", {
       draftDropletId,
@@ -896,10 +892,11 @@ export async function publishDraftToOriginal(
 
     const user = await getCurrentUser();
     if (!user?.email) throw new Error("No email identified");
-    const author = await getAuthorizedUserByEmail(user.email, {
+    const authorizedUser = await getAuthorizedUserByEmail(user.email, {
       populate: {},
     });
-    if (!author) throw new Error("No author identified");
+    if (!authorizedUser) throw new Error("No author identified");
+    author = authorizedUser;
 
     console.log("Fetching draft droplet...");
     // Fetch the draft droplet with all its data
@@ -946,6 +943,7 @@ export async function publishDraftToOriginal(
     if (!originalDroplet) {
       throw new Error("Original droplet not found");
     }
+    originalSlug = originalDroplet.slug;
     console.log(
       "Original droplet fetched:",
       originalDroplet.id,
@@ -953,6 +951,18 @@ export async function publishDraftToOriginal(
       originalDroplet.lessons?.length || 0,
       "lessons",
     );
+
+    // Fetch draft enrollments before DB writes begin
+    draftEnrollments = await fetch(
+      `${STRAPI_API_URL}/api/enrollments?filters[droplet][id][$eq]=${draftDropletId}&populate[authorizedUser][fields][0]=id`,
+      {
+        headers: {
+          Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}`,
+        },
+      },
+    ).then((res) => res.json());
+
+    dbWritesStarted = true;
 
     // Delete all lessons from the original droplet
     if (originalDroplet.lessons && originalDroplet.lessons.length > 0) {
@@ -1032,7 +1042,6 @@ export async function publishDraftToOriginal(
     );
     const updateResult = await updateDroplet(originalDropletId, updateData, {
       regenerateSlug: false,
-      revalidate: true,
     });
 
     if (!updateResult.ok) {
@@ -1044,19 +1053,8 @@ export async function publishDraftToOriginal(
 
     console.log("Updated original droplet successfully");
 
-    // After updating original droplet and creating lessons, update enrollments
     try {
       console.log("Updating enrollments to point to original droplet");
-
-      // Fetch all enrollments for the draft
-      const draftEnrollments = await fetch(
-        `${STRAPI_API_URL}/api/enrollments?filters[droplet][id][$eq]=${draftDropletId}&populate=*`,
-        {
-          headers: {
-            Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}`,
-          },
-        },
-      ).then((res) => res.json());
 
       // Update each enrollment to point to the original droplet
       for (const enrollment of draftEnrollments.data || []) {
@@ -1219,13 +1217,8 @@ export async function publishDraftToOriginal(
       );
     }
 
-    revalidateTag("authors");
-    revalidateTag("droplets");
-    revalidatePath("(general)/my-content", "page");
-    revalidatePath(`/d/${originalDroplet.slug}`, "page");
-
     console.log("publishDraftToOriginal completed successfully");
-    return { ok: true, error: null, slug: originalDroplet.slug };
+    return { ok: true, error: null, slug: originalSlug };
   } catch (err) {
     console.error("Full error in publishDraftToOriginal:", err);
     return {
@@ -1236,6 +1229,14 @@ export async function publishDraftToOriginal(
           : "Database Error: Failed to publish draft.",
       slug: null,
     };
+  } finally {
+    if (dbWritesStarted) {
+      revalidateTag(CACHE_TAGS.authors);
+      revalidateTag(CACHE_TAGS.droplets);
+      revalidateTag(CACHE_TAGS.lesson);
+      revalidateTag(CACHE_TAGS.playlists);
+      revalidateTag(CACHE_TAGS.allEnrollments);
+    }
   }
 }
 
@@ -1305,16 +1306,8 @@ export async function favoriteDroplet(
       throw new Error("Failed to update favorite status");
     }
 
-    revalidateTag("dashboard");
-    revalidateTag("droplets");
-    revalidatePath("/");
-    revalidatePath("/dashboard");
-    revalidatePath("/dashboard/favorited");
-    revalidatePath(`/d/${droplet.slug}`);
-    revalidatePath("/dashboard", "page");
-    revalidatePath("/", "page");
-    revalidateTag("enrollments");
-    revalidateTag("droplets");
+    revalidateTag(CACHE_TAGS.droplets);
+    revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
     return { success: true };
   } catch (error) {
     console.error("Error updating favorite status:", error);
@@ -1369,7 +1362,7 @@ export async function updateDropletLearningObjective(
       throw new Error("Failed to update learning objective");
     }
 
-    revalidateTag("droplets");
+    revalidateTag(CACHE_TAGS.droplets);
     return { success: true };
   } catch (error) {
     console.error("Error updating learning objective:", error);

--- a/frontend/lib/requests/enrollment.ts
+++ b/frontend/lib/requests/enrollment.ts
@@ -7,10 +7,11 @@ import { ENROLLMENT_POPULATES } from "./enrollment-populates";
 
 import { getCurrentUser } from "@/lib/auth/session";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { Droplet } from "@/types";
 import { DropletEnrollmentSchema } from "../validations/enrollment";
 import { z } from "zod";
+import { CACHE_TAGS } from "../cache-tags";
 
 const STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -53,7 +54,13 @@ export async function getEnrollmentsByAuthorizedUser(
   };
   return await fetchAPI<Enrollment[]>(path, {
     urlParams,
-    next: { tags: ["enrollments"], revalidate: 0 },
+    next: {
+      tags: [
+        CACHE_TAGS.enrollments(authorizedUserId),
+        CACHE_TAGS.allEnrollments,
+      ],
+      revalidate: 900,
+    },
   });
 }
 
@@ -94,7 +101,13 @@ export async function getEnrollmentsForGroupMembers(
 
     const enrollmentsPage = await fetchAPI<Enrollment[]>(path, {
       urlParams,
-      next: { tags: ["enrollments"], revalidate: 0 },
+      next: {
+        tags: [
+          ...memberIds.map((id) => CACHE_TAGS.enrollments(id)),
+          CACHE_TAGS.allEnrollments,
+        ],
+        revalidate: 900,
+      },
     });
 
     if (!enrollmentsPage || enrollmentsPage.length === 0) break;
@@ -115,6 +128,29 @@ export async function getEnrollmentsForGroupMembers(
  * @param options Strapi query modifiers.
  * @returns `true` if the authorized user is already enrolled in the Droplet, else `false`.
  */
+/**
+ * Fetches a single enrollment for a specific user and droplet.
+ * Returns null if no enrollment exists.
+ */
+export async function getEnrollmentByUserAndDroplet(
+  authorizedUserId: number,
+  dropletId: number,
+): Promise<Enrollment | null> {
+  return fetchAPI<Enrollment[]>("/enrollments", {
+    urlParams: {
+      filters: {
+        $and: [
+          { authorizedUser: { id: { $eq: authorizedUserId } } },
+          { droplet: { id: { $eq: dropletId } } },
+        ],
+      },
+      fields: ["id", "isComplete", "isArchived"],
+      populate: { viewedLessons: { fields: ["id"] } },
+      pagination: { pageSize: 1, page: 1 },
+    },
+  }).then((enrollments) => enrollments[0] || null);
+}
+
 export async function getIsEnrolled(
   authorizedUserId: number,
   dropletId: number,
@@ -208,8 +244,8 @@ export async function changeEnrollmentRating(
       throw new Error("Failed to update enrollment");
     }
 
-    revalidatePath("/p/[slug]", "page");
-    revalidatePath("/dashboard", "page");
+    const authorizedUser = await getAuthorizedUserByEmail(user.email);
+    revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
 
     return { success: true };
   } catch (error) {
@@ -368,6 +404,10 @@ export async function fetchEnrollmentMetadata({
 
 export async function updateEnrollmentFirstTime(enrollmentId: string) {
   try {
+    const user = await getCurrentUser();
+    if (!user?.email) throw new Error("User not authenticated");
+    const authorizedUser = await getAuthorizedUserByEmail(user.email);
+
     const response = await fetch(
       `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/api/enrollments/${enrollmentId}`,
       {
@@ -388,6 +428,7 @@ export async function updateEnrollmentFirstTime(enrollmentId: string) {
       throw new Error("Failed to update enrollment");
     }
 
+    revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
     return await response.json();
   } catch (error) {
     console.error("Error updating enrollment:", error);
@@ -401,14 +442,12 @@ export async function createEnrollmentFromEmail(
 ) {
   try {
     const authorizedUser = await getAuthorizedUserByEmail(email);
-    const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+    const existing = await getEnrollmentByUserAndDroplet(
+      authorizedUser.id,
+      formData.droplet,
+    );
 
-    if (
-      !enrollments
-        .filter((enrollment) => enrollment.droplet != null)
-        .map((enrollment) => enrollment.droplet.id)
-        .includes(formData.droplet)
-    ) {
+    if (!existing) {
       const response = await fetch(STRAPI_API_URL + "/api/enrollments", {
         method: "POST",
         body: JSON.stringify({
@@ -426,6 +465,8 @@ export async function createEnrollmentFromEmail(
         const errorMessage = `${data.error.message} (${errorPath})`;
         return { ok: false, error: errorMessage, data: null };
       }
+
+      revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
     }
   } catch (err) {
     console.error(err);
@@ -440,15 +481,14 @@ export async function deleteEnrollment(
     const user = await getCurrentUser();
     if (!user?.email) throw new Error("No email identified");
     const authorizedUser = await getAuthorizedUserByEmail(user.email);
-    const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+    const enrollment = await getEnrollmentByUserAndDroplet(
+      authorizedUser.id,
+      formData.droplet,
+    );
 
-    const toRemove = enrollments
-      .filter((e) => e.droplet != null)
-      .filter((e) => e.droplet.id === formData.droplet);
-
-    if (toRemove.length > 0) {
+    if (enrollment) {
       const response = await fetch(
-        STRAPI_API_URL + "/api/enrollments/" + toRemove[0].id,
+        STRAPI_API_URL + "/api/enrollments/" + enrollment.id,
         {
           method: "DELETE",
           headers: {
@@ -465,9 +505,7 @@ export async function deleteEnrollment(
         return { ok: false, error: errorMessage, data: null };
       }
 
-      revalidateTag("enrollments");
-      revalidatePath("/(droplets)/d/[slug]", "page");
-      revalidatePath("/(general)/dashboard", "page");
+      revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
     }
   } catch (err) {
     console.error(err);
@@ -483,14 +521,12 @@ export async function createEnrollment(
     const user = await getCurrentUser();
     if (!user?.email) throw new Error("No email identified");
     const authorizedUser = await getAuthorizedUserByEmail(user.email);
-    const enrollments = await getEnrollmentsByAuthorizedUser(authorizedUser.id);
+    const existing = await getEnrollmentByUserAndDroplet(
+      authorizedUser.id,
+      droplet.id,
+    );
 
-    if (
-      !enrollments
-        .filter((enrollment) => enrollment.droplet != null)
-        .map((enrollment) => enrollment.droplet.id)
-        .includes(droplet.id)
-    ) {
+    if (!existing) {
       const response = await fetch(STRAPI_API_URL + "/api/enrollments", {
         method: "POST",
         body: JSON.stringify({
@@ -512,17 +548,7 @@ export async function createEnrollment(
         const errorMessage = `${data.error.message} (${errorPath})`;
         return { ok: false, error: errorMessage, data: null };
       }
-      revalidateTag("enrollments");
-      revalidatePath("/(droplets)/d/[slug]", "page");
-      revalidatePath("/(droplets)/d/[slug]/[lessonSlug]", "page");
-      revalidatePath("/(general)/dashboard", "page");
-      revalidatePath(`/(droplets)/d/${droplet.slug}`, "page");
-      if (droplet.lessons) {
-        revalidatePath(
-          `/(droplets)/d/${droplet.slug}/${droplet.lessons[0].slug}`,
-          "page",
-        );
-      }
+      revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
       return { ok: true, error: null, data: data.data };
     }
     return { ok: true };
@@ -543,6 +569,7 @@ export async function updateViewedLessons(
     if (!user?.email) {
       throw new Error("User not authenticated");
     }
+    const authorizedUser = await getAuthorizedUserByEmail(user.email);
 
     // Get current enrollment to check current viewedLessons
     const enrollment = await getEnrollByID(enrollmentId, {
@@ -605,6 +632,9 @@ export async function updateViewedLessons(
       );
     }
     const alreadyViewed = currentViewedIds.includes(lessonId);
+    if (!alreadyViewed || (isNowComplete && !enrollment.isComplete)) {
+      revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
+    }
     return { success: true, alreadyViewed };
   } catch (error) {
     console.error("Error updating viewed lessons:", error);
@@ -619,6 +649,7 @@ export async function updateCompletionDate(enrollmentID: string) {
     if (!user?.email) {
       throw new Error("User not authenticated");
     }
+    const authorizedUser = await getAuthorizedUserByEmail(user.email);
 
     const response = await fetch(
       `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/api/enrollments/${enrollmentID}`,
@@ -641,6 +672,7 @@ export async function updateCompletionDate(enrollmentID: string) {
       throw new Error("Failed to update completion date");
     }
 
+    revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
     return { success: true };
   } catch (error) {
     console.error("Error in adding completion date: ", error);

--- a/frontend/lib/requests/feed.ts
+++ b/frontend/lib/requests/feed.ts
@@ -1,85 +1,119 @@
 "use server";
 
-import { Announcement, AuthorizedUser, Droplet } from "@/types";
+import { Announcement, AuthorizedUser, Droplet, Friendship } from "@/types";
 import qs from "qs";
-import { flattenAttributes } from "../utils";
-import { revalidatePath } from "next/cache";
+import { flattenAttributes, fetchAPI } from "../utils";
+import { revalidateTag } from "next/cache";
+import { CACHE_TAGS } from "../cache-tags";
 
 const NEXT_PUBLIC_STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
 
+/**
+ * Pre-computes the IDs needed for the feed query using fast, minimal queries
+ * run in parallel, then queries announcements with simple $in filters
+ * instead of deep nested relation joins.
+ */
 export async function fetchAnnouncements(
   user: AuthorizedUser,
   page?: number,
 ): Promise<Announcement[]> {
   try {
+    // Extract friend IDs from the user's friendships (already populated on authUser)
+    const friendIds = (user.friendships || [])
+      .flatMap((f: Friendship) =>
+        (f.authorized_users || [])
+          .filter((u) => u.id !== user.id)
+          .map((u) => u.id),
+      )
+      .filter((id, i, arr) => arr.indexOf(id) === i);
+
+    // Fetch group IDs, playlist IDs, and enrolled droplet IDs in parallel
+    const [groupIds, playlistIds, enrolledDropletIds] = await Promise.all([
+      fetchAPI<{ id: number }[]>("/groups", {
+        urlParams: {
+          filters: {
+            $or: [
+              { creator: { id: { $eq: user.id } } },
+              { admins: { id: { $eq: user.id } } },
+              { managers: { id: { $eq: user.id } } },
+              { members: { id: { $eq: user.id } } },
+            ],
+          },
+          fields: ["id"],
+          pagination: { pageSize: 250, page: 1 },
+        },
+        next: { tags: [CACHE_TAGS.allGroups], revalidate: 900 },
+      }).then((groups) => groups.map((g) => g.id)),
+      fetchAPI<{ id: number }[]>("/playlists", {
+        urlParams: {
+          filters: {
+            authorized_users: { id: { $eq: user.id } },
+          },
+          fields: ["id"],
+          pagination: { pageSize: 250, page: 1 },
+        },
+        next: { tags: [CACHE_TAGS.playlists], revalidate: 900 },
+      }).then((playlists) => playlists.map((p) => p.id)),
+      fetchAPI<{ id: number; droplet?: { id: number } }[]>("/enrollments", {
+        urlParams: {
+          filters: {
+            authorizedUser: { id: { $eq: user.id } },
+          },
+          fields: ["id"],
+          populate: { droplet: { fields: ["id"] } },
+          pagination: { pageSize: 250, page: 1 },
+        },
+        next: {
+          tags: [CACHE_TAGS.enrollments(user.id), CACHE_TAGS.allEnrollments],
+          revalidate: 900,
+        },
+      }).then((enrollments) =>
+        enrollments
+          .map((e) => e.droplet?.id)
+          .filter((id): id is number => id != null),
+      ),
+    ]);
+
+    // Build the query with simple $in filters instead of nested relation joins
+    const orFilters: any[] = [];
+
+    if (groupIds.length > 0) {
+      orFilters.push({ group: { id: { $in: groupIds } } });
+    }
+    if (playlistIds.length > 0) {
+      orFilters.push({ playlist: { id: { $in: playlistIds } } });
+    }
+    if (friendIds.length > 0) {
+      orFilters.push({
+        type: "friend",
+        authorized_user: { id: { $in: friendIds } },
+      });
+      orFilters.push({
+        type: "kudos",
+        authorized_user: { id: { $in: friendIds } },
+      });
+    }
+    if (enrolledDropletIds.length > 0) {
+      orFilters.push({
+        type: "droplet",
+        droplet: { id: { $in: enrolledDropletIds } },
+      });
+    }
+    // System announcements: global (no user) or targeted at this user
+    orFilters.push({
+      type: "system",
+      $or: [
+        { authorized_user: { id: { $null: true } } },
+        { authorized_user: { id: { $eq: user.id } } },
+      ],
+    });
+
     const query = qs.stringify({
       sort: ["firstCreated:desc"],
       fields: ["id", "type", "content", "firstCreated"],
       filters: {
-        $or: [
-          {
-            group: {
-              members: {
-                id: { $eq: user.id },
-              },
-            },
-          },
-          {
-            playlist: {
-              authorized_users: {
-                id: { $eq: user.id },
-              },
-            },
-          },
-          {
-            type: "friend",
-            authorized_user: {
-              friendships: {
-                authorized_users: {
-                  id: { $eq: user.id },
-                },
-              },
-              id: { $ne: user.id },
-            },
-          },
-          {
-            type: "kudos",
-            authorized_user: {
-              friendships: {
-                authorized_users: {
-                  id: { $eq: user.id },
-                },
-              },
-              id: { $ne: user.id },
-            },
-          },
-          {
-            type: "droplet",
-            droplet: {
-              enrollments: {
-                authorizedUser: {
-                  id: { $eq: user.id },
-                },
-              },
-            },
-          },
-          {
-            type: "system",
-            $or: [
-              {
-                authorized_user: {
-                  id: { $null: true },
-                },
-              },
-              {
-                authorized_user: {
-                  id: { $eq: user.id },
-                },
-              },
-            ],
-          },
-        ],
+        $or: orFilters,
       },
       populate: {
         authorized_user: {
@@ -96,12 +130,8 @@ export async function fetchAnnouncements(
             "website",
           ],
           populate: {
-            blocked: {
-              fields: ["id"],
-            },
-            was_blocked: {
-              fields: ["id"],
-            },
+            blocked: { fields: ["id"] },
+            was_blocked: { fields: ["id"] },
           },
         },
         kudosGiven: {
@@ -117,12 +147,8 @@ export async function fetchAnnouncements(
             "website",
           ],
           populate: {
-            blocked: {
-              fields: ["id"],
-            },
-            was_blocked: {
-              fields: ["id"],
-            },
+            blocked: { fields: ["id"] },
+            was_blocked: { fields: ["id"] },
           },
         },
         playlist: {
@@ -155,7 +181,7 @@ export async function fetchAnnouncements(
       NEXT_PUBLIC_STRAPI_API_URL + "/api/announcements?" + query,
       {
         headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-        cache: "no-store",
+        next: { tags: [CACHE_TAGS.announcements], revalidate: 900 },
       },
     );
     const data = await response.json();
@@ -197,7 +223,7 @@ export async function createFriendAnnouncement(
       throw new Error("Failed to create announcement");
     }
 
-    revalidatePath("/feed");
+    revalidateTag(CACHE_TAGS.announcements);
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -263,7 +289,7 @@ export async function createKudosAnnouncement(
       throw new Error("Failed to create announcement");
     }
 
-    revalidatePath("/feed");
+    revalidateTag(CACHE_TAGS.announcements);
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -301,7 +327,7 @@ export async function createPlaylistAnnouncement(
       throw new Error("Failed to create announcement");
     }
 
-    revalidatePath("/feed");
+    revalidateTag(CACHE_TAGS.announcements);
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -336,7 +362,7 @@ export async function createGroupAnnouncement(groupName: string, id: number) {
       throw new Error("Failed to create announcement");
     }
 
-    revalidatePath("/feed");
+    revalidateTag(CACHE_TAGS.announcements);
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -371,7 +397,7 @@ export async function createDropletAnnouncement(name: string, id: number) {
       throw new Error("Failed to create announcement");
     }
 
-    revalidatePath("/feed");
+    revalidateTag(CACHE_TAGS.announcements);
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -409,7 +435,7 @@ export async function createSystemAnnouncement(
       throw new Error("Failed to create announcement");
     }
 
-    revalidatePath("/feed");
+    revalidateTag(CACHE_TAGS.announcements);
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -476,7 +502,7 @@ export async function fetchAnnouncementById(id: number) {
       NEXT_PUBLIC_STRAPI_API_URL + "/api/announcements?" + query,
       {
         headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-        cache: "no-store",
+        next: { tags: [CACHE_TAGS.announcements], revalidate: 900 },
       },
     );
     const data = await response.json();
@@ -527,7 +553,7 @@ export async function fetchUserAnnouncements(
       NEXT_PUBLIC_STRAPI_API_URL + "/api/announcements?" + query,
       {
         headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-        cache: "no-store",
+        next: { tags: [CACHE_TAGS.announcements], revalidate: 900 },
       },
     );
     const data = await response.json();

--- a/frontend/lib/requests/friends.ts
+++ b/frontend/lib/requests/friends.ts
@@ -1,7 +1,8 @@
 "use server";
 import { flattenAttributes } from "@/lib/utils";
 import { AuthorizedUser, Friendship } from "@/types";
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
+import { CACHE_TAGS } from "../cache-tags";
 import qs from "qs";
 
 const NEXT_PUBLIC_STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
@@ -58,7 +59,10 @@ export async function fetchFriends(
         NEXT_PUBLIC_STRAPI_API_URL + "/api/friendships?" + query,
         {
           headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-          cache: "no-store",
+          next: {
+            tags: [CACHE_TAGS.friendships(authorizedUser.id)],
+            revalidate: 900,
+          },
         },
       );
       const data = await response.json();
@@ -122,7 +126,10 @@ export async function getSentRequestIds(
         NEXT_PUBLIC_STRAPI_API_URL + "/api/authorized-users?" + query,
         {
           headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-          cache: "no-store",
+          next: {
+            tags: [CACHE_TAGS.friendships(requester.id)],
+            revalidate: 900,
+          },
         },
       );
       const data = await response.json();
@@ -186,7 +193,8 @@ export async function acceptFriendRequest(userId: number, requestId: number) {
       console.error("Delete Response:", await deleteResponse.text());
       throw new Error("Failed to delete friend request");
     }
-    revalidatePath("/settings/friends");
+    revalidateTag(CACHE_TAGS.friendships(userId));
+    revalidateTag(CACHE_TAGS.friendships(requestId));
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -246,7 +254,8 @@ export async function sendFriendRequest(
       throw new Error("Failed to add to sent requests");
     }
 
-    revalidatePath("/settings/friends");
+    revalidateTag(CACHE_TAGS.friendships(requester.id));
+    revalidateTag(CACHE_TAGS.friendships(requestee.id));
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -279,7 +288,8 @@ export async function rejectFriendRequest(userId: number, requestId: number) {
       throw new Error("Failed to delete friend request");
     }
 
-    revalidatePath("/settings/friends");
+    revalidateTag(CACHE_TAGS.friendships(userId));
+    revalidateTag(CACHE_TAGS.friendships(requestId));
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -311,7 +321,8 @@ export async function cancelFriendRequest(userId: number, requestId: number) {
       console.error("Delete Response:", await deleteResponse.text());
       throw new Error("Failed to delete friend request");
     }
-    revalidatePath("/settings/friends");
+    revalidateTag(CACHE_TAGS.friendships(userId));
+    revalidateTag(CACHE_TAGS.friendships(requestId));
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -343,7 +354,8 @@ export async function unblockUser(userId: number, requestId: number) {
       console.error("Delete Response:", await deleteResponse.text());
       throw new Error("Failed to unblock user");
     }
-    revalidatePath("/settings/friends");
+    revalidateTag(CACHE_TAGS.friendships(userId));
+    revalidateTag(CACHE_TAGS.friendships(requestId));
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -375,7 +387,8 @@ export async function BlockUser(userId: number, requestId: number) {
       console.error("Delete Response:", await deleteResponse.text());
       throw new Error("Failed to block user");
     }
-    revalidatePath("/settings/friends");
+    revalidateTag(CACHE_TAGS.friendships(userId));
+    revalidateTag(CACHE_TAGS.friendships(requestId));
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -439,7 +452,8 @@ export async function removeFriend(userId: number, friendId: number) {
       console.error("Delete Response:", await deleteResponse.text());
       throw new Error("Failed to delete friendship");
     }
-    revalidatePath("/settings/friends");
+    revalidateTag(CACHE_TAGS.friendships(userId));
+    revalidateTag(CACHE_TAGS.friendships(friendId));
     return { success: true };
   } catch (error) {
     console.error("Error:", error);
@@ -496,7 +510,7 @@ export async function fetchFriendshipsById(
       NEXT_PUBLIC_STRAPI_API_URL + "/api/friendships?" + query,
       {
         headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-        cache: "no-store",
+        next: { tags: [CACHE_TAGS.friendships(userId)], revalidate: 900 },
       },
     );
     const data = await response.json();
@@ -555,7 +569,10 @@ export async function fetchFriendshipsByUserIds(
       NEXT_PUBLIC_STRAPI_API_URL + "/api/friendships?" + query,
       {
         headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-        cache: "no-store",
+        next: {
+          tags: userIds.map((id) => CACHE_TAGS.friendships(id)),
+          revalidate: 900,
+        },
       },
     );
     const data = await response.json();

--- a/frontend/lib/requests/galleries.ts
+++ b/frontend/lib/requests/galleries.ts
@@ -3,7 +3,6 @@
 import { Gallery } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
 import { fetchAPI } from "../utils";
-
 /**
  * Returns the Gallery object with the given slug
  * @param slug the slug of the Gallery
@@ -15,7 +14,13 @@ export async function getGalleryBySlug(
     sort,
     pagination = { pageSize: 250, page: 1 },
     populate = {
-      items: { populate: "*" },
+      items: {
+        populate: {
+          media: {
+            fields: ["id", "url", "alternativeText", "width", "height"],
+          },
+        },
+      },
     },
     fields = ["id", "slug", "title", "subtitle"],
   }: StrapiRequestParams = {},
@@ -33,8 +38,7 @@ export async function getGalleryBySlug(
 
   const galleries = await fetchAPI<Gallery[]>(path, {
     urlParams,
-    next: { tags: ["galleries"] },
-    cache: "no-store",
+    next: { revalidate: 3600 },
   });
 
   return galleries.length > 0 ? galleries[0] : undefined;

--- a/frontend/lib/requests/groups.ts
+++ b/frontend/lib/requests/groups.ts
@@ -9,10 +9,11 @@ import {
   createAuthorizedUser,
 } from "./authorized-user";
 import type { Droplet, DueDate, Playlist } from "@/types";
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { enrollInPlaylist } from "./playlist-enrollment";
 import { getCurrentUser } from "../auth/session";
 import { createEnrollmentFromEmail } from "./enrollment";
+import { CACHE_TAGS } from "../cache-tags";
 
 const STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -64,7 +65,7 @@ export async function getManagedGroups(
 
   return await fetchAPI<Group[]>(path, {
     urlParams,
-    cache: "no-store",
+    next: { tags: [CACHE_TAGS.allGroups], revalidate: 900 },
   });
 }
 
@@ -114,7 +115,7 @@ export async function getGroupBySlug(
 
   return await fetchAPI<Group[]>(path, {
     urlParams,
-    cache: "no-store",
+    next: { tags: [CACHE_TAGS.allGroups], revalidate: 900 },
   }).then((groups) => groups[0] || null);
 }
 
@@ -171,12 +172,9 @@ export async function getGroupByID(
     },
   };
 
-  revalidatePath("/dashboard");
-  revalidatePath("/explore");
-
   return await fetchAPI<Group[]>(path, {
     urlParams,
-    cache: "no-store",
+    next: { tags: [CACHE_TAGS.allGroups], revalidate: 900 },
   }).then((groups) => groups[0]);
 }
 
@@ -203,10 +201,10 @@ export async function getUserGroups(
         fields: ["id", "email"],
       },
       creator: {
-        fields: ["*"],
+        fields: ["id", "email", "firstName", "lastName"],
       },
       users_archived: {
-        fields: ["*"],
+        fields: ["id"],
       },
     },
     fields = ["id", "groupName", "slug", "semester", "isArchived"],
@@ -231,7 +229,7 @@ export async function getUserGroups(
 
   return await fetchAPI<Group[]>(path, {
     urlParams,
-    cache: "no-store",
+    next: { tags: [CACHE_TAGS.allGroups], revalidate: 900 },
   });
 }
 
@@ -263,12 +261,14 @@ export async function updateGroupMembers(
     data[disconnect.role] = { disconnect: disconnect.userIds };
   }
 
-  return await fetchAPI<Group>(path, {
+  const result = await fetchAPI<Group>(path, {
     options: {
       method: "PUT",
       body: JSON.stringify({ data }),
     },
   });
+  revalidateTag(CACHE_TAGS.allGroups);
+  return result;
 }
 
 /**
@@ -379,14 +379,15 @@ export async function createGroup(
       playlists: { connect: playlists.map((id) => ({ id })) },
     }),
   };
-  revalidatePath("/g/dashboard");
-  revalidatePath("/g/dashboard?tab=creator");
-  return await fetchAPI<Group>(path, {
+  const result = await fetchAPI<Group>(path, {
     options: {
       method: "POST",
       body: JSON.stringify({ data: createData }),
     },
   });
+  revalidateTag(CACHE_TAGS.allGroups);
+
+  return result;
 }
 
 export async function getGroupBySlugV2(
@@ -447,7 +448,7 @@ export async function getGroupBySlugV2(
 
   const groups = await fetchAPI<Group[]>(path, {
     urlParams,
-    cache: "no-store",
+    next: { tags: [CACHE_TAGS.allGroups], revalidate: 900 },
   });
 
   return groups[0] || null;
@@ -542,14 +543,16 @@ export async function updateGroup(
     };
   }
 
-  revalidatePath("/admin");
-
-  return await fetchAPI<Group>(path, {
+  const result = await fetchAPI<Group>(path, {
     options: {
       method: "PUT",
       body: JSON.stringify({ data: dataToSend }),
     },
   });
+
+  revalidateTag(CACHE_TAGS.allGroups);
+
+  return result;
 }
 
 async function ensureAuthorizedUsers(
@@ -589,45 +592,54 @@ async function ensureAuthorizedUsers(
 
 export async function enrollUsers(group: Group) {
   try {
-    group.members?.map(async (member) => {
-      group.droplets?.map(async (droplet) => {
-        try {
-          const enrollmentData = {
-            droplet: droplet.id,
-            viewedLessons: [],
-          };
-          return await createEnrollmentFromEmail(enrollmentData, member.email);
-        } catch (error) {
-          console.error(
-            `Error enrolling this user in droplet [${droplet.name || droplet.id}]: `,
-            error,
-          );
-        }
-        //return await createEnrollment(enrollmentData);
-      }) || [];
+    await Promise.all(
+      group.members?.map(async (member) => {
+        await Promise.all(
+          group.droplets?.map(async (droplet) => {
+            try {
+              const enrollmentData = {
+                droplet: droplet.id,
+                viewedLessons: [],
+              };
+              return await createEnrollmentFromEmail(
+                enrollmentData,
+                member.email,
+              );
+            } catch (error) {
+              console.error(
+                `Error enrolling this user in droplet [${droplet.name || droplet.id}]: `,
+                error,
+              );
+            }
+          }) || [],
+        );
 
-      group.playlists?.map(async (playlist) => {
-        await enrollInPlaylist(playlist.id, member.id);
-        playlist.droplets?.map(async (droplet) => {
-          try {
-            const enrollmentData = {
-              droplet: droplet.id,
-              viewedLessons: [],
-            };
-            return await createEnrollmentFromEmail(
-              enrollmentData,
-              member.email,
+        await Promise.all(
+          group.playlists?.map(async (playlist) => {
+            await enrollInPlaylist(playlist.id, member.id);
+            await Promise.all(
+              playlist.droplets?.map(async (droplet) => {
+                try {
+                  const enrollmentData = {
+                    droplet: droplet.id,
+                    viewedLessons: [],
+                  };
+                  return await createEnrollmentFromEmail(
+                    enrollmentData,
+                    member.email,
+                  );
+                } catch (error) {
+                  console.error(
+                    `Error enrolling this user in playlist [${playlist.name || playlist.id}] droplet [${droplet.name || droplet.id}]: `,
+                    error,
+                  );
+                }
+              }) || [],
             );
-          } catch (error) {
-            console.error(
-              `Error enrolling this user in playlist [${playlist.name || playlist.id}] droplet [${droplet.name || droplet.id}]: `,
-              error,
-            );
-          }
-          //return await createEnrollment(enrollmentData);
-        }) || [];
-      }) || [];
-    }) || [];
+          }) || [],
+        );
+      }) || [],
+    );
   } catch (error) {
     console.error("Error enrolling users:", error);
     throw error;
@@ -714,7 +726,13 @@ export async function assignDropletDueDate(
 
     const results = await Promise.all(dueDatePromises);
 
+    const anySuccessful = results.some((result) => result === true);
     const allSuccessful = results.every((result) => result === true);
+
+    // Revalidate if ANY writes succeeded, even if some failed
+    if (anySuccessful) {
+      revalidateTag(CACHE_TAGS.allDueDates);
+    }
 
     if (!allSuccessful) {
       return {
@@ -722,11 +740,6 @@ export async function assignDropletDueDate(
         error: "Failed to process due dates for some users",
       };
     }
-
-    revalidatePath("/explore");
-    revalidatePath("/dashboard");
-    revalidatePath("/groups/g/[slug]", "page");
-    revalidatePath("/");
 
     return { success: true };
   } catch (error) {
@@ -814,7 +827,13 @@ export async function assignPlaylistDueDate(
 
     const results = await Promise.all(dueDatePromises);
 
+    const anySuccessful = results.some((result) => result === true);
     const allSuccessful = results.every((result) => result === true);
+
+    // Revalidate if ANY writes succeeded, even if some failed
+    if (anySuccessful) {
+      revalidateTag(CACHE_TAGS.allDueDates);
+    }
 
     if (!allSuccessful) {
       return {
@@ -822,11 +841,6 @@ export async function assignPlaylistDueDate(
         error: "Failed to process due dates for some users",
       };
     }
-
-    revalidatePath("/explore");
-    revalidatePath("/dashboard");
-    revalidatePath("/groups/g/[slug]", "page");
-    revalidatePath("/");
 
     return { success: true };
   } catch (error) {
@@ -890,7 +904,7 @@ export async function getGroupDueDates(
 
   return await fetchAPI<DueDate[]>(path, {
     urlParams,
-    cache: "no-store",
+    next: { tags: [CACHE_TAGS.allDueDates], revalidate: 900 },
   });
 }
 
@@ -924,7 +938,7 @@ export async function getUserDueDates(
 
   return await fetchAPI<DueDate[]>(path, {
     urlParams,
-    cache: "no-store",
+    next: { tags: [CACHE_TAGS.allDueDates], revalidate: 900 },
   });
 }
 
@@ -946,9 +960,8 @@ export async function deleteGroup(id: number) {
       return { ok: false, error: "Failed to delete group.", data: null };
     }
 
-    revalidateTag("authors");
-    revalidateTag("groups");
-    revalidatePath("(general)/my-content", "page");
+    revalidateTag(CACHE_TAGS.authors);
+    revalidateTag(CACHE_TAGS.allGroups);
     return { ok: true, error: null, data: data.data };
   } catch (err) {
     console.error(err);
@@ -987,11 +1000,7 @@ export async function archiveGroup(group: Group, archiveState: boolean) {
       throw new Error("Failed to archive group");
     }
 
-    revalidateTag("dashboard");
-    revalidatePath("/");
-    revalidatePath("/draft");
-    revalidatePath("/dashboard");
-    revalidatePath("/dashboard/archived");
+    revalidateTag(CACHE_TAGS.allGroups);
     return { success: true };
   } catch (error) {
     console.error("Error archiving group:", error);

--- a/frontend/lib/requests/highlights.ts
+++ b/frontend/lib/requests/highlights.ts
@@ -3,6 +3,8 @@
 import { Highlight } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
 import { fetchAPI } from "../utils";
+import { CACHE_TAGS } from "../cache-tags";
+import { revalidateTag } from "next/cache";
 import { getCurrentUser } from "../auth/session";
 import { getAuthorizedUserByEmail } from "./authorized-user";
 
@@ -38,7 +40,7 @@ export async function getHighlights(
 
   return await fetchAPI<Highlight[]>(path, {
     urlParams,
-    next: { tags: ["highlights"] },
+    next: { tags: [CACHE_TAGS.highlights(authorizedUserId)] },
   });
 }
 
@@ -75,11 +77,11 @@ export async function getHighlightsByDroplet(
 
   return await fetchAPI<Highlight[]>(path, {
     urlParams,
-    next: { tags: ["highlights"] },
+    next: { tags: [CACHE_TAGS.highlights(authUser)] },
   });
 }
 
-export async function deleteHighlight(id: number) {
+export async function deleteHighlight(id: number, authorizedUserId: number) {
   const response = await fetch(`${STRAPI_API_URL}/api/highlights/${id}`, {
     method: "DELETE",
     headers: {
@@ -91,6 +93,7 @@ export async function deleteHighlight(id: number) {
   if (!response.ok) {
     throw new Error("Failed to delete highlight");
   }
+  revalidateTag(CACHE_TAGS.highlights(authorizedUserId));
   return response.json();
 }
 
@@ -104,6 +107,10 @@ export async function getHighlightsForLesson(lessonId: number) {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}`,
+      },
+      next: {
+        tags: [CACHE_TAGS.highlights(authorizedUser.id)],
+        revalidate: 900,
       },
     },
   );
@@ -123,5 +130,6 @@ export async function createHighlight(highlightData: any) {
   if (!response.ok) {
     throw new Error("Failed to create highlight");
   }
+  revalidateTag(CACHE_TAGS.highlights(highlightData.data.authorized_user));
   return response.json();
 }

--- a/frontend/lib/requests/lesson.ts
+++ b/frontend/lib/requests/lesson.ts
@@ -2,9 +2,12 @@
 import { Lesson } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
 import { fetchAPI, stripHtmlTags } from "../utils";
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { z } from "zod";
 import { LessonSchema } from "../validations/lesson";
+import { CACHE_TAGS } from "@/lib/cache-tags";
+import { getCurrentUser } from "@/lib/auth/session";
+import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
 
 const NEXT_PUBLIC_STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -41,7 +44,7 @@ export async function getLessonBySlug<T extends Partial<Lesson> = Lesson>(
 
   return await fetchAPI<T[]>(path, {
     urlParams,
-    cache: "no-store",
+    next: { tags: [CACHE_TAGS.droplets], revalidate: 900 },
   }).then((lessons) => lessons[0]);
 }
 
@@ -51,6 +54,10 @@ export async function markLessonAsComplete(
   lessonId: number,
 ) {
   try {
+    const user = await getCurrentUser();
+    if (!user?.email) throw new Error("User not authenticated");
+    const authorizedUser = await getAuthorizedUserByEmail(user.email);
+
     const response = await fetch(
       `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/api/enrollments/${enrollmentId}`,
       {
@@ -74,10 +81,7 @@ export async function markLessonAsComplete(
       throw new Error("Failed to mark lesson as complete");
     }
 
-    revalidatePath("/", "layout");
-    revalidatePath("/dashboard");
-    revalidatePath("/(droplets)/d/[slug]/[lessonSlug]", "page");
-    revalidatePath("/(playlists)/p/[slug]", "page");
+    revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
 
     return true;
   } catch (error) {
@@ -88,6 +92,10 @@ export async function markLessonAsComplete(
 
 export async function completeLesson(activityId: number, lessonIds: number[]) {
   try {
+    const user = await getCurrentUser();
+    if (!user?.email) throw new Error("User not authenticated");
+    const authorizedUser = await getAuthorizedUserByEmail(user.email);
+
     const response = await fetch(
       NEXT_PUBLIC_STRAPI_API_URL +
         `/api/authorized-user-activities/${activityId}`,
@@ -109,7 +117,7 @@ export async function completeLesson(activityId: number, lessonIds: number[]) {
       throw new Error("Failed to complete lesson");
     }
 
-    revalidatePath("/(droplets)/d/[slug]/[lessonSlug]");
+    revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
     return { success: true };
   } catch (error) {
     console.error("Error completing lesson:", error);
@@ -134,7 +142,8 @@ export async function deleteLesson(id: number, revalidate: boolean = true) {
       return { ok: false, error: data.error.message, data: null };
 
     if (revalidate) {
-      revalidateTag("droplets");
+      revalidateTag(CACHE_TAGS.droplets);
+      revalidateTag(CACHE_TAGS.allEnrollments);
     }
 
     return { ok: true, error: null, data: data.data };
@@ -185,13 +194,8 @@ export async function updateLesson(
       return { ok: false, error: errorMessage, data: null };
     }
 
-    if (options.reload) {
-      revalidatePath("(editing)/draft/d/[slug]/[lessonSlug]", "page");
-    }
-
-    if (data.name) {
-      revalidateTag("droplets");
-    }
+    revalidateTag(CACHE_TAGS.droplets);
+    revalidateTag(CACHE_TAGS.lesson);
 
     return { ok: true, error: null, data: responseData.data };
   } catch (err) {
@@ -205,8 +209,7 @@ export async function updateLesson(
 }
 
 export async function revalidateLesson() {
-  revalidateTag("lesson");
-  revalidatePath("(editing)/draft/d/[slug]/[lessonSlug]", "page");
+  revalidateTag(CACHE_TAGS.lesson);
 }
 
 const CreateLessonSchema = LessonSchema.pick({
@@ -254,7 +257,9 @@ export async function addLesson(formData: z.infer<typeof CreateLessonSchema>) {
       return { ok: false, error: lessonResult.error?.message, data: null };
     }
 
-    revalidateTag("droplets");
+    revalidateTag(CACHE_TAGS.droplets);
+    revalidateTag(CACHE_TAGS.allEnrollments);
+
     return { ok: true, error: null, data: lessonResult.data };
   } catch (err) {
     console.error(err);
@@ -437,8 +442,8 @@ export async function duplicateLessonToDroplet(
 
     console.log("Created lesson successfully:", responseData.data.id);
 
-    revalidateTag("droplets");
-    revalidatePath("(editing)/draft/d/[slug]", "page");
+    revalidateTag(CACHE_TAGS.droplets);
+    revalidateTag(CACHE_TAGS.allEnrollments);
 
     return {
       ok: true,

--- a/frontend/lib/requests/notes.ts
+++ b/frontend/lib/requests/notes.ts
@@ -3,7 +3,8 @@
 import { Enrollment, Note, Lesson, Highlight } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
 import { fetchAPI } from "../utils";
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
+import { CACHE_TAGS } from "../cache-tags";
 
 const NEXT_PUBLIC_STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -46,7 +47,7 @@ export async function getNotesByAuthorizedUserAndLesson(
 
   return await fetchAPI<Note[]>(path, {
     urlParams,
-    next: { tags: ["notes"] },
+    next: { tags: [CACHE_TAGS.notes(authorizedUserId)] },
   });
 }
 
@@ -88,11 +89,15 @@ export async function getNotesByDroplet(
 
   return await fetchAPI<Note[]>(path, {
     urlParams,
-    next: { tags: ["notes"] },
+    next: { tags: [CACHE_TAGS.notes(authorizedUserId)] },
   });
 }
 
-export async function updateNoteContent(noteId: number, newContent: string) {
+export async function updateNoteContent(
+  noteId: number,
+  newContent: string,
+  authorizedUserId: number,
+) {
   try {
     const response = await fetch(
       `${NEXT_PUBLIC_STRAPI_API_URL}/api/notes/${noteId}`,
@@ -114,8 +119,7 @@ export async function updateNoteContent(noteId: number, newContent: string) {
       throw new Error("Failed to update note content");
     }
 
-    revalidatePath("/d/[slug]/[lessonSlug]", "page");
-    revalidateTag("notes");
+    revalidateTag(CACHE_TAGS.notes(authorizedUserId));
 
     return { success: true };
   } catch (error) {
@@ -124,7 +128,11 @@ export async function updateNoteContent(noteId: number, newContent: string) {
   }
 }
 
-export async function updateNotePosition(noteId: number, newPos: number) {
+export async function updateNotePosition(
+  noteId: number,
+  newPos: number,
+  authorizedUserId: number,
+) {
   try {
     const response = await fetch(
       `${NEXT_PUBLIC_STRAPI_API_URL}/api/notes/${noteId}`,
@@ -146,8 +154,7 @@ export async function updateNotePosition(noteId: number, newPos: number) {
       throw new Error("Failed to update note content");
     }
 
-    revalidatePath("/d/[slug]/[lessonSlug]", "page");
-    revalidateTag("notes");
+    revalidateTag(CACHE_TAGS.notes(authorizedUserId));
 
     return { success: true };
   } catch (error) {
@@ -160,6 +167,7 @@ export async function createNote(
   lesson: Lesson,
   enrollment: Enrollment,
   position: number,
+  authorizedUserId: number,
   highlight?: Highlight,
   content?: string,
 ) {
@@ -186,8 +194,7 @@ export async function createNote(
       return { success: false, error: "Failed to add new note" };
     }
 
-    revalidatePath("/d/[slug]/[lessonSlug]", "page");
-    revalidateTag("notes");
+    revalidateTag(CACHE_TAGS.notes(authorizedUserId));
     return { success: true };
   } catch (error) {
     console.error("Error adding note:", error);
@@ -195,7 +202,7 @@ export async function createNote(
   }
 }
 
-export async function deleteNote(id: number) {
+export async function deleteNote(id: number, authorizedUserId: number) {
   try {
     const response = await fetch(
       NEXT_PUBLIC_STRAPI_API_URL + "/api/notes/" + id,
@@ -211,8 +218,7 @@ export async function deleteNote(id: number) {
     if (!response.ok || (response.ok && data.error))
       return { ok: false, error: data.error.message, data: null };
 
-    revalidatePath("/d/[slug]/[lessonSlug]", "page");
-    revalidateTag("notes");
+    revalidateTag(CACHE_TAGS.notes(authorizedUserId));
 
     return { ok: true, error: null, data: data.data };
   } catch (err) {

--- a/frontend/lib/requests/playlist-enrollment.ts
+++ b/frontend/lib/requests/playlist-enrollment.ts
@@ -2,7 +2,8 @@
 
 import { getCurrentUser } from "@/lib/auth/session";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
+import { CACHE_TAGS } from "../cache-tags";
 
 const STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -52,8 +53,8 @@ export async function togglePlaylistEnrollment(playlistId: number) {
       throw new Error("Failed to update enrollment");
     }
 
-    revalidatePath("/p/[slug]", "page");
-    revalidatePath("/dashboard", "page");
+    revalidateTag(CACHE_TAGS.playlists);
+    revalidateTag(CACHE_TAGS.enrollments(authorizedUser.id));
 
     return { success: true };
   } catch (error) {
@@ -85,6 +86,8 @@ export async function enrollInPlaylist(playlistId: number, userId: number) {
     if (!response.ok) {
       throw new Error("Failed to update playlists");
     }
+    revalidateTag(CACHE_TAGS.playlists);
+    revalidateTag(CACHE_TAGS.enrollments(userId));
     return { success: true };
   } catch (error) {
     console.error("Error updating playlists:", error);

--- a/frontend/lib/requests/playlist.ts
+++ b/frontend/lib/requests/playlist.ts
@@ -4,9 +4,10 @@ import { Playlist } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
 import { fetchAPI, flattenAttributes } from "@/lib/utils";
 import qs from "qs";
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { getCurrentUser } from "../auth/session";
 import { getAuthorizedUserByEmail } from "./authorized-user";
+import { CACHE_TAGS } from "../cache-tags";
 
 const NEXT_PUBLIC_STRAPI_API_URL =
   process.env.NEXT_PUBLIC_STRAPI_API_URL || "http://localhost:1337";
@@ -48,7 +49,7 @@ export async function getPlaylists({
 
   return await fetchAPI<Playlist[]>(path, {
     urlParams,
-    cache: "no-store",
+    next: { tags: [CACHE_TAGS.playlists], revalidate: 900 },
   });
 }
 
@@ -72,7 +73,6 @@ export async function getPlaylistBySlug(
       },
       authors: {
         fields: ["id", "name"],
-        populate: "*",
       },
     },
   }: StrapiRequestParams = {},
@@ -93,7 +93,7 @@ export async function getPlaylistBySlug(
 
   const playlists = await fetchAPI<Playlist[]>(path, {
     urlParams,
-    cache: "no-store",
+    next: { tags: [CACHE_TAGS.playlists], revalidate: 900 },
   });
 
   return playlists[0] || null;
@@ -121,7 +121,7 @@ export async function getPlaylistById<T extends Partial<Playlist> = Playlist>(
       NEXT_PUBLIC_STRAPI_API_URL + "/api/playlists/" + id + "?" + query,
       {
         headers: { Authorization: "Bearer " + NEXT_PUBLIC_STRAPI_API_TOKEN },
-        cache: "no-store",
+        next: { tags: [CACHE_TAGS.playlists], revalidate: 900 },
       },
     );
 
@@ -182,7 +182,7 @@ export async function updatePlaylist(
       };
     }
 
-    revalidateTag("playlists");
+    revalidateTag(CACHE_TAGS.playlists);
     return { ok: true, error: null, data: responseData.data };
   } catch (err) {
     console.error(err);
@@ -242,7 +242,7 @@ export async function createPlaylist(data: {
       };
     }
 
-    revalidateTag("playlists");
+    revalidateTag(CACHE_TAGS.playlists);
     return { ok: true, error: null, data: responseData.data };
   } catch (err) {
     console.error(err);
@@ -275,9 +275,9 @@ export async function deletePlaylist(id: number) {
       return { ok: false, error: "Failed to delete playlist.", data: null };
     }
 
-    revalidateTag("authors");
-    revalidateTag("groups");
-    revalidatePath("(general)/my-content", "page");
+    revalidateTag(CACHE_TAGS.playlists);
+    revalidateTag(CACHE_TAGS.authors);
+    revalidateTag(CACHE_TAGS.allGroups);
     return { ok: true, error: null, data: data.data };
   } catch (err) {
     console.error(err);
@@ -322,11 +322,7 @@ export async function archivePlaylist(
       throw new Error("Failed to archive playlist");
     }
 
-    revalidateTag("dashboard");
-    revalidatePath("/");
-    revalidatePath("/draft");
-    revalidatePath("/dashboard");
-    revalidatePath("/dashboard/archived");
+    revalidateTag(CACHE_TAGS.playlists);
     return { success: true };
   } catch (error) {
     console.error("Error archiving playlist:", error);

--- a/frontend/lib/requests/tag.ts
+++ b/frontend/lib/requests/tag.ts
@@ -1,6 +1,7 @@
 import { Tag } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
 import { fetchAPI, PopulateValue } from "../utils";
+import { CACHE_TAGS } from "../cache-tags";
 
 // sort server side by name ascending
 export async function getTags({
@@ -25,7 +26,10 @@ export async function getTags({
     },
   };
 
-  return await fetchAPI<Tag[]>(path, { urlParams });
+  return await fetchAPI<Tag[]>(path, {
+    urlParams,
+    next: { tags: [CACHE_TAGS.tags], revalidate: 3600 },
+  });
 }
 
 export async function getTagBySlug(
@@ -38,5 +42,8 @@ export async function getTagBySlug(
     populate,
   };
 
-  return await fetchAPI<Tag[]>(path, { urlParams }).then((tags) => tags[0]);
+  return await fetchAPI<Tag[]>(path, {
+    urlParams,
+    next: { tags: [CACHE_TAGS.tags], revalidate: 3600 },
+  }).then((tags) => tags[0]);
 }

--- a/frontend/lib/requests/user-populates.ts
+++ b/frontend/lib/requests/user-populates.ts
@@ -25,10 +25,18 @@ export const USER_POPULATES = {
   social: {
     fields: PROFILE_FIELDS,
     populate: {
-      received_requests: { fields: ["*"] },
-      sent_requests: { fields: ["*"] },
-      blocked: { fields: ["*"] },
-      was_blocked: { fields: ["*"] },
+      received_requests: {
+        fields: ["id", "email", "firstName", "lastName", "profilePhoto"],
+      },
+      sent_requests: {
+        fields: ["id", "email", "firstName", "lastName", "profilePhoto"],
+      },
+      blocked: {
+        fields: ["id", "email", "firstName", "lastName", "profilePhoto"],
+      },
+      was_blocked: {
+        fields: ["id", "email", "firstName", "lastName", "profilePhoto"],
+      },
       friendships: {
         populate: {
           authorized_users: {
@@ -84,10 +92,10 @@ export const USER_POPULATES = {
     fields: PROFILE_FIELDS,
     populate: {
       droplets: {
-        fields: ["*"],
+        fields: ["id", "name", "slug", "status", "type", "focusArea"],
       },
       created_playlists: {
-        fields: ["*"],
+        fields: ["id", "name", "slug", "isPublic"],
         populate: {
           droplets: {
             fields: ["id", "name", "slug"],

--- a/frontend/testing/requests/authorized-users.test.js
+++ b/frontend/testing/requests/authorized-users.test.js
@@ -440,7 +440,7 @@ describe("Authorized User Tests", () => {
           headers: expect.objectContaining({
             Authorization: expect.stringContaining("Bearer"),
           }),
-          cache: "no-store",
+          next: { revalidate: 3600 },
         }),
       );
 

--- a/frontend/testing/requests/droplet.test.js
+++ b/frontend/testing/requests/droplet.test.js
@@ -4,20 +4,24 @@ import {
   createDroplet,
   createNewTag,
   deepDeleteDroplet,
+  duplicateDroplet,
   getDroplets,
   getDropletBySlug,
   getDropletById,
   getDraftDroplets,
   getInReviewDroplets,
   getRandomFunFactDroplet,
+  publishDraftToOriginal,
   updateDropletAverageRating,
   updateDropletFunFact,
   updateDroplet,
   archiveDroplet,
+  updateDropletLearningObjective,
+  favoriteDroplet,
 } from "@/lib/requests/droplet";
 import { deleteLesson, addLesson } from "@/lib/requests/lesson";
-import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
-import { revalidatePath, revalidateTag } from "next/cache";
+import { getEnrollmentByUserAndDroplet } from "@/lib/requests/enrollment";
+import { revalidateTag } from "next/cache";
 
 jest.mock("@/lib/requests/lesson", () => ({
   addLesson: jest.fn(),
@@ -41,7 +45,7 @@ jest.mock("@/lib/requests/lesson", () => ({
 }));
 
 jest.mock("@/lib/requests/enrollment", () => ({
-  getEnrollmentsByAuthorizedUser: jest.fn(),
+  getEnrollmentByUserAndDroplet: jest.fn(),
 }));
 
 jest.mock("@/lib/auth/session", () => ({
@@ -63,6 +67,36 @@ beforeEach(() => {
 });
 
 describe("deepDeleteDroplet", () => {
+  it("successfully deletes a droplet and revalidates tags", async () => {
+    const { fetchAPI } = require("@/lib/utils");
+    const { deleteLesson: deleteLessonMock } = require("@/lib/requests/lesson");
+
+    fetchAPI.mockResolvedValueOnce({
+      id: 123,
+      name: "Test Droplet",
+      lessons: [{ id: 1 }, { id: 2 }],
+      authorized_users: [{ id: 1 }],
+      tags: [],
+      prerequisites: [],
+      postrequisites: [],
+      nextSteps: [],
+      learningObjectives: [],
+    });
+    deleteLessonMock.mockResolvedValue({ ok: true });
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { id: 123 } }),
+    });
+
+    const result = await deepDeleteDroplet(123);
+
+    expect(result).toEqual({ ok: true, error: null, data: { id: 123 } });
+    expect(revalidateTag).toHaveBeenCalledWith("authors");
+    expect(revalidateTag).toHaveBeenCalledWith("droplets");
+    expect(revalidateTag).toHaveBeenCalledWith("enrollments");
+  });
+
   it("handles droplet deletion failure", async () => {
     global.fetch.mockResolvedValueOnce({ ok: false });
 
@@ -71,6 +105,7 @@ describe("deepDeleteDroplet", () => {
     expect(result).toEqual({
       error: "Database Error: Failed to Delete Droplet.",
     });
+    expect(revalidateTag).not.toHaveBeenCalled();
   });
 });
 
@@ -78,9 +113,11 @@ beforeEach(() => {
   jest.clearAllMocks();
   getCurrentUser.mockResolvedValue({ email: "test@example.com" });
   getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
-  getEnrollmentsByAuthorizedUser.mockResolvedValue([
-    { id: "enrollment-1", droplet: { id: 1 } },
-  ]);
+  getEnrollmentByUserAndDroplet.mockResolvedValue({
+    id: "enrollment-1",
+    isComplete: false,
+    isArchived: false,
+  });
 });
 
 describe("Droplet API Functions", () => {
@@ -109,6 +146,7 @@ describe("Droplet API Functions", () => {
           fields: ["*"],
           pagination: { pageSize: 100, page: 1 },
         },
+        next: { tags: ["droplets"], revalidate: 900 },
       });
       expect(result).toEqual(mockDroplets);
     });
@@ -139,6 +177,7 @@ describe("Droplet API Functions", () => {
           fields: ["id", "name"],
           pagination: { pageSize: 50, page: 2 },
         },
+        next: { tags: ["droplets"], revalidate: 900 },
       });
       expect(result).toEqual(mockDroplets);
     });
@@ -176,6 +215,7 @@ describe("Droplet API Functions", () => {
             "originalDropletId",
           ]),
         }),
+        next: { tags: ["droplets"], revalidate: 900 },
       });
       expect(result).toEqual(mockDroplet);
     });
@@ -194,6 +234,7 @@ describe("Droplet API Functions", () => {
         urlParams: expect.objectContaining({
           filters: { status: "draft" },
         }),
+        next: { tags: ["droplets"], revalidate: 900 },
       });
       expect(result).toEqual(mockDroplets);
     });
@@ -214,6 +255,7 @@ describe("Droplet API Functions", () => {
         urlParams: expect.objectContaining({
           filters: { inReview: true, status: "draft" },
         }),
+        next: { tags: ["droplets"], revalidate: 900 },
       });
       expect(result).toEqual(mockDroplets);
     });
@@ -238,12 +280,17 @@ describe("Droplet API Functions", () => {
           },
           pagination: { pageSize: 1000, page: 1 },
         }),
+        next: { tags: ["droplets"], revalidate: 900 },
       });
       expect(result).toEqual(mockDroplets);
     });
   });
 
   describe("updateDropletAverageRating", () => {
+    beforeEach(() => {
+      global.fetch.mockReset();
+    });
+
     it("clamps rating to valid range", async () => {
       global.fetch.mockResolvedValueOnce({
         ok: true,
@@ -262,6 +309,156 @@ describe("Droplet API Functions", () => {
           }),
         }),
       );
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+    });
+
+    it("successfully updates average rating and revalidates enrollments", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 1 } }),
+      });
+
+      const result = await updateDropletAverageRating(4.2, 123);
+
+      expect(result).toEqual({ success: true });
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments");
+    });
+
+    it("does not revalidate on failure", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+      });
+
+      const result = await updateDropletAverageRating(4.2, 123);
+
+      expect(result).toEqual({ success: false, error: expect.any(Error) });
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateDropletFunFact", () => {
+    beforeEach(() => {
+      global.fetch.mockReset();
+    });
+
+    it("successfully updates fun fact and revalidates", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 1 } }),
+      });
+
+      const result = await updateDropletFunFact("A fun fact!", 123);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/droplets/123"),
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ data: { funFact: "A fun fact!" } }),
+        }),
+      );
+      expect(result).toEqual({ success: true });
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+    });
+
+    it("does not revalidate on failure", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+      });
+
+      const result = await updateDropletFunFact("A fun fact!", 123);
+
+      expect(result).toEqual({ success: false, error: expect.any(Error) });
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateDroplet", () => {
+    beforeEach(() => {
+      global.fetch.mockReset();
+    });
+
+    it("successfully updates a droplet with name change and revalidates", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ data: { id: 123, name: "Updated Name" } }),
+      });
+
+      const result = await updateDroplet(123, { name: "Updated Name" });
+
+      expect(result).toEqual({
+        ok: true,
+        error: null,
+        data: { id: 123, name: "Updated Name" },
+      });
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+      expect(revalidateTag).toHaveBeenCalledWith("authors");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments");
+      expect(revalidateTag).toHaveBeenCalledWith("playlists");
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
+    });
+
+    it("revalidates droplets when isHidden changes", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 123 } }),
+      });
+
+      await updateDroplet(123, { isHidden: true });
+
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+      expect(revalidateTag).toHaveBeenCalledWith("authors");
+      expect(revalidateTag).toHaveBeenCalledWith("playlists");
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
+    });
+
+    it("revalidates with regenerateSlug option", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 123 } }),
+      });
+
+      await updateDroplet(
+        123,
+        { focusArea: "New Area" },
+        { regenerateSlug: true },
+      );
+
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+      expect(revalidateTag).toHaveBeenCalledWith("authors");
+      expect(revalidateTag).toHaveBeenCalledWith("playlists");
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
+    });
+
+    it("always revalidates droplets, authors, playlists, and groups on any successful update", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 123 } }),
+      });
+
+      await updateDroplet(123, { focusArea: "New Area" });
+
+      expect(revalidateTag).toHaveBeenCalledWith("authors");
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+      expect(revalidateTag).toHaveBeenCalledWith("playlists");
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
+    });
+
+    it("does not revalidate on failure", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.resolve({ error: { message: "Update failed" } }),
+      });
+
+      const result = await updateDroplet(123, { name: "Bad" });
+
+      expect(result).toEqual({
+        ok: false,
+        error: "Update failed",
+        data: null,
+      });
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
@@ -278,7 +475,7 @@ describe("Droplet API Functions", () => {
 
       expect(getCurrentUser).toHaveBeenCalled();
       expect(getAuthorizedUserByEmail).toHaveBeenCalledWith("test@example.com");
-      expect(getEnrollmentsByAuthorizedUser).toHaveBeenCalledWith(1);
+      expect(getEnrollmentByUserAndDroplet).toHaveBeenCalledWith(1, 1);
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringMatching("/api/enrollments/enrollment-1"),
         expect.objectContaining({
@@ -291,6 +488,7 @@ describe("Droplet API Functions", () => {
         }),
       );
       expect(result).toEqual({ success: true });
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
     it("handles missing user email", async () => {
@@ -300,6 +498,7 @@ describe("Droplet API Functions", () => {
 
       const result = await archiveDroplet(mockDroplet, true);
       expect(result).toEqual({ success: false, error: expect.any(Error) });
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
@@ -324,6 +523,7 @@ describe("Droplet API Functions", () => {
           }),
         }),
       );
+      expect(revalidateTag).toHaveBeenCalledWith("tags");
     });
   });
 
@@ -390,6 +590,8 @@ describe("Droplet API Functions", () => {
         error: null,
         data: { id: 1 },
       });
+      expect(revalidateTag).toHaveBeenCalledWith("authors");
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
     });
 
     it("handles duplicate droplet name", async () => {
@@ -432,6 +634,7 @@ describe("Droplet API Functions", () => {
         error: "This attribute must be unique (name)",
         data: null,
       });
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("handles missing user email", async () => {
@@ -452,6 +655,7 @@ describe("Droplet API Functions", () => {
         error: "Database Error: Failed to create droplet.",
         data: null,
       });
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("handles missing author", async () => {
@@ -472,6 +676,385 @@ describe("Droplet API Functions", () => {
         error: "Database Error: Failed to create droplet.",
         data: null,
       });
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
+  });
+
+  describe("updateDropletLearningObjective", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      global.fetch.mockReset();
+      getCurrentUser.mockResolvedValue({ email: "test@example.com" });
+      getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
+    });
+
+    it("successfully updates a learning objective and revalidates", async () => {
+      const { fetchAPI } = require("@/lib/utils");
+      fetchAPI.mockReset();
+      fetchAPI.mockResolvedValueOnce({
+        id: 123,
+        learningObjectives: [
+          { objective: "Old objective" },
+          { objective: "Keep this one" },
+        ],
+      });
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 123 } }),
+      });
+
+      const result = await updateDropletLearningObjective(
+        123,
+        "Old objective",
+        "New objective",
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+    });
+
+    it("does not revalidate on failure", async () => {
+      const { fetchAPI } = require("@/lib/utils");
+      fetchAPI.mockReset();
+      fetchAPI.mockResolvedValueOnce({
+        id: 123,
+        learningObjectives: [{ objective: "Old objective" }],
+      });
+
+      global.fetch.mockResolvedValueOnce({ ok: false });
+
+      const result = await updateDropletLearningObjective(
+        123,
+        "Old objective",
+        "New objective",
+      );
+
+      expect(result).toEqual({ success: false, error: expect.any(Error) });
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("favoriteDroplet", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      global.fetch.mockReset();
+      getCurrentUser.mockResolvedValue({ email: "test@example.com" });
+      getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
+    });
+
+    it("successfully favorites a droplet and revalidates", async () => {
+      // Mock fetching latest droplet state
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              attributes: {
+                usersFavorited: { data: [] },
+              },
+            },
+          }),
+      });
+
+      // Mock the PUT to update favorites
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 1 } }),
+      });
+
+      const result = await favoriteDroplet(
+        { id: 1, slug: "test-droplet" },
+        true,
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
+    });
+
+    it("does not revalidate on failure", async () => {
+      // First fetch (get latest droplet state) fails
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+      });
+
+      const result = await favoriteDroplet(
+        { id: 1, slug: "test-droplet" },
+        true,
+      );
+
+      expect(result).toEqual({ success: false, error: expect.any(Error) });
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("duplicateDroplet", () => {
+  beforeEach(() => {
+    global.fetch.mockReset();
+    const { fetchAPI } = require("@/lib/utils");
+    fetchAPI.mockReset();
+    jest.clearAllMocks();
+    getCurrentUser.mockResolvedValue({ email: "test@test.com" });
+    getAuthorizedUserByEmail.mockResolvedValue({ id: 5 });
+  });
+
+  it("successfully duplicates a droplet", async () => {
+    const { fetchAPI } = require("@/lib/utils");
+
+    // Mock getDropletById (originalDroplet fetch via fetchAPI)
+    fetchAPI.mockResolvedValueOnce({
+      id: 10,
+      name: "Original Droplet",
+      focusArea: "Science",
+      type: "standard",
+      description: "A droplet",
+      overview: "Overview",
+      tags: [],
+      authorized_users: [{ id: 5 }],
+      learningObjectives: [],
+      prerequisites: [],
+      postrequisites: [],
+      nextSteps: [],
+      lessons: [],
+    });
+
+    // Mock draft check fetch (no existing drafts)
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: [] }),
+    });
+
+    // Mock droplet creation fetch
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: {
+            id: 99,
+            attributes: { slug: "draft-new", name: "[EDIT] Original Droplet" },
+          },
+        }),
+    });
+
+    const result = await duplicateDroplet(10);
+
+    expect(result.ok).toBe(true);
+    expect(result.isExisting).toBe(false);
+    expect(revalidateTag).toHaveBeenCalledWith("authors");
+    expect(revalidateTag).toHaveBeenCalledWith("droplets");
+  });
+
+  it("returns existing draft without revalidating", async () => {
+    const { fetchAPI } = require("@/lib/utils");
+
+    // Mock getDropletById (originalDroplet fetch via fetchAPI)
+    fetchAPI.mockResolvedValueOnce({
+      id: 10,
+      name: "Original Droplet",
+      focusArea: "Science",
+      type: "standard",
+      description: "A droplet",
+      overview: "Overview",
+      tags: [],
+      authorized_users: [{ id: 5 }],
+      learningObjectives: [],
+      prerequisites: [],
+      postrequisites: [],
+      nextSteps: [],
+      lessons: [],
+    });
+
+    // Mock draft check fetch — returns a draft where current user (id: 5) is authorized
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          data: [
+            {
+              id: 42,
+              attributes: {
+                slug: "draft-existing",
+                name: "[EDIT] Original Droplet",
+                authorized_users: {
+                  data: [{ id: 5 }],
+                },
+              },
+            },
+          ],
+        }),
+    });
+
+    const result = await duplicateDroplet(10);
+
+    expect(result.ok).toBe(true);
+    expect(result.isExisting).toBe(true);
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it("fails when user not authenticated", async () => {
+    getCurrentUser.mockResolvedValue(null);
+
+    const result = await duplicateDroplet(10);
+
+    expect(result.ok).toBe(false);
+    expect(result.isExisting).toBe(false);
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it("fails when droplet creation fails", async () => {
+    const { fetchAPI } = require("@/lib/utils");
+
+    // Mock getDropletById (originalDroplet fetch via fetchAPI)
+    fetchAPI.mockResolvedValueOnce({
+      id: 10,
+      name: "Original Droplet",
+      focusArea: "Science",
+      type: "standard",
+      description: "A droplet",
+      overview: "Overview",
+      tags: [],
+      authorized_users: [{ id: 5 }],
+      learningObjectives: [],
+      prerequisites: [],
+      postrequisites: [],
+      nextSteps: [],
+      lessons: [],
+    });
+
+    // Mock draft check fetch (no existing drafts)
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: [] }),
+    });
+
+    // Mock droplet creation fetch — fails
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      json: () =>
+        Promise.resolve({
+          error: { message: "Failed to create droplet" },
+        }),
+    });
+
+    const result = await duplicateDroplet(10);
+
+    expect(result.ok).toBe(false);
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+});
+
+describe("publishDraftToOriginal", () => {
+  beforeEach(() => {
+    global.fetch.mockReset();
+    const { fetchAPI } = require("@/lib/utils");
+    fetchAPI.mockReset();
+    jest.clearAllMocks();
+    getCurrentUser.mockResolvedValue({ email: "test@test.com" });
+    getAuthorizedUserByEmail.mockResolvedValue({ id: 5 });
+  });
+
+  it("successfully publishes a draft to original", async () => {
+    const { fetchAPI } = require("@/lib/utils");
+    const { deleteLesson: deleteLessonMock } = require("@/lib/requests/lesson");
+
+    // First fetchAPI call: getDropletById for draft droplet
+    fetchAPI.mockResolvedValueOnce({
+      id: 20,
+      name: "[EDIT] Original Droplet",
+      focusArea: "Science",
+      type: "standard",
+      description: "A droplet",
+      overview: "Overview",
+      slug: "edit-original-droplet",
+      tags: [],
+      authorized_users: [{ id: 5 }],
+      learningObjectives: [],
+      prerequisites: [],
+      postrequisites: [],
+      nextSteps: [],
+      lessons: [],
+    });
+
+    // Second fetchAPI call: getDropletById for original droplet
+    fetchAPI.mockResolvedValueOnce({
+      id: 10,
+      name: "Original Droplet",
+      slug: "original-droplet",
+      tags: [],
+      authorized_users: [{ id: 5 }],
+      learningObjectives: [],
+      prerequisites: [],
+      postrequisites: [],
+      nextSteps: [],
+      lessons: [],
+    });
+
+    // Fetch enrollments for the draft
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: [] }),
+    });
+
+    // updateDroplet calls global.fetch internally — mock the PUT
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({ data: { id: 10, name: "Original Droplet" } }),
+    });
+
+    // deepDeleteDroplet: fetchAPI call for getDropletById inside deepDeleteDroplet
+    fetchAPI.mockResolvedValueOnce({
+      id: 20,
+      name: "[EDIT] Original Droplet",
+      lessons: [],
+      authorized_users: [{ id: 5 }],
+      tags: [],
+      prerequisites: [],
+      postrequisites: [],
+      nextSteps: [],
+      learningObjectives: [],
+    });
+
+    // deepDeleteDroplet: actual delete fetch
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { id: 20 } }),
+    });
+
+    const result = await publishDraftToOriginal(20, 10);
+
+    expect(result.ok).toBe(true);
+    // Revalidation now happens in finally block
+    expect(revalidateTag).toHaveBeenCalledWith("authors");
+    expect(revalidateTag).toHaveBeenCalledWith("droplets");
+    expect(revalidateTag).toHaveBeenCalledWith("lesson");
+    expect(revalidateTag).toHaveBeenCalledWith("playlists");
+    expect(revalidateTag).toHaveBeenCalledWith("enrollments");
+  });
+
+  it("fails when user not authenticated", async () => {
+    getCurrentUser.mockResolvedValue(null);
+
+    const result = await publishDraftToOriginal(20, 10);
+
+    expect(result.ok).toBe(false);
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it("fails when draft droplet not found", async () => {
+    const { fetchAPI } = require("@/lib/utils");
+
+    // getDropletById returns null for the draft droplet
+    fetchAPI.mockResolvedValueOnce(null);
+
+    const result = await publishDraftToOriginal(20, 10);
+
+    expect(result.ok).toBe(false);
+    expect(revalidateTag).not.toHaveBeenCalled();
   });
 });

--- a/frontend/testing/requests/enrollments.test.js
+++ b/frontend/testing/requests/enrollments.test.js
@@ -61,7 +61,7 @@ afterEach(() => {
 });
 
 describe("Enrollment Tests", () => {
-  const { revalidatePath, revalidateTag } = require("next/cache");
+  const { revalidateTag } = require("next/cache");
 
   describe("getEnrollmentsByAuthorizedUser", () => {
     it("should find and return the enrollments corresponding to the given authorized user", async () => {
@@ -412,6 +412,7 @@ describe("Enrollment Tests", () => {
       getCurrentUser.mockResolvedValue({
         email: "test@northeastern.edu",
       });
+      getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
 
       global.fetch.mockResolvedValueOnce({
         ok: true,
@@ -421,8 +422,7 @@ describe("Enrollment Tests", () => {
       const result = await changeEnrollmentRating(3, "24");
 
       expect(result).toEqual({ success: true });
-      expect(revalidatePath).toHaveBeenCalledWith("/p/[slug]", "page");
-      expect(revalidatePath).toHaveBeenCalledWith("/dashboard", "page");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
     it("should handle unauthenticated user", async () => {
@@ -432,6 +432,7 @@ describe("Enrollment Tests", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("Failed to rate enrollment");
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("should handle user without email", async () => {
@@ -441,6 +442,7 @@ describe("Enrollment Tests", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("Failed to rate enrollment");
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("should handle API error response", async () => {
@@ -458,7 +460,7 @@ describe("Enrollment Tests", () => {
         success: false,
         error: "Failed to rate enrollment",
       });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("should handle network errors", async () => {
@@ -471,7 +473,7 @@ describe("Enrollment Tests", () => {
       const result = await changeEnrollmentRating(3, "24");
 
       expect(result.success).toBe(false);
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
@@ -594,6 +596,9 @@ describe("Enrollment Tests", () => {
 
   describe("updateEnrollmentFirstTime", () => {
     it("should successfully update isFirstTime", async () => {
+      getCurrentUser.mockResolvedValue({ email: "test@test.com" });
+      getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
+
       global.fetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ data: { id: 1, isFirstTime: false } }),
@@ -613,6 +618,7 @@ describe("Enrollment Tests", () => {
         }),
       );
       expect(result).toBeDefined();
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
     it("should handle API error", async () => {
@@ -623,6 +629,7 @@ describe("Enrollment Tests", () => {
       await expect(updateEnrollmentFirstTime("123")).rejects.toThrow(
         "Failed to update enrollment",
       );
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("should handle network error", async () => {
@@ -634,6 +641,7 @@ describe("Enrollment Tests", () => {
         "Error updating enrollment:",
         expect.any(Error),
       );
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
@@ -658,6 +666,7 @@ describe("Enrollment Tests", () => {
           method: "POST",
         }),
       );
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
     it("does not create enrollment when already enrolled", async () => {
@@ -695,6 +704,7 @@ describe("Enrollment Tests", () => {
       expect(result.ok).toBe(false);
       expect(result.error).toContain("Creation failed");
       expect(result.error).toContain("droplet");
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("handles API error when ok is true but has error", async () => {
@@ -719,6 +729,7 @@ describe("Enrollment Tests", () => {
 
       expect(result.ok).toBe(false);
       expect(result.error).toContain("Validation failed");
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("handles network errors", async () => {
@@ -732,6 +743,7 @@ describe("Enrollment Tests", () => {
 
       expect(result.error).toBe("Database Error: Failed to enroll.");
       expect(consoleError).toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
@@ -754,13 +766,13 @@ describe("Enrollment Tests", () => {
           method: "DELETE",
         }),
       );
-      expect(revalidateTag).toHaveBeenCalledWith("enrollments");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
     it("does not call API when enrollment not found", async () => {
       getCurrentUser.mockResolvedValue({ email: "test@test.com" });
       getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
-      fetchAPI.mockResolvedValue([{ id: 50, droplet: { id: 999 } }]);
+      fetchAPI.mockResolvedValue([]);
 
       await deleteEnrollment({ droplet: 123 });
 
@@ -775,6 +787,7 @@ describe("Enrollment Tests", () => {
 
       expect(result.error).toBe("Database Error: Failed to unenroll.");
       expect(consoleError).toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("handles user without email", async () => {
@@ -785,6 +798,7 @@ describe("Enrollment Tests", () => {
 
       expect(result.error).toBe("Database Error: Failed to unenroll.");
       expect(consoleError).toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("handles API error when ok is false", async () => {
@@ -807,6 +821,7 @@ describe("Enrollment Tests", () => {
 
       expect(result.ok).toBe(false);
       expect(result.error).toContain("Delete failed");
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("handles API error when ok is true but has error", async () => {
@@ -829,6 +844,7 @@ describe("Enrollment Tests", () => {
 
       expect(result.ok).toBe(false);
       expect(result.error).toContain("Validation error");
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
@@ -852,7 +868,7 @@ describe("Enrollment Tests", () => {
       const result = await createEnrollment(mockDroplet, []);
 
       expect(result.ok).toBe(true);
-      expect(revalidateTag).toHaveBeenCalledWith("enrollments");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
     it("does not create when already enrolled", async () => {
@@ -864,28 +880,6 @@ describe("Enrollment Tests", () => {
 
       expect(result.ok).toBe(true);
       expect(global.fetch).not.toHaveBeenCalled();
-    });
-
-    it("revalidates droplet-specific paths when lessons exist", async () => {
-      getCurrentUser.mockResolvedValue({ email: "test@test.com" });
-      getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
-      fetchAPI.mockResolvedValue([]);
-
-      global.fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: { id: 1 } }),
-      });
-
-      await createEnrollment(mockDroplet, []);
-
-      expect(revalidatePath).toHaveBeenCalledWith(
-        "/(droplets)/d/test-droplet",
-        "page",
-      );
-      expect(revalidatePath).toHaveBeenCalledWith(
-        "/(droplets)/d/test-droplet/lesson-1",
-        "page",
-      );
     });
 
     it("handles droplet without lessons", async () => {
@@ -900,11 +894,6 @@ describe("Enrollment Tests", () => {
 
       const dropletNoLessons = { ...mockDroplet, lessons: null };
       await createEnrollment(dropletNoLessons, []);
-
-      expect(revalidatePath).toHaveBeenCalledWith(
-        "/(droplets)/d/test-droplet",
-        "page",
-      );
     });
 
     it("handles unauthenticated user", async () => {
@@ -915,6 +904,7 @@ describe("Enrollment Tests", () => {
 
       expect(result.error).toBe("Database Error: Failed to enroll.");
       expect(consoleError).toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("handles API error responses", async () => {
@@ -937,12 +927,14 @@ describe("Enrollment Tests", () => {
 
       expect(result.ok).toBe(false);
       expect(result.error).toContain("Creation failed");
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
   describe("updateViewedLessons", () => {
     it("adds lesson when not already viewed", async () => {
       getCurrentUser.mockResolvedValue({ email: "test@test.com" });
+      getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
       fetchAPI.mockResolvedValueOnce([
         {
           id: "123",
@@ -960,10 +952,12 @@ describe("Enrollment Tests", () => {
 
       expect(result.success).toBe(true);
       expect(result.alreadyViewed).toBe(false);
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
-    it("does not update when lesson already viewed", async () => {
+    it("does not update when lesson already viewed but not completing", async () => {
       getCurrentUser.mockResolvedValue({ email: "test@test.com" });
+      getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
       fetchAPI.mockResolvedValueOnce([
         {
           id: "123",
@@ -977,10 +971,36 @@ describe("Enrollment Tests", () => {
         json: async () => ({ data: {} }),
       });
 
+      const result = await updateViewedLessons("123", 3, [1, 2, 3, 4]);
+
+      expect(result.alreadyViewed).toBe(true);
+      expect(result.success).toBe(true);
+      // Not completing (4 not viewed) and already viewed, so no revalidation
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it("revalidates when lesson already viewed but completion is newly detected", async () => {
+      getCurrentUser.mockResolvedValue({ email: "test@test.com" });
+      getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
+      fetchAPI.mockResolvedValueOnce([
+        {
+          id: "123",
+          viewedLessons: [{ id: 1 }, { id: 2 }, { id: 3 }],
+          isComplete: false,
+        },
+      ]);
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
       const result = await updateViewedLessons("123", 3, [1, 2, 3]);
 
       expect(result.alreadyViewed).toBe(true);
       expect(result.success).toBe(true);
+      // Even though lesson was already viewed, completion changed so cache must refresh
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
     it("marks complete when all lessons viewed", async () => {
@@ -1035,6 +1055,7 @@ describe("Enrollment Tests", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("Failed to update viewed lessons");
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("handles API error", async () => {
@@ -1054,6 +1075,7 @@ describe("Enrollment Tests", () => {
       const result = await updateViewedLessons("123", 1, [1, 2]);
 
       expect(result.success).toBe(false);
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("handles network errors", async () => {
@@ -1068,6 +1090,7 @@ describe("Enrollment Tests", () => {
         "Error updating viewed lessons:",
         expect.any(Error),
       );
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
@@ -1076,6 +1099,7 @@ describe("Enrollment Tests", () => {
       getCurrentUser.mockResolvedValue({
         email: "test@test.com",
       });
+      getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
 
       global.fetch.mockResolvedValue({
         ok: true,
@@ -1092,6 +1116,7 @@ describe("Enrollment Tests", () => {
         }),
       );
       expect(result.success).toBe(true);
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
     it("should handle unauthenticated user", async () => {
@@ -1101,6 +1126,7 @@ describe("Enrollment Tests", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("Failed to add completion date");
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("should handle user without email", async () => {
@@ -1109,6 +1135,7 @@ describe("Enrollment Tests", () => {
       const result = await updateCompletionDate("123");
 
       expect(result.success).toBe(false);
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("should handle API failure", async () => {
@@ -1123,6 +1150,7 @@ describe("Enrollment Tests", () => {
       const result = await updateCompletionDate("123");
 
       expect(result.success).toBe(false);
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("should handle network errors", async () => {
@@ -1138,6 +1166,7 @@ describe("Enrollment Tests", () => {
         "Error in adding completion date: ",
         expect.any(Error),
       );
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/testing/requests/feed.test.js
+++ b/frontend/testing/requests/feed.test.js
@@ -5,6 +5,7 @@ const {
   createKudosAnnouncement,
   createPlaylistAnnouncement,
   createGroupAnnouncement,
+  createSystemAnnouncement,
 } = require("../../lib/requests/feed");
 const { flattenAttributes } = require("../../lib/utils");
 
@@ -38,7 +39,7 @@ jest.mock("next/cache", () => ({
 }));
 
 describe("Feed tests", () => {
-  const { revalidatePath } = require("next/cache");
+  const { revalidateTag } = require("next/cache");
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -46,11 +47,18 @@ describe("Feed tests", () => {
 
   describe("fetchAnnouncements", () => {
     it("should fetch and return announcements for a user", async () => {
+      const { fetchAPI } = require("../../lib/utils");
+
       const mockUser = {
         id: 5,
         firstName: "Test",
         lastName: "User",
         email: "test.user@northeastern.edu",
+        friendships: [
+          {
+            authorized_users: [{ id: 5 }, { id: 10 }],
+          },
+        ],
       };
 
       const mockAnnouncements = [
@@ -68,8 +76,6 @@ describe("Feed tests", () => {
         },
       ];
 
-      const mockDroplet = { id: 10, name: "Sample Droplet" };
-
       const mockStrapiResponse = {
         data: mockAnnouncements.map((announcement) => ({
           id: announcement.id,
@@ -81,6 +87,12 @@ describe("Feed tests", () => {
         })),
       };
 
+      // Mock the 3 parallel pre-compute queries via fetchAPI
+      fetchAPI
+        .mockResolvedValueOnce([{ id: 1 }]) // groups
+        .mockResolvedValueOnce([{ id: 2 }]) // playlists
+        .mockResolvedValueOnce([{ id: 3, droplet: { id: 100 } }]); // enrollments
+
       global.fetch.mockResolvedValueOnce({
         ok: true,
         json: async () => mockStrapiResponse,
@@ -88,13 +100,16 @@ describe("Feed tests", () => {
 
       const result = await fetchAnnouncements(mockUser);
 
+      // fetchAPI called 3 times for pre-compute
+      expect(fetchAPI).toHaveBeenCalledTimes(3);
+
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringMatching(/\/api\/announcements\?/),
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: expect.stringContaining("Bearer"),
           }),
-          cache: "no-store",
+          next: { tags: ["announcements"], revalidate: 900 },
         }),
       );
 
@@ -110,7 +125,15 @@ describe("Feed tests", () => {
     });
 
     it("should handle fetch errors", async () => {
-      const mockUser = { id: 5 };
+      const { fetchAPI } = require("../../lib/utils");
+      const mockUser = { id: 5, friendships: [] };
+
+      // Mock pre-compute queries to succeed, but the main fetch fails
+      fetchAPI
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
       global.fetch.mockRejectedValueOnce(new Error("Network error"));
 
       await expect(fetchAnnouncements(mockUser)).rejects.toThrow(
@@ -122,7 +145,6 @@ describe("Feed tests", () => {
   describe("createFriendAnnouncement", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
     });
 
     it("should successfully create a friend announcement", async () => {
@@ -162,7 +184,7 @@ describe("Feed tests", () => {
       expect(requestBody.data.type).toBe("friend");
       expect(requestBody.data.authorized_user).toBe(mockUser.id);
 
-      expect(revalidatePath).toHaveBeenCalledWith("/feed");
+      expect(revalidateTag).toHaveBeenCalledWith("announcements");
 
       expect(result).toEqual({ success: true });
     });
@@ -201,7 +223,7 @@ describe("Feed tests", () => {
       const result = await createFriendAnnouncement(mockDroplet, mockUser);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -219,7 +241,7 @@ describe("Feed tests", () => {
       const result = await createFriendAnnouncement(mockDroplet, mockUser);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -228,7 +250,6 @@ describe("Feed tests", () => {
   describe("createKudosAnnouncement", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
       process.env.NEXT_PUBLIC_STRAPI_API_URL = "http://test-api-url";
       process.env.STRAPI_ACCESS_TOKEN = "test-token";
     });
@@ -297,7 +318,7 @@ describe("Feed tests", () => {
       expect(requestBody.data.type).toBe("kudos");
       expect(requestBody.data.authorized_user).toBe(mockUser.id);
 
-      expect(revalidatePath).toHaveBeenCalledWith("/feed");
+      expect(revalidateTag).toHaveBeenCalledWith("announcements");
 
       expect(result).toEqual({ success: true });
     });
@@ -320,7 +341,6 @@ describe("Feed tests", () => {
       ).rejects.toThrow("Failed to update kudos status");
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
-      expect(revalidatePath).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -351,7 +371,7 @@ describe("Feed tests", () => {
       );
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -377,7 +397,6 @@ describe("Feed tests", () => {
   describe("createPlaylistAnnouncement", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
     });
 
     it("should successfully create a playlist announcement", async () => {
@@ -411,7 +430,7 @@ describe("Feed tests", () => {
       expect(requestBody.data.playlist).toBe(playlistId);
       expect(requestBody.data.firstCreated).toBeDefined();
 
-      expect(revalidatePath).toHaveBeenCalledWith("/feed");
+      expect(revalidateTag).toHaveBeenCalledWith("announcements");
 
       expect(result).toEqual({ success: true });
     });
@@ -432,7 +451,7 @@ describe("Feed tests", () => {
       const result = await createPlaylistAnnouncement(playlistName, playlistId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -450,7 +469,7 @@ describe("Feed tests", () => {
       const result = await createPlaylistAnnouncement(playlistName, playlistId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -459,7 +478,6 @@ describe("Feed tests", () => {
   describe("createGroupAnnouncement", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
     });
 
     it("should successfully create a group announcement", async () => {
@@ -493,7 +511,7 @@ describe("Feed tests", () => {
       expect(requestBody.data.group).toBe(groupId);
       expect(requestBody.data.firstCreated).toBeDefined();
 
-      expect(revalidatePath).toHaveBeenCalledWith("/feed");
+      expect(revalidateTag).toHaveBeenCalledWith("announcements");
 
       expect(result).toEqual({ success: true });
     });
@@ -514,7 +532,7 @@ describe("Feed tests", () => {
       const result = await createGroupAnnouncement(groupName, groupId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -532,7 +550,7 @@ describe("Feed tests", () => {
       const result = await createGroupAnnouncement(groupName, groupId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -541,7 +559,6 @@ describe("Feed tests", () => {
   describe("createDropletAnnouncement", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
     });
 
     it("should successfully create a droplet announcement", async () => {
@@ -575,7 +592,7 @@ describe("Feed tests", () => {
       expect(requestBody.data.droplet).toBe(dropletId);
       expect(requestBody.data.firstCreated).toBeDefined();
 
-      expect(revalidatePath).toHaveBeenCalledWith("/feed");
+      expect(revalidateTag).toHaveBeenCalledWith("announcements");
 
       expect(result).toEqual({ success: true });
     });
@@ -596,7 +613,7 @@ describe("Feed tests", () => {
       const result = await createDropletAnnouncement(dropletName, dropletId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -614,9 +631,61 @@ describe("Feed tests", () => {
       const result = await createDropletAnnouncement(dropletName, dropletId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe("createSystemAnnouncement", () => {
+    beforeEach(() => {
+      global.fetch.mockReset();
+      revalidateTag.mockReset();
+    });
+
+    it("should successfully create a system announcement and revalidate", async () => {
+      const mockAuthUser = { id: 5, email: "admin@northeastern.edu" };
+      const content = "System maintenance scheduled";
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { id: 1 } }),
+      });
+
+      const result = await createSystemAnnouncement(content, mockAuthUser);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/announcements"),
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+          }),
+        }),
+      );
+
+      const requestBody = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(requestBody.data.content).toBe(content);
+      expect(requestBody.data.authorized_user).toBe(mockAuthUser.id);
+      expect(requestBody.data.type).toBe("system");
+      expect(requestBody.data.firstCreated).toBeDefined();
+
+      expect(revalidateTag).toHaveBeenCalledWith("announcements");
+      expect(result).toEqual({ success: true });
+    });
+
+    it("should handle API errors when creating a system announcement", async () => {
+      const mockAuthUser = { id: 5 };
+
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+        text: async () => "Bad Request",
+      });
+
+      const result = await createSystemAnnouncement("Test", mockAuthUser);
+
+      expect(result).toEqual({ success: false, error: expect.any(Error) });
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/testing/requests/friends.test.js
+++ b/frontend/testing/requests/friends.test.js
@@ -44,7 +44,7 @@ jest.mock("next/cache", () => ({
 }));
 
 describe("Friends tests", () => {
-  const { revalidatePath } = require("next/cache");
+  const { revalidateTag } = require("next/cache");
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -153,7 +153,7 @@ describe("Friends tests", () => {
           headers: expect.objectContaining({
             Authorization: expect.stringContaining("Bearer"),
           }),
-          cache: "no-store",
+          next: { tags: ["friendships-5"], revalidate: 900 },
         }),
       );
 
@@ -326,7 +326,7 @@ describe("Friends tests", () => {
           headers: expect.objectContaining({
             Authorization: expect.stringContaining("Bearer"),
           }),
-          cache: "no-store",
+          next: { tags: ["friendships-5"], revalidate: 900 },
         }),
       );
 
@@ -351,7 +351,6 @@ describe("Friends tests", () => {
   describe("acceptFriendRequest", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
     });
 
     it("should successfully accept a friend request", async () => {
@@ -406,7 +405,8 @@ describe("Friends tests", () => {
         }),
       );
 
-      expect(revalidatePath).toHaveBeenCalledWith("/settings/friends");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-5");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-6");
 
       expect(result).toEqual({ success: true });
     });
@@ -427,7 +427,7 @@ describe("Friends tests", () => {
       const result = await acceptFriendRequest(userId, requesterId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -453,6 +453,7 @@ describe("Friends tests", () => {
       const result = await acceptFriendRequest(userId, requesterId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -470,7 +471,7 @@ describe("Friends tests", () => {
       const result = await acceptFriendRequest(userId, requesterId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -479,7 +480,6 @@ describe("Friends tests", () => {
   describe("sendFriendRequest", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
     });
 
     it("should successfully send a friend request", async () => {
@@ -536,7 +536,8 @@ describe("Friends tests", () => {
         }),
       );
 
-      expect(revalidatePath).toHaveBeenCalledWith("/settings/friends");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-5");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-6");
 
       expect(result).toEqual({ success: true });
     });
@@ -557,7 +558,7 @@ describe("Friends tests", () => {
       const result = await sendFriendRequest(requester, requestee);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -583,6 +584,7 @@ describe("Friends tests", () => {
       const result = await sendFriendRequest(requester, requestee);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -600,7 +602,7 @@ describe("Friends tests", () => {
       const result = await sendFriendRequest(requester, requestee);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -609,7 +611,6 @@ describe("Friends tests", () => {
   describe("rejectFriendRequest", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
     });
 
     it("should successfully reject a friend request", async () => {
@@ -641,7 +642,8 @@ describe("Friends tests", () => {
         }),
       );
 
-      expect(revalidatePath).toHaveBeenCalledWith("/settings/friends");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-5");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-6");
 
       expect(result).toEqual({ success: true });
     });
@@ -662,7 +664,7 @@ describe("Friends tests", () => {
       const result = await rejectFriendRequest(userId, requesterId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -680,7 +682,7 @@ describe("Friends tests", () => {
       const result = await rejectFriendRequest(userId, requesterId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -689,7 +691,6 @@ describe("Friends tests", () => {
   describe("cancelFriendRequest", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
     });
 
     it("should successfully cancel a friend request", async () => {
@@ -721,7 +722,8 @@ describe("Friends tests", () => {
         }),
       );
 
-      expect(revalidatePath).toHaveBeenCalledWith("/settings/friends");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-5");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-6");
 
       expect(result).toEqual({ success: true });
     });
@@ -742,7 +744,7 @@ describe("Friends tests", () => {
       const result = await cancelFriendRequest(userId, requesteeId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -760,7 +762,7 @@ describe("Friends tests", () => {
       const result = await cancelFriendRequest(userId, requesteeId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -769,7 +771,6 @@ describe("Friends tests", () => {
   describe("unblockUser", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
     });
 
     it("should successfully unblock a user", async () => {
@@ -801,7 +802,8 @@ describe("Friends tests", () => {
         }),
       );
 
-      expect(revalidatePath).toHaveBeenCalledWith("/settings/friends");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-5");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-6");
 
       expect(result).toEqual({ success: true });
     });
@@ -822,7 +824,7 @@ describe("Friends tests", () => {
       const result = await unblockUser(userId, blockedUserId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -840,7 +842,7 @@ describe("Friends tests", () => {
       const result = await unblockUser(userId, blockedUserId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -849,7 +851,6 @@ describe("Friends tests", () => {
   describe("BlockUser", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
     });
 
     it("should successfully block a user", async () => {
@@ -881,7 +882,8 @@ describe("Friends tests", () => {
         }),
       );
 
-      expect(revalidatePath).toHaveBeenCalledWith("/settings/friends");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-5");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-6");
 
       expect(result).toEqual({ success: true });
     });
@@ -902,7 +904,7 @@ describe("Friends tests", () => {
       const result = await BlockUser(userId, userToBlockId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -920,7 +922,7 @@ describe("Friends tests", () => {
       const result = await BlockUser(userId, userToBlockId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -929,7 +931,6 @@ describe("Friends tests", () => {
   describe("removeFriend", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
     });
 
     it("should successfully remove a friend", async () => {
@@ -978,7 +979,8 @@ describe("Friends tests", () => {
         }),
       );
 
-      expect(revalidatePath).toHaveBeenCalledWith("/settings/friends");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-5");
+      expect(revalidateTag).toHaveBeenCalledWith("friendships-6");
 
       expect(result).toEqual({ success: true });
     });
@@ -1007,7 +1009,7 @@ describe("Friends tests", () => {
           message: "Friendship not found",
         }),
       );
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -1035,7 +1037,7 @@ describe("Friends tests", () => {
       const result = await removeFriend(userId, friendId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -1053,7 +1055,7 @@ describe("Friends tests", () => {
       const result = await removeFriend(userId, friendId);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -1159,7 +1161,7 @@ describe("Friends tests", () => {
           headers: expect.objectContaining({
             Authorization: expect.stringContaining("Bearer"),
           }),
-          cache: "no-store",
+          next: { tags: ["friendships-5"], revalidate: 900 },
         }),
       );
 

--- a/frontend/testing/requests/groups.test.js
+++ b/frontend/testing/requests/groups.test.js
@@ -20,6 +20,7 @@ const {
   getGroupDueDate,
   getGroupDueDates,
   getUserDueDates,
+  archiveGroup,
 } = require("../../lib/requests/groups");
 
 const { fetchAPI } = require("../../lib/utils");
@@ -30,7 +31,7 @@ const {
 } = require("../../lib/requests/authorized-user");
 const { createEnrollmentFromEmail } = require("../../lib/requests/enrollment");
 const { enrollInPlaylist } = require("../../lib/requests/playlist-enrollment");
-const { revalidatePath } = require("next/cache");
+const { revalidateTag } = require("next/cache");
 
 jest.mock("../../lib/utils", () => ({
   fetchAPI: jest.fn(),
@@ -65,6 +66,11 @@ jest.mock("../../lib/requests/playlist-enrollment", () => ({
 
 jest.mock("../../lib/requests/authorized-user-roles", () => ({
   getAuthorizedUserRoleIdByTitle: jest.fn().mockResolvedValue(1),
+}));
+
+const { getCurrentUser } = require("@/lib/auth/session");
+jest.mock("@/lib/auth/session", () => ({
+  getCurrentUser: jest.fn(),
 }));
 
 jest.mock("next/cache", () => ({
@@ -142,7 +148,7 @@ describe("Groups Tests", () => {
           fields: ["id", "groupName", "slug", "semester", "isArchived"],
           pagination: { pageSize: 25, page: 1 },
         }),
-        cache: "no-store",
+        next: { tags: ["groups"], revalidate: 900 },
       });
     });
 
@@ -164,7 +170,7 @@ describe("Groups Tests", () => {
           pagination: { pageSize: 50, page: 2 },
           fields: ["id", "groupName", "isArchived"],
         }),
-        cache: "no-store",
+        next: { tags: ["groups"], revalidate: 900 },
       });
     });
 
@@ -230,7 +236,7 @@ describe("Groups Tests", () => {
             page: 1,
           },
         }),
-        cache: "no-store",
+        next: { tags: ["groups"], revalidate: 900 },
       });
     });
 
@@ -267,7 +273,7 @@ describe("Groups Tests", () => {
         urlParams: expect.objectContaining({
           populate: customPopulate,
         }),
-        cache: "no-store",
+        next: { tags: ["groups"], revalidate: 900 },
       });
     });
 
@@ -286,8 +292,6 @@ describe("Groups Tests", () => {
   });
 
   describe("getGroupByID", () => {
-    const { revalidatePath } = require("next/cache");
-
     it("should fetch and return a group by its ID", async () => {
       const groupId = 1;
       const mockGroup = {
@@ -339,11 +343,8 @@ describe("Groups Tests", () => {
             page: 1,
           },
         }),
-        cache: "no-store",
+        next: { tags: ["groups"], revalidate: 900 },
       });
-
-      expect(revalidatePath).toHaveBeenCalledWith("/dashboard");
-      expect(revalidatePath).toHaveBeenCalledWith("/explore");
     });
 
     it("should use custom population options when provided", async () => {
@@ -362,7 +363,7 @@ describe("Groups Tests", () => {
         urlParams: expect.objectContaining({
           populate: customPopulate,
         }),
-        cache: "no-store",
+        next: { tags: ["groups"], revalidate: 900 },
       });
     });
 
@@ -417,7 +418,7 @@ describe("Groups Tests", () => {
           fields: ["id", "groupName", "slug", "semester", "isArchived"],
           pagination: { pageSize: 25, page: 1 },
         }),
-        cache: "no-store",
+        next: { tags: ["groups"], revalidate: 900 },
       });
     });
 
@@ -444,7 +445,7 @@ describe("Groups Tests", () => {
           },
           pagination: { pageSize: 50, page: 2 },
         }),
-        cache: "no-store",
+        next: { tags: ["groups"], revalidate: 900 },
       });
     });
 
@@ -480,6 +481,7 @@ describe("Groups Tests", () => {
       const result = await updateGroupMembers(groupId, updates);
 
       expect(result).toEqual(mockUpdatedGroup);
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
 
       expect(fetchAPI).toHaveBeenCalledWith(`/groups/${groupId}`, {
         options: {
@@ -509,6 +511,7 @@ describe("Groups Tests", () => {
 
       await updateGroupMembers(groupId, updates);
 
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
       expect(fetchAPI).toHaveBeenCalledWith(`/groups/${groupId}`, {
         options: {
           method: "PUT",
@@ -532,6 +535,7 @@ describe("Groups Tests", () => {
 
       await updateGroupMembers(groupId, updates);
 
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
       expect(fetchAPI).toHaveBeenCalledWith(`/groups/${groupId}`, {
         options: {
           method: "PUT",
@@ -579,6 +583,7 @@ describe("Groups Tests", () => {
       const result = await addGroupMembers(groupId, userIds);
 
       expect(result).toEqual(mockUpdatedGroup);
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
 
       expect(fetchAPI).toHaveBeenCalledWith(`/groups/${groupId}`, {
         options: {
@@ -601,6 +606,7 @@ describe("Groups Tests", () => {
 
       await addGroupMembers(groupId, userIds, role);
 
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
       expect(fetchAPI).toHaveBeenCalledWith(`/groups/${groupId}`, {
         options: {
           method: "PUT",
@@ -640,6 +646,7 @@ describe("Groups Tests", () => {
       const result = await removeGroupMembers(groupId, userIds);
 
       expect(result).toEqual(mockUpdatedGroup);
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
 
       expect(fetchAPI).toHaveBeenCalledWith(`/groups/${groupId}`, {
         options: {
@@ -662,6 +669,7 @@ describe("Groups Tests", () => {
 
       await removeGroupMembers(groupId, userIds, role);
 
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
       expect(fetchAPI).toHaveBeenCalledWith(`/groups/${groupId}`, {
         options: {
           method: "PUT",
@@ -712,6 +720,7 @@ describe("Groups Tests", () => {
       );
 
       expect(result).toEqual(mockUpdatedGroup);
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
 
       expect(fetchAPI).toHaveBeenCalledWith(`/groups/${groupId}`, {
         options: {
@@ -737,6 +746,7 @@ describe("Groups Tests", () => {
 
       await changeGroupMemberRole(groupId, userId, fromRole, toRole);
 
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
       expect(fetchAPI).toHaveBeenCalledWith(`/groups/${groupId}`, {
         options: {
           method: "PUT",
@@ -799,6 +809,7 @@ describe("Groups Tests", () => {
       const result = await createGroup(authorizedUserId, groupData);
 
       expect(result).toEqual(mockCreatedGroup);
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
 
       expect(getAuthorizedUsersByEmails).toHaveBeenCalledWith([
         "member1@northeastern.edu",
@@ -854,6 +865,7 @@ describe("Groups Tests", () => {
       const result = await createGroup(authorizedUserId, groupData);
 
       expect(result).toEqual(mockCreatedGroup);
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
 
       const requestBody = JSON.parse(fetchAPI.mock.calls[0][1].options.body);
       expect(requestBody.data).toHaveProperty("groupName", "Minimal Group");
@@ -889,6 +901,7 @@ describe("Groups Tests", () => {
 
       await createGroup(authorizedUserId, groupData);
 
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
       expect(getAuthorizedUsersByEmails).toHaveBeenCalledWith([
         "existing@northeastern.edu",
         "new@northeastern.edu",
@@ -915,6 +928,7 @@ describe("Groups Tests", () => {
       await expect(createGroup(authorizedUserId, groupData)).rejects.toThrow(
         "Failed to create group",
       );
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
@@ -1013,7 +1027,7 @@ describe("Groups Tests", () => {
           }),
           fields: ["*", "dropletDueDates"],
         },
-        cache: "no-store",
+        next: { tags: ["groups"], revalidate: 900 },
       });
     });
 
@@ -1047,7 +1061,7 @@ describe("Groups Tests", () => {
           populate: customParams.populate,
           fields: customParams.fields,
         }),
-        cache: "no-store",
+        next: { tags: ["groups"], revalidate: 900 },
       });
     });
 
@@ -1119,7 +1133,7 @@ describe("Groups Tests", () => {
         },
       });
 
-      expect(revalidatePath).toHaveBeenCalledWith("/admin");
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
 
       const requestBody = JSON.parse(fetchAPI.mock.calls[0][1].options.body);
 
@@ -1153,6 +1167,8 @@ describe("Groups Tests", () => {
 
       await updateGroup(groupId, partialUpdateData);
 
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
+
       const requestBody = JSON.parse(fetchAPI.mock.calls[0][1].options.body);
       expect(requestBody.data).toHaveProperty("groupName", "Renamed Group");
       expect(requestBody.data).toHaveProperty("description", "New description");
@@ -1175,6 +1191,8 @@ describe("Groups Tests", () => {
       fetchAPI.mockResolvedValueOnce({ id: 1, groupName: "Updated Group" });
 
       await updateGroup(groupId, updateData);
+
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
 
       const requestBody = JSON.parse(fetchAPI.mock.calls[0][1].options.body);
       expect(requestBody.data).toHaveProperty("groupName", "Updated Group");
@@ -1201,6 +1219,8 @@ describe("Groups Tests", () => {
 
       await updateGroup(groupId, updateData);
 
+      expect(revalidateTag).toHaveBeenCalledWith("groups");
+
       const requestBody = JSON.parse(fetchAPI.mock.calls[0][1].options.body);
       expect(requestBody.data.members.set).toEqual([{ id: 101 }, { id: 102 }]);
     });
@@ -1216,7 +1236,8 @@ describe("Groups Tests", () => {
       await expect(updateGroup(groupId, updateData)).rejects.toThrow(
         "Failed to update group",
       );
-      expect(revalidatePath).toHaveBeenCalledWith("/admin");
+      // revalidation should NOT happen when the update fails
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
@@ -1383,6 +1404,7 @@ describe("Groups Tests", () => {
       const result = await assignDropletDueDate(date, mockGroup, mockDroplet);
 
       expect(result).toEqual({ success: true });
+      expect(revalidateTag).toHaveBeenCalledWith("due-dates");
 
       expect(global.fetch).toHaveBeenNthCalledWith(
         2,
@@ -1447,6 +1469,52 @@ describe("Groups Tests", () => {
       expect(console.error).toHaveBeenCalled();
     });
 
+    it("should revalidate when some members succeed and some fail", async () => {
+      const date = "2023-12-31";
+      const mockGroup = {
+        id: 1,
+        members: [
+          { id: 10, email: "member1@northeastern.edu" },
+          { id: 11, email: "member2@northeastern.edu" },
+        ],
+      };
+      const mockDroplet = { id: 101 };
+
+      // Both members run in parallel via Promise.all, so use a call counter
+      let fetchCallCount = 0;
+      global.fetch.mockImplementation(async (url, options) => {
+        fetchCallCount++;
+        const urlStr = String(url);
+
+        // Check-existing calls (GET with filters)
+        if (!options?.method || options?.method === "GET") {
+          return { json: async () => ({ data: [] }) };
+        }
+
+        // POST calls — first POST succeeds, second fails
+        if (options?.method === "POST") {
+          const body = JSON.parse(options.body);
+          if (body.data.authorized_user === 10) {
+            return { ok: true };
+          } else {
+            return { ok: false, text: async () => "Server error" };
+          }
+        }
+
+        return { ok: true };
+      });
+
+      const result = await assignDropletDueDate(date, mockGroup, mockDroplet);
+
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to process due dates for some users",
+      });
+
+      // Revalidation should still happen because member 10 succeeded
+      expect(revalidateTag).toHaveBeenCalledWith("due-dates");
+    });
+
     it("should handle network errors", async () => {
       const date = "2023-12-31";
       const mockGroup = {
@@ -1475,6 +1543,28 @@ describe("Groups Tests", () => {
 
       process.env.NEXT_PUBLIC_STRAPI_API_URL = "http://test-api-url";
       process.env.STRAPI_ACCESS_TOKEN = "test-token";
+    });
+
+    it("should create new due dates when none exist", async () => {
+      const date = "2023-12-31";
+      const mockGroup = {
+        id: 1,
+        members: [{ id: 10, email: "member@northeastern.edu" }],
+      };
+      const mockPlaylist = { id: 201, name: "Test Playlist" };
+
+      global.fetch
+        .mockResolvedValueOnce({
+          json: async () => ({ data: [] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+        });
+
+      const result = await assignPlaylistDueDate(date, mockGroup, mockPlaylist);
+
+      expect(result).toEqual({ success: true });
+      expect(revalidateTag).toHaveBeenCalledWith("due-dates");
     });
 
     it("should handle empty group members array", async () => {
@@ -1520,6 +1610,50 @@ describe("Groups Tests", () => {
       });
 
       expect(console.error).toHaveBeenCalled();
+    });
+
+    it("should revalidate when some members succeed and some fail", async () => {
+      const date = "2023-12-31";
+      const mockGroup = {
+        id: 1,
+        members: [
+          { id: 10, email: "member1@northeastern.edu" },
+          { id: 11, email: "member2@northeastern.edu" },
+        ],
+      };
+      const mockPlaylist = { id: 201 };
+
+      // Both members run in parallel via Promise.all, so use mockImplementation
+      global.fetch.mockImplementation(async (url, options) => {
+        const urlStr = String(url);
+
+        // Check-existing calls (GET with filters)
+        if (!options?.method || options?.method === "GET") {
+          return { json: async () => ({ data: [] }) };
+        }
+
+        // POST calls — first POST succeeds, second fails
+        if (options?.method === "POST") {
+          const body = JSON.parse(options.body);
+          if (body.data.authorized_user === 10) {
+            return { ok: true };
+          } else {
+            return { ok: false, text: async () => "Server error" };
+          }
+        }
+
+        return { ok: true };
+      });
+
+      const result = await assignPlaylistDueDate(date, mockGroup, mockPlaylist);
+
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to process due dates for some users",
+      });
+
+      // Revalidation should still happen because member 10 succeeded
+      expect(revalidateTag).toHaveBeenCalledWith("due-dates");
     });
 
     it("should handle network errors", async () => {
@@ -1742,7 +1876,7 @@ describe("Groups Tests", () => {
             page: 1,
           },
         },
-        cache: "no-store",
+        next: { tags: ["due-dates"], revalidate: 900 },
       });
 
       expect(result).toEqual(mockDueDates);
@@ -1862,7 +1996,7 @@ describe("Groups Tests", () => {
             page: 1,
           },
         },
-        cache: "no-store",
+        next: { tags: ["due-dates"], revalidate: 900 },
       });
 
       expect(result).toEqual(mockDueDates);
@@ -1953,6 +2087,29 @@ describe("Groups Tests", () => {
 });
 
 describe("deleteGroup", () => {
+  it("successfully deletes a group and revalidates tags", async () => {
+    // Mock getGroupByID (fetchAPI returns array, .then(groups => groups[0]))
+    fetchAPI.mockResolvedValueOnce([
+      {
+        id: 123,
+        groupName: "Test Group",
+        members: [{ id: 10 }, { id: 11 }],
+      },
+    ]);
+
+    // Mock the DELETE fetch call
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { id: 123 } }),
+    });
+
+    const result = await deleteGroup(123);
+
+    expect(result).toEqual({ ok: true, error: null, data: { id: 123 } });
+    expect(revalidateTag).toHaveBeenCalledWith("authors");
+    expect(revalidateTag).toHaveBeenCalledWith("groups");
+  });
+
   it("handles group deletion failure", async () => {
     const mockResponse = { ok: false };
     fetchAPI.mockResolvedValueOnce(mockResponse);
@@ -1962,5 +2119,54 @@ describe("deleteGroup", () => {
     expect(result).toEqual({
       error: "Database Error: Failed to Delete Group.",
     });
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+});
+
+describe("archiveGroup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getCurrentUser.mockResolvedValue({ email: "test@example.com" });
+    getAuthorizedUserByEmail.mockResolvedValue({ id: 5 });
+  });
+
+  it("successfully archives a group and revalidates", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ data: { id: 10 } })),
+    });
+
+    const mockGroup = { id: 10, groupName: "Test Group" };
+    const result = await archiveGroup(mockGroup, true);
+
+    expect(result).toEqual({ success: true });
+    expect(revalidateTag).toHaveBeenCalledWith("groups");
+  });
+
+  it("successfully unarchives a group and revalidates", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ data: { id: 10 } })),
+    });
+
+    const mockGroup = { id: 10, groupName: "Test Group" };
+    const result = await archiveGroup(mockGroup, false);
+
+    expect(result).toEqual({ success: true });
+    expect(revalidateTag).toHaveBeenCalledWith("groups");
+  });
+
+  it("does not revalidate on failure", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      text: () => Promise.resolve("Bad Request"),
+      status: 400,
+    });
+
+    const mockGroup = { id: 10, groupName: "Test Group" };
+    const result = await archiveGroup(mockGroup, true);
+
+    expect(result).toEqual({ success: false, error: expect.any(Error) });
+    expect(revalidateTag).not.toHaveBeenCalled();
   });
 });

--- a/frontend/testing/requests/highlights.test.js
+++ b/frontend/testing/requests/highlights.test.js
@@ -87,7 +87,7 @@ describe("Highlights Tests", () => {
           fields: ["id", "color", "text", "yLevel"],
           pagination: { pageSize: 250, page: 1 },
         }),
-        next: { tags: ["highlights"] },
+        next: { tags: ["highlights-5"] },
       });
     });
 
@@ -114,7 +114,7 @@ describe("Highlights Tests", () => {
           pagination: { pageSize: 50, page: 2 },
           fields: ["id", "color"],
         }),
-        next: { tags: ["highlights"] },
+        next: { tags: ["highlights-5"] },
       });
     });
 
@@ -189,7 +189,7 @@ describe("Highlights Tests", () => {
           fields: ["text", "color", "yLevel"],
           pagination: { pageSize: 250, page: 1 },
         }),
-        next: { tags: ["highlights"] },
+        next: { tags: ["highlights-5"] },
       });
     });
 
@@ -216,7 +216,7 @@ describe("Highlights Tests", () => {
           pagination: { pageSize: 100, page: 3 },
           fields: ["text", "color"],
         }),
-        next: { tags: ["highlights"] },
+        next: { tags: ["highlights-5"] },
       });
     });
 
@@ -263,11 +263,12 @@ describe("Highlights Tests", () => {
 
 describe("Highlight Actions", () => {
   it("should create highlight", async () => {
+    const { revalidateTag } = require("next/cache");
     const highlightData = {
       data: {
         content: "Test highlight",
         lesson: 1,
-        user: 1,
+        authorized_user: 5,
       },
     };
 
@@ -279,14 +280,16 @@ describe("Highlight Actions", () => {
     const result = await createHighlight(highlightData);
     expect(result.data).toBeDefined();
     expect(result.data.id).toBe(1);
+    expect(revalidateTag).toHaveBeenCalledWith("highlights-5");
   });
 
   it("should handle highlight creation error", async () => {
+    const { revalidateTag } = require("next/cache");
     const highlightData = {
       data: {
         content: "Test highlight",
         lesson: 1,
-        user: 1,
+        authorized_user: 5,
       },
     };
 
@@ -296,17 +299,20 @@ describe("Highlight Actions", () => {
     });
 
     await expect(createHighlight(highlightData)).rejects.toThrow();
+    expect(revalidateTag).not.toHaveBeenCalled();
   });
 
   it("should delete highlight", async () => {
+    const { revalidateTag } = require("next/cache");
     global.fetch.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ data: { id: 1 } }),
     });
 
-    const result = await deleteHighlight(1);
+    const result = await deleteHighlight(1, 5);
     expect(result).toBeDefined();
     expect(result.data.id).toBe(1);
+    expect(revalidateTag).toHaveBeenCalledWith("highlights-5");
   });
 
   it("should handle get highlights error", async () => {
@@ -330,7 +336,7 @@ describe("Error Cases", () => {
     global.fetch.mockRejectedValueOnce(new Error("Network error"));
 
     await expect(
-      createHighlight({ data: { content: "Test" } }),
+      createHighlight({ data: { content: "Test", authorized_user: 5 } }),
     ).rejects.toThrow();
   });
 

--- a/frontend/testing/requests/lesson.test.js
+++ b/frontend/testing/requests/lesson.test.js
@@ -8,7 +8,7 @@ import {
   revalidateLesson,
   duplicateLessonToDroplet,
 } from "@/lib/requests/lesson";
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 
 global.fetch = jest.fn();
 
@@ -22,6 +22,14 @@ jest.mock("next/cache", () => ({
   revalidateTag: jest.fn(),
 }));
 
+jest.mock("@/lib/auth/session", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/requests/authorized-user", () => ({
+  getAuthorizedUserByEmail: jest.fn(),
+}));
+
 describe("Lesson API Functions", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -29,7 +37,7 @@ describe("Lesson API Functions", () => {
   });
 
   describe("addLesson", () => {
-    it("successfully creates a lesson", async () => {
+    it("successfully creates a lesson and revalidates enrollment caches", async () => {
       global.fetch.mockResolvedValueOnce({
         ok: true,
         json: () =>
@@ -73,6 +81,7 @@ describe("Lesson API Functions", () => {
         data: expect.objectContaining({ id: 1 }),
       });
       expect(revalidateTag).toHaveBeenCalledWith("droplets");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments");
     });
 
     it("creates lesson with blocksV2", async () => {
@@ -216,6 +225,7 @@ describe("Lesson API Functions", () => {
         error: "Creation failed",
         data: null,
       });
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("handles network errors", async () => {
@@ -230,6 +240,7 @@ describe("Lesson API Functions", () => {
       expect(result).toEqual({
         error: "Database Error: Failed to create lesson.",
       });
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("creates lesson with empty blocks array when no blocksV2", async () => {
@@ -278,6 +289,8 @@ describe("Lesson API Functions", () => {
         }),
       );
       expect(result.ok).toBe(true);
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+      expect(revalidateTag).toHaveBeenCalledWith("lesson");
     });
 
     it("strips IDs from blocks when updating", async () => {
@@ -320,6 +333,7 @@ describe("Lesson API Functions", () => {
         error: "Validation failed (name)",
         data: null,
       });
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it("revalidates paths when reload option is true", async () => {
@@ -330,10 +344,8 @@ describe("Lesson API Functions", () => {
 
       await updateLesson(123, { name: "Test" }, { reload: true });
 
-      expect(revalidatePath).toHaveBeenCalledWith(
-        "(editing)/draft/d/[slug]/[lessonSlug]",
-        "page",
-      );
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+      expect(revalidateTag).toHaveBeenCalledWith("lesson");
     });
 
     it("supports regenerateSlug option", async () => {
@@ -378,7 +390,7 @@ describe("Lesson API Functions", () => {
             },
           },
         }),
-        cache: "no-store",
+        next: { tags: ["droplets"], revalidate: 900 },
       });
       expect(result).toEqual(mockLesson);
     });
@@ -394,6 +406,13 @@ describe("Lesson API Functions", () => {
 
   describe("markLessonAsComplete", () => {
     it("successfully marks a lesson as complete", async () => {
+      const { getCurrentUser } = require("@/lib/auth/session");
+      const {
+        getAuthorizedUserByEmail,
+      } = require("@/lib/requests/authorized-user");
+      getCurrentUser.mockResolvedValue({ email: "test@test.com" });
+      getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
+
       global.fetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ data: { id: 1 } }),
@@ -402,7 +421,7 @@ describe("Lesson API Functions", () => {
       const result = await markLessonAsComplete("enrollment-1", [1, 2], 3);
 
       expect(result).toBe(true);
-      expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
     it("handles errors when marking as complete", async () => {
@@ -413,11 +432,19 @@ describe("Lesson API Functions", () => {
 
       const result = await markLessonAsComplete("enrollment-1", [1, 2], 3);
       expect(result).toBe(false);
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
   describe("completeLesson", () => {
     it("successfully completes a lesson", async () => {
+      const { getCurrentUser } = require("@/lib/auth/session");
+      const {
+        getAuthorizedUserByEmail,
+      } = require("@/lib/requests/authorized-user");
+      getCurrentUser.mockResolvedValue({ email: "test@test.com" });
+      getAuthorizedUserByEmail.mockResolvedValue({ id: 1 });
+
       global.fetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ data: { id: 1 } }),
@@ -425,6 +452,7 @@ describe("Lesson API Functions", () => {
 
       const result = await completeLesson(1, [1, 2, 3]);
       expect(result).toEqual({ success: true });
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
     it("handles errors", async () => {
@@ -435,6 +463,7 @@ describe("Lesson API Functions", () => {
         success: false,
         error: expect.any(Error),
       });
+      expect(revalidateTag).not.toHaveBeenCalled();
     });
   });
 
@@ -466,15 +495,11 @@ describe("Lesson API Functions", () => {
       await revalidateLesson();
 
       expect(revalidateTag).toHaveBeenCalledWith("lesson");
-      expect(revalidatePath).toHaveBeenCalledWith(
-        "(editing)/draft/d/[slug]/[lessonSlug]",
-        "page",
-      );
     });
   });
 
   describe("duplicateLessonToDroplet", () => {
-    it("duplicates v2 lesson correctly", async () => {
+    it("duplicates v2 lesson correctly and revalidates enrollments", async () => {
       const mockV2Lesson = {
         data: {
           id: 1,
@@ -501,6 +526,8 @@ describe("Lesson API Functions", () => {
       const result = await duplicateLessonToDroplet(1, 2, 0);
 
       expect(result.ok).toBe(true);
+      expect(revalidateTag).toHaveBeenCalledWith("droplets");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments");
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringMatching("/api/lessons"),
         expect.objectContaining({

--- a/frontend/testing/requests/notes.test.js
+++ b/frontend/testing/requests/notes.test.js
@@ -1,4 +1,4 @@
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 
 const {
   getNotesByAuthorizedUserAndLesson,
@@ -42,7 +42,7 @@ jest.mock("next/cache", () => ({
 }));
 
 describe("Notes Tests", () => {
-  const { revalidatePath, revalidateTag } = require("next/cache");
+  const { revalidateTag } = require("next/cache");
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -91,7 +91,7 @@ describe("Notes Tests", () => {
           },
         },
         next: {
-          tags: ["notes"],
+          tags: ["notes-4"],
         },
       });
 
@@ -151,7 +151,7 @@ describe("Notes Tests", () => {
           },
         },
         next: {
-          tags: ["notes"],
+          tags: ["notes-4"],
         },
       });
 
@@ -184,7 +184,7 @@ describe("Notes Tests", () => {
           fields: ["id", "content"],
         }),
         next: {
-          tags: ["notes"],
+          tags: ["notes-4"],
         },
       });
     });
@@ -193,7 +193,6 @@ describe("Notes Tests", () => {
   describe("updateNoteContent", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
       revalidateTag.mockReset();
     });
 
@@ -207,7 +206,7 @@ describe("Notes Tests", () => {
 
       global.fetch.mockResolvedValueOnce(mockResponse);
 
-      const result = await updateNoteContent(1, "Updated content");
+      const result = await updateNoteContent(1, "Updated content", 4);
 
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining("/api/notes/1"),
@@ -225,11 +224,7 @@ describe("Notes Tests", () => {
         }),
       );
 
-      expect(revalidatePath).toHaveBeenCalledWith(
-        "/d/[slug]/[lessonSlug]",
-        "page",
-      );
-      expect(revalidateTag).toHaveBeenCalledWith("notes");
+      expect(revalidateTag).toHaveBeenCalledWith("notes-4");
 
       expect(result).toEqual({ success: true });
     });
@@ -245,10 +240,9 @@ describe("Notes Tests", () => {
         .spyOn(console, "error")
         .mockImplementation(() => {});
 
-      const result = await updateNoteContent(1, "Test content");
+      const result = await updateNoteContent(1, "Test content", 4);
 
       expect(result).toEqual({ success: false, error: expect.any(Object) });
-      expect(revalidatePath).not.toHaveBeenCalled();
       expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
@@ -261,10 +255,9 @@ describe("Notes Tests", () => {
         .spyOn(console, "error")
         .mockImplementation(() => {});
 
-      const result = await updateNoteContent(1, "Test content");
+      const result = await updateNoteContent(1, "Test content", 4);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
       expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
@@ -274,7 +267,6 @@ describe("Notes Tests", () => {
   describe("updateNotePosition", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
       revalidateTag.mockReset();
     });
 
@@ -286,7 +278,7 @@ describe("Notes Tests", () => {
 
       global.fetch.mockResolvedValueOnce(mockResponse);
 
-      const result = await updateNotePosition(1, 150);
+      const result = await updateNotePosition(1, 150, 4);
 
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining("/api/notes/1"),
@@ -304,11 +296,7 @@ describe("Notes Tests", () => {
         }),
       );
 
-      expect(revalidatePath).toHaveBeenCalledWith(
-        "/d/[slug]/[lessonSlug]",
-        "page",
-      );
-      expect(revalidateTag).toHaveBeenCalledWith("notes");
+      expect(revalidateTag).toHaveBeenCalledWith("notes-4");
 
       expect(result).toEqual({ success: true });
     });
@@ -324,10 +312,9 @@ describe("Notes Tests", () => {
         .spyOn(console, "error")
         .mockImplementation(() => {});
 
-      const result = await updateNotePosition(1, 150);
+      const result = await updateNotePosition(1, 150, 4);
 
       expect(result).toEqual({ success: false, error: expect.any(Object) });
-      expect(revalidatePath).not.toHaveBeenCalled();
       expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
@@ -340,10 +327,9 @@ describe("Notes Tests", () => {
         .spyOn(console, "error")
         .mockImplementation(() => {});
 
-      const result = await updateNotePosition(1, 150);
+      const result = await updateNotePosition(1, 150, 4);
 
       expect(result).toEqual({ success: false, error: expect.any(Error) });
-      expect(revalidatePath).not.toHaveBeenCalled();
       expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
@@ -353,7 +339,6 @@ describe("Notes Tests", () => {
   describe("createNote", () => {
     beforeEach(() => {
       global.fetch.mockReset();
-      revalidatePath.mockReset();
       revalidateTag.mockReset();
     });
 
@@ -393,6 +378,7 @@ describe("Notes Tests", () => {
         mockLesson,
         mockEnrollment,
         mockPosition,
+        4,
         mockHighlight,
         mockContent,
       );
@@ -417,11 +403,7 @@ describe("Notes Tests", () => {
         }),
       );
 
-      expect(revalidatePath).toHaveBeenCalledWith(
-        "/d/[slug]/[lessonSlug]",
-        "page",
-      );
-      expect(revalidateTag).toHaveBeenCalledWith("notes");
+      expect(revalidateTag).toHaveBeenCalledWith("notes-4");
 
       expect(result).toEqual({ success: true });
     });
@@ -438,7 +420,12 @@ describe("Notes Tests", () => {
 
       global.fetch.mockResolvedValueOnce(mockResponse);
 
-      const result = await createNote(mockLesson, mockEnrollment, mockPosition);
+      const result = await createNote(
+        mockLesson,
+        mockEnrollment,
+        mockPosition,
+        4,
+      );
 
       expect(global.fetch).toHaveBeenCalledWith(
         expect.anything(),
@@ -472,13 +459,17 @@ describe("Notes Tests", () => {
         .spyOn(console, "error")
         .mockImplementation(() => {});
 
-      const result = await createNote(mockLesson, mockEnrollment, mockPosition);
+      const result = await createNote(
+        mockLesson,
+        mockEnrollment,
+        mockPosition,
+        4,
+      );
 
       expect(result).toEqual({
         success: false,
         error: "Failed to add new note",
       });
-      expect(revalidatePath).not.toHaveBeenCalled();
       expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
@@ -495,13 +486,17 @@ describe("Notes Tests", () => {
         .spyOn(console, "error")
         .mockImplementation(() => {});
 
-      const result = await createNote(mockLesson, mockEnrollment, mockPosition);
+      const result = await createNote(
+        mockLesson,
+        mockEnrollment,
+        mockPosition,
+        4,
+      );
 
       expect(result).toEqual({
         success: false,
         error: "Failed to process request",
       });
-      expect(revalidatePath).not.toHaveBeenCalled();
       expect(revalidateTag).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
@@ -512,7 +507,6 @@ describe("Notes Tests", () => {
 describe("deleteNote", () => {
   beforeEach(() => {
     global.fetch.mockReset();
-    revalidatePath.mockReset();
     revalidateTag.mockReset();
   });
   it("successfully deletes a note", async () => {
@@ -524,7 +518,7 @@ describe("deleteNote", () => {
 
     global.fetch.mockResolvedValueOnce(mockResponse);
 
-    const result = await deleteNote(1);
+    const result = await deleteNote(1, 4);
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringMatching("/api/notes/1"),
@@ -543,11 +537,7 @@ describe("deleteNote", () => {
       data: { id: 1 },
     });
 
-    expect(revalidatePath).toHaveBeenCalledWith(
-      "/d/[slug]/[lessonSlug]",
-      "page",
-    );
-    expect(revalidateTag).toHaveBeenCalledWith("notes");
+    expect(revalidateTag).toHaveBeenCalledWith("notes-4");
   });
 
   it("handles deletion failure", async () => {
@@ -559,7 +549,7 @@ describe("deleteNote", () => {
 
     global.fetch.mockResolvedValueOnce(mockResponse);
 
-    const result = await deleteNote(1);
+    const result = await deleteNote(1, 4);
 
     expect(result).toEqual({
       ok: false,
@@ -567,7 +557,6 @@ describe("deleteNote", () => {
       data: null,
     });
 
-    expect(revalidatePath).not.toHaveBeenCalled();
     expect(revalidateTag).not.toHaveBeenCalled();
   });
 });

--- a/frontend/testing/requests/playlist-enrollment.test.js
+++ b/frontend/testing/requests/playlist-enrollment.test.js
@@ -1,0 +1,199 @@
+const {
+  togglePlaylistEnrollment,
+  enrollInPlaylist,
+} = require("../../lib/requests/playlist-enrollment");
+
+const { getCurrentUser } = require("../../lib/auth/session");
+const {
+  getAuthorizedUserByEmail,
+} = require("../../lib/requests/authorized-user");
+
+jest.mock("next/cache", () => ({
+  revalidateTag: jest.fn(),
+}));
+
+jest.mock("@/lib/auth/session", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/requests/authorized-user", () => ({
+  getAuthorizedUserByEmail: jest.fn(),
+}));
+
+global.fetch = jest.fn();
+
+beforeEach(() => {
+  jest.spyOn(console, "error").mockImplementation(() => {});
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+});
+
+describe("Playlist Enrollment Tests", () => {
+  const { revalidateTag } = require("next/cache");
+
+  describe("togglePlaylistEnrollment", () => {
+    beforeEach(() => {
+      global.fetch.mockReset();
+      revalidateTag.mockReset();
+    });
+
+    it("successfully enrolls (connect) when user is NOT enrolled", async () => {
+      getCurrentUser.mockResolvedValue({ email: "test@northeastern.edu" });
+      getAuthorizedUserByEmail.mockResolvedValue({
+        id: 5,
+        playlists: [{ id: 10 }, { id: 20 }],
+      });
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { id: 5 } }),
+      });
+
+      const result = await togglePlaylistEnrollment(99);
+
+      expect(result).toEqual({ success: true });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/authorized-users/5"),
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            data: {
+              playlists: {
+                connect: [99],
+              },
+            },
+          }),
+        }),
+      );
+      expect(revalidateTag).toHaveBeenCalledWith("playlists");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-5");
+    });
+
+    it("successfully unenrolls (disconnect) when user IS enrolled", async () => {
+      getCurrentUser.mockResolvedValue({ email: "test@northeastern.edu" });
+      getAuthorizedUserByEmail.mockResolvedValue({
+        id: 5,
+        playlists: [{ id: 10 }, { id: 42 }],
+      });
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { id: 5 } }),
+      });
+
+      const result = await togglePlaylistEnrollment(42);
+
+      expect(result).toEqual({ success: true });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/authorized-users/5"),
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            data: {
+              playlists: {
+                disconnect: [42],
+              },
+            },
+          }),
+        }),
+      );
+      expect(revalidateTag).toHaveBeenCalledWith("playlists");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-5");
+    });
+
+    it("fails when user is not authenticated", async () => {
+      getCurrentUser.mockResolvedValue(null);
+
+      const result = await togglePlaylistEnrollment(99);
+
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to update enrollment",
+      });
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it("fails when API returns an error response", async () => {
+      getCurrentUser.mockResolvedValue({ email: "test@northeastern.edu" });
+      getAuthorizedUserByEmail.mockResolvedValue({
+        id: 5,
+        playlists: [],
+      });
+
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+      });
+
+      const result = await togglePlaylistEnrollment(99);
+
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to update enrollment",
+      });
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enrollInPlaylist", () => {
+    beforeEach(() => {
+      global.fetch.mockReset();
+      revalidateTag.mockReset();
+    });
+
+    it("successfully enrolls and revalidates tags", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { id: 7 } }),
+      });
+
+      const result = await enrollInPlaylist(55, 7);
+
+      expect(result).toEqual({ success: true });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/authorized-users/7"),
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            data: {
+              playlists: {
+                connect: [55],
+              },
+            },
+          }),
+        }),
+      );
+      expect(revalidateTag).toHaveBeenCalledWith("playlists");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-7");
+    });
+
+    it("fails when API returns an error response", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+      });
+
+      const result = await enrollInPlaylist(55, 7);
+
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to enroll in playlist",
+      });
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it("fails on network error", async () => {
+      global.fetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const result = await enrollInPlaylist(55, 7);
+
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to enroll in playlist",
+      });
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/testing/requests/playlist.test.ts
+++ b/frontend/testing/requests/playlist.test.ts
@@ -2,12 +2,23 @@ import {
   createPlaylist,
   deletePlaylist,
   updatePlaylist,
+  archivePlaylist,
 } from "@/lib/requests/playlist";
 import { revalidateTag } from "next/cache";
+import { getCurrentUser } from "@/lib/auth/session";
+import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
 
 jest.mock("next/cache", () => ({
   revalidatePath: jest.fn(),
   revalidateTag: jest.fn(),
+}));
+
+jest.mock("@/lib/auth/session", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/requests/authorized-user", () => ({
+  getAuthorizedUserByEmail: jest.fn(),
 }));
 
 describe("createPlaylist", () => {
@@ -50,6 +61,7 @@ describe("createPlaylist", () => {
       error: "Creation failed",
       data: null,
     });
+    expect(revalidateTag).not.toHaveBeenCalled();
   });
 });
 
@@ -93,6 +105,7 @@ describe("updatePlaylist", () => {
       error: "Update failed",
       data: null,
     });
+    expect(revalidateTag).not.toHaveBeenCalled();
   });
 });
 
@@ -130,6 +143,27 @@ describe("Playlist Actions", () => {
 });
 
 describe("deletePlaylist", () => {
+  it("successfully deletes a playlist and revalidates tags", async () => {
+    // Mock getPlaylistById (fetch for GET)
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({ data: { id: 123, attributes: { name: "Test" } } }),
+    });
+    // Mock the DELETE fetch
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { id: 123 } }),
+    });
+
+    const result = await deletePlaylist(123);
+
+    expect(result).toEqual({ ok: true, error: null, data: { id: 123 } });
+    expect(revalidateTag).toHaveBeenCalledWith("playlists");
+    expect(revalidateTag).toHaveBeenCalledWith("authors");
+    expect(revalidateTag).toHaveBeenCalledWith("groups");
+  });
+
   it("handles playlist deletion failure", async () => {
     const mockResponse = { ok: false };
     (global.fetch as jest.Mock).mockResolvedValueOnce(mockResponse);
@@ -139,5 +173,55 @@ describe("deletePlaylist", () => {
     expect(result).toEqual({
       error: "Database Error: Failed to Delete Playlist.",
     });
+  });
+});
+
+describe("archivePlaylist", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getCurrentUser as jest.Mock).mockResolvedValue({
+      email: "test@example.com",
+    });
+    (getAuthorizedUserByEmail as jest.Mock).mockResolvedValue({ id: 5 });
+  });
+
+  it("successfully archives a playlist and revalidates", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ data: { id: 10 } })),
+    });
+
+    const mockPlaylist = { id: 10, name: "Test Playlist" };
+    const result = await archivePlaylist(mockPlaylist, true);
+
+    expect(result).toEqual({ success: true });
+    expect(revalidateTag).toHaveBeenCalledWith("playlists");
+  });
+
+  it("successfully unarchives a playlist and revalidates", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ data: { id: 10 } })),
+    });
+
+    const mockPlaylist = { id: 10, name: "Test Playlist" };
+    const result = await archivePlaylist(mockPlaylist, false);
+
+    expect(result).toEqual({ success: true });
+    expect(revalidateTag).toHaveBeenCalledWith("playlists");
+  });
+
+  it("does not revalidate on failure", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      text: () => Promise.resolve("Bad Request"),
+      status: 400,
+    });
+
+    const mockPlaylist = { id: 10, name: "Test Playlist" };
+    const result = await archivePlaylist(mockPlaylist, true);
+
+    expect(result).toEqual({ success: false, error: expect.any(Error) });
+    expect(revalidateTag).not.toHaveBeenCalled();
   });
 });

--- a/frontend/testing/requests/requests.test.js
+++ b/frontend/testing/requests/requests.test.js
@@ -29,6 +29,7 @@ const { getCurrentUser } = require("../../lib/auth/session");
 const {
   getAuthorizedUserByEmail,
 } = require("../../lib/requests/authorized-user");
+const { revalidateTag } = require("next/cache");
 
 const mockGroups = require("../mocks/groupsMock");
 
@@ -378,6 +379,7 @@ describe("Droplet tests", () => {
           filters: { slug: "droplet-1" },
           pagination: { pageSize: 1, page: 1 },
         }),
+        next: { tags: ["droplets"], revalidate: 900 },
       });
     });
 
@@ -522,6 +524,8 @@ describe("Playlist enrollment tests", () => {
       );
 
       expect(result).toEqual({ success: true });
+      expect(revalidateTag).toHaveBeenCalledWith("playlists");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-12");
     });
 
     it("should enroll user in playlist when not already enrolled", async () => {
@@ -574,6 +578,8 @@ describe("Playlist enrollment tests", () => {
       );
 
       expect(result).toEqual({ success: true });
+      expect(revalidateTag).toHaveBeenCalledWith("playlists");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-12");
     });
 
     it("should throw the correct error when an API error occurs", async () => {
@@ -655,6 +661,8 @@ describe("Playlist enrollment tests", () => {
       );
 
       expect(result).toEqual({ success: true });
+      expect(revalidateTag).toHaveBeenCalledWith("playlists");
+      expect(revalidateTag).toHaveBeenCalledWith("enrollments-1");
     });
 
     it("should throw the correct error when an API error occurs", async () => {

--- a/frontend/tests/components/droplets/note-block.test.tsx
+++ b/frontend/tests/components/droplets/note-block.test.tsx
@@ -74,6 +74,7 @@ describe("NoteBlock", () => {
 
   const mockProps = {
     note: mockNote,
+    authorizedUserId: 1,
     onUpdate: jest.fn(),
     onDelete: jest.fn(),
     onFocus: jest.fn(),
@@ -217,6 +218,7 @@ describe("NoteBlock", () => {
         expect(updateNoteContent).toHaveBeenCalledWith(
           mockNote.id,
           expect.any(String),
+          1,
         );
         expect(mockProps.onUpdate).toHaveBeenCalled();
       });

--- a/frontend/tests/components/droplets/notes-bar.test.tsx
+++ b/frontend/tests/components/droplets/notes-bar.test.tsx
@@ -291,7 +291,7 @@ describe("NotesBar", () => {
       await userEvent.click(deleteButtons[0]);
 
       await waitFor(() => {
-        expect(deleteNote).toHaveBeenCalledWith(1);
+        expect(deleteNote).toHaveBeenCalledWith(1, 1);
       });
     });
 

--- a/frontend/tests/components/friends/friend-completed-droplets.test.tsx
+++ b/frontend/tests/components/friends/friend-completed-droplets.test.tsx
@@ -1,10 +1,14 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
+import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { FriendCompletedDroplets } from "@/components/friends/friend-completed-droplets";
 import { TimeZone } from "@/types";
 
-jest.mock("@/lib/requests/cached", () => ({
-  getCachedEnrollmentsWithLessonIds: jest.fn(() => Promise.resolve([])),
+jest.mock("@/lib/requests/enrollment", () => ({
+  getEnrollmentsByAuthorizedUser: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock("@/lib/requests/enrollment-populates", () => ({
+  ENROLLMENT_POPULATES: { withLessonIds: {} },
 }));
 
 jest.mock("@/components/friends/friend-completed-droplets-list", () => ({
@@ -69,7 +73,7 @@ describe("FriendCompletedDroplets", () => {
       },
     ];
 
-    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValueOnce(
+    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValueOnce(
       mockEnrollments,
     );
 
@@ -83,7 +87,7 @@ describe("FriendCompletedDroplets", () => {
   });
 
   it("shows no completed droplets message when none available", async () => {
-    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValueOnce([]);
+    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValueOnce([]);
 
     render(<FriendCompletedDroplets friend={mockFriend} />);
 
@@ -112,7 +116,7 @@ describe("FriendCompletedDroplets", () => {
       },
     ];
 
-    (getCachedEnrollmentsWithLessonIds as jest.Mock).mockResolvedValueOnce(
+    (getEnrollmentsByAuthorizedUser as jest.Mock).mockResolvedValueOnce(
       mockEnrollments,
     );
 


### PR DESCRIPTION

## Description
Created a single cache-tags.ts file that holds all cache tag names in one place, replacing hardcoded strings scattered across 15 request files (ODY-316). Switched from revalidatePath (which refreshes an entire page) to revalidateTag (which only refreshes the specific data that changed) across all mutations (ODY-317). Enabled ISR caching with tags on all read-side fetches (ODY-318). Mutations that used to fetch all of a user's enrollments just to find one now query for that specific enrollment directly (ODY-308). Removed force-dynamic flags that were preventing pages from caching at all (ODY-319). Fixed a bug where enrollUsers was firing off API calls without waiting for them to finish (ODY-312). Added loading spinners to 8 routes.
 
## Motivation and Context
- Cache invalidation was inconsistent, tag strings were copy-pasted across files with no single source of truth, so they could easily get out of sync
- revalidatePath was too aggressive, updating one droplet would blow away the cache for an entire page instead of just the droplet data
- Mutations were over-fetching, pulling every enrollment for a user just to find one specific one, when a targeted query would do
- Per-user group/due-date tags were redundant since every mutation already called the global tag, just adding unnecessary revalidateTag calls that risk hitting the Next.js #53117 silent failure bug
- enrollUsers wasn't awaiting its async calls, so enrollment failures were completely silent
- force-dynamic was preventing caching entirely on several routes, even though Next.js 15 already defaults to uncached bug
- enrollUsers had a fire-and-forget promise bug where enrollment API calls could silently fail
- Routes using force-dynamic bypassed caching entirely, even though Next.js 15 defaults to uncached



## Checklist:


- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.