### PR TITLE
ODY-315: Slim down draft editor droplet catalog fetch 

### DIFF
--- a/frontend/app/(editing)/draft/d/[slug]/page.tsx
+++ b/frontend/app/(editing)/draft/d/[slug]/page.tsx
@@ -57,6 +57,9 @@ export default async function Droplet({ params }: Props) {
     filters: {
       $and: [{ status: { $eq: "published" } }, { isHidden: false }],
     },
+    fields: ["id", "name", "slug"],
+    populate: {},
+    pagination: { pageSize: 250, page: 1 },
   });
 
   const tags = await getTags();


### PR DESCRIPTION
## Description

Provide fields so only id, name, and slug is fetched instead of all the contents of all the droplets.

## Motivation and Context

To reduce latency as droplet number grows.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.