### PR TITLE
Use lightweight populate in student progress 

### DIFF
--- a/frontend/components/admin/progress/student-progress.tsx
+++ b/frontend/components/admin/progress/student-progress.tsx
@@ -1,5 +1,6 @@
 import { getCurrentUser } from "@/lib/auth/session";
-import { getCachedEnrollmentsWithLessonIds } from "@/lib/requests/cached";
+import { getEnrollmentsForGroupMembers } from "@/lib/requests/enrollment";
+import { ENROLLMENT_POPULATES } from "@/lib/requests/enrollment-populates";
 import { StudentProgressList } from "./student-progress-list";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
 
@@ -38,45 +39,66 @@ export async function StudentProgress() {
   const playlists = author.created_playlists;
   if (!playlists) return null;
 
-  const playlistsWithProgress = await Promise.all(
-    playlists.map(async (playlist) => {
-      const usersWithProgress = await Promise.all(
-        (playlist.authorized_users || []).map(async (user: AuthorizedUser) => {
-          const enrollments = await getCachedEnrollmentsWithLessonIds(user.id);
-          const completedLessonIds = enrollments.flatMap(
-            (enrollment) =>
-              enrollment.viewedLessons?.map((lesson: Lesson) => lesson.id) ||
-              [],
-          );
-
-          const allLessonIds =
-            playlist.droplets?.flatMap(
-              (d) => d.lessons?.map((l: Lesson) => l.id) || [],
-            ) || [];
-
-          const progress =
-            allLessonIds.length > 0
-              ? Math.round(
-                  (completedLessonIds.filter((id) => allLessonIds.includes(id))
-                    .length /
-                    allLessonIds.length) *
-                    100,
-                )
-              : 0;
-
-          return {
-            ...user,
-            progress,
-          };
-        }),
-      );
-
-      return {
-        ...playlist,
-        authorized_users: usersWithProgress,
-      };
-    }),
+  // Collect all unique user IDs and droplet IDs across all playlists
+  const allUserIds = playlists.flatMap(
+    (p) => (p.authorized_users || []).map((u: AuthorizedUser) => u.id),
   );
+  const allDropletIds = playlists.flatMap(
+    (p) => (p.droplets || []).map((d) => d.id),
+  );
+  const uniqueUserIds = [...new Set(allUserIds)];
+  const uniqueDropletIds = [...new Set(allDropletIds)];
+
+  // 1-2 queries instead of N per user
+  const allEnrollments =
+    uniqueUserIds.length > 0 && uniqueDropletIds.length > 0
+      ? await getEnrollmentsForGroupMembers(uniqueUserIds, uniqueDropletIds, {
+          populate: {
+            ...ENROLLMENT_POPULATES.withLessonIds,
+            authorizedUser: { fields: ["id"] },
+          },
+          fields: ["id"],
+        })
+      : [];
+
+  // Build a map: userId -> set of completed lesson IDs
+  const completedByUser = new Map<number, Set<number>>();
+  for (const enrollment of allEnrollments) {
+    const userId = enrollment.authorizedUser?.id;
+    if (!userId) continue;
+    if (!completedByUser.has(userId)) {
+      completedByUser.set(userId, new Set());
+    }
+    const set = completedByUser.get(userId)!;
+    for (const lesson of enrollment.viewedLessons || []) {
+      set.add(lesson.id);
+    }
+  }
+
+  const playlistsWithProgress = playlists.map((playlist) => {
+    const allLessonIds =
+      playlist.droplets?.flatMap(
+        (d) => d.lessons?.map((l: Lesson) => l.id) || [],
+      ) || [];
+
+    const usersWithProgress = (playlist.authorized_users || []).map(
+      (u: AuthorizedUser) => {
+        const completed = completedByUser.get(u.id) || new Set();
+        const progress =
+          allLessonIds.length > 0
+            ? Math.round(
+                (allLessonIds.filter((id) => completed.has(id)).length /
+                  allLessonIds.length) *
+                  100,
+              )
+            : 0;
+
+        return { ...u, progress };
+      },
+    );
+
+    return { ...playlist, authorized_users: usersWithProgress };
+  });
 
   return (
     <div className="space-y-8">

--- a/frontend/components/admin/progress/student-progress.tsx
+++ b/frontend/components/admin/progress/student-progress.tsx
@@ -40,11 +40,11 @@ export async function StudentProgress() {
   if (!playlists) return null;
 
   // Collect all unique user IDs and droplet IDs across all playlists
-  const allUserIds = playlists.flatMap(
-    (p) => (p.authorized_users || []).map((u: AuthorizedUser) => u.id),
+  const allUserIds = playlists.flatMap((p) =>
+    (p.authorized_users || []).map((u: AuthorizedUser) => u.id),
   );
-  const allDropletIds = playlists.flatMap(
-    (p) => (p.droplets || []).map((d) => d.id),
+  const allDropletIds = playlists.flatMap((p) =>
+    (p.droplets || []).map((d) => d.id),
   );
   const uniqueUserIds = [...new Set(allUserIds)];
   const uniqueDropletIds = [...new Set(allDropletIds)];

--- a/frontend/lib/requests/enrollment.ts
+++ b/frontend/lib/requests/enrollment.ts
@@ -71,6 +71,17 @@ export async function getEnrollmentsByAuthorizedUser(
 export async function getEnrollmentsForGroupMembers(
   memberIds: number[],
   groupDropletIds: number[],
+  {
+    populate = {
+      droplet: {
+        populate: { lessons: { fields: ["id", "name", "slug"] } },
+        fields: ["id"],
+      },
+      viewedLessons: { fields: ["id", "name", "slug"] },
+      authorizedUser: { fields: ["id"] },
+    },
+    fields = ["id", "isComplete", "completionDate"],
+  }: { populate?: Record<string, any>; fields?: string[] } = {},
 ): Promise<Enrollment[]> {
   const path = `/enrollments`;
   const pageSize = 250;
@@ -85,17 +96,8 @@ export async function getEnrollmentsForGroupMembers(
           { droplet: { id: { $in: groupDropletIds } } },
         ],
       },
-      populate: {
-        droplet: {
-          populate: {
-            lessons: { fields: ["id", "name", "slug"] },
-          },
-          fields: ["id"],
-        },
-        viewedLessons: { fields: ["id", "name", "slug"] },
-        authorizedUser: { fields: ["id"] },
-      },
-      fields: ["id", "isComplete", "completionDate"],
+      populate,
+      fields,
       pagination: { page, pageSize },
     };
 


### PR DESCRIPTION
## Description

Made getEnrollmentsForGroupMembers accept an optional { populate, fields } parameter (defaults to existing behavior). Student progress now passes ENROLLMENT_POPULATES.withLessonIds to fetch only IDs instead of name/slug on lessons and viewedLessons.


## Motivation and Context

Student progress only needs IDs to calculate completion percentages. The previous hardcoded populate fetched name and slug on lessons/viewedLessons unnecessarily, increasing payload size.




## Checklist:


- [X] My code follows the code style of this project.
- [X] I have moved the ticket to "In Review"
- [X] I have added reviewers to this PR
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.