### PR TITLE
Batch notes and highlights queries on notes settings page to reduce 2N Strapi calls to 2                                                                                                                        

### DIFF
--- a/frontend/app/(general)/settings/notes/page.tsx
+++ b/frontend/app/(general)/settings/notes/page.tsx
@@ -2,8 +2,9 @@ import { Metadata } from "next";
 import { getCachedUser } from "@/lib/requests/cached";
 import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getNotesByDroplet } from "@/lib/requests/notes";
-import { getHighlightsByDroplet } from "@/lib/requests/highlights";
+import { getAllNotesByUser } from "@/lib/requests/notes";
+import { getAllHighlightsByUser } from "@/lib/requests/highlights";
+import { Note, Highlight } from "@/types";
 import { PDFDocument } from "pdf-lib";
 import { NoteSummary } from "@/components/droplets/lessons/note-taking/note-summary";
 import { NotesManager } from "@/components/droplets/notes-manager";
@@ -32,34 +33,48 @@ export default async function NotesPage() {
 
   const authUser = await getCachedUser(user.email);
 
-  const defined = <T,>(v: T | null | undefined): v is T => v != null;
+  // Build lessonId -> dropletId map from enrollments
+  const lessonToDroplet = new Map<number, number>();
+  for (const enrollment of enrollments) {
+    for (const lesson of enrollment.droplet.lessons || []) {
+      lessonToDroplet.set(lesson.id, enrollment.droplet.id);
+    }
+  }
 
-  const allNotes = (
-    await Promise.all(
-      enrollments.map(async (enrollment) => {
-        if (!enrollment) return null;
-        const dropletNotes = await getNotesByDroplet(
-          authUser.id,
-          enrollment.droplet.id,
-        );
-        const dropletHighlights = await getHighlightsByDroplet(
-          authUser.id,
-          enrollment.droplet.id,
-        );
+  const [allUserNotes, allUserHighlights] = await Promise.all([
+    getAllNotesByUser(authUser.id),
+    getAllHighlightsByUser(authUser.id),
+  ]);
 
-        return {
-          dropletId: enrollment.droplet.id,
-          notes: dropletNotes,
-          highlights: dropletHighlights.filter(
-            (highlight) =>
-              !dropletNotes.some(
-                (lesson) => lesson.highlight?.id === highlight.id,
-              ),
-          ),
-        };
-      }),
-    )
-  ).filter(defined);
+  // Group by droplet
+  const notesByDroplet = new Map<number, Note[]>();
+  for (const note of allUserNotes) {
+    const dropletId = lessonToDroplet.get(note.lesson?.id);
+    if (dropletId == null) continue;
+    if (!notesByDroplet.has(dropletId)) notesByDroplet.set(dropletId, []);
+    notesByDroplet.get(dropletId)!.push(note);
+  }
+
+  const highlightsByDroplet = new Map<number, Highlight[]>();
+  for (const hl of allUserHighlights) {
+    if (!hl.lesson?.id) continue;
+    const dropletId = lessonToDroplet.get(hl.lesson.id);
+    if (dropletId == null) continue;
+    if (!highlightsByDroplet.has(dropletId))
+      highlightsByDroplet.set(dropletId, []);
+    highlightsByDroplet.get(dropletId)!.push(hl);
+  }
+
+  // Build allNotes in the same shape as before
+  const allNotes = enrollments
+    .map((enrollment) => {
+      const notes = notesByDroplet.get(enrollment.droplet.id) || [];
+      const highlights = (
+        highlightsByDroplet.get(enrollment.droplet.id) || []
+      ).filter((hl) => !notes.some((n) => n.highlight?.id === hl.id));
+      return { dropletId: enrollment.droplet.id, notes, highlights };
+    })
+    .filter((d) => d.notes.length > 0 || d.highlights.length > 0);
 
   const pdfDoc = await PDFDocument.create();
 

--- a/frontend/lib/requests/highlights.ts
+++ b/frontend/lib/requests/highlights.ts
@@ -81,6 +81,41 @@ export async function getHighlightsByDroplet(
   });
 }
 
+export async function getAllHighlightsByUser(
+  authorizedUserId: number,
+): Promise<Highlight[]> {
+  const path = `/highlights`;
+  const pageSize = 250;
+  let page = 1;
+  let allHighlights: Highlight[] = [];
+
+  while (true) {
+    const urlParams = {
+      sort: ["yLevel:asc"],
+      filters: {
+        authorized_user: { id: { $eq: authorizedUserId } },
+      },
+      populate: {
+        lesson: { fields: ["id", "name", "slug"] },
+      },
+      fields: ["text", "color", "yLevel"],
+      pagination: { page, pageSize },
+    };
+
+    const highlightsPage = await fetchAPI<Highlight[]>(path, {
+      urlParams,
+      next: { tags: [CACHE_TAGS.highlights(authorizedUserId)] },
+    });
+
+    if (!highlightsPage || highlightsPage.length === 0) break;
+    allHighlights = allHighlights.concat(highlightsPage);
+    if (highlightsPage.length < pageSize) break;
+    page++;
+  }
+
+  return allHighlights;
+}
+
 export async function deleteHighlight(id: number, authorizedUserId: number) {
   const response = await fetch(`${STRAPI_API_URL}/api/highlights/${id}`, {
     method: "DELETE",

--- a/frontend/lib/requests/notes.ts
+++ b/frontend/lib/requests/notes.ts
@@ -202,6 +202,41 @@ export async function createNote(
   }
 }
 
+export async function getAllNotesByUser(
+  authorizedUserId: number,
+): Promise<Note[]> {
+  const path = `/notes`;
+  const pageSize = 250;
+  let page = 1;
+  let allNotes: Note[] = [];
+
+  while (true) {
+    const urlParams = {
+      filters: {
+        enrollment: { authorizedUser: { id: { $eq: authorizedUserId } } },
+      },
+      populate: {
+        highlight: { fields: ["text", "color", "yLevel"] },
+        lesson: { fields: ["id", "name", "slug"] },
+      },
+      fields: ["id", "content", "positionY"],
+      pagination: { page, pageSize },
+    };
+
+    const notesPage = await fetchAPI<Note[]>(path, {
+      urlParams,
+      next: { tags: [CACHE_TAGS.notes(authorizedUserId)] },
+    });
+
+    if (!notesPage || notesPage.length === 0) break;
+    allNotes = allNotes.concat(notesPage);
+    if (notesPage.length < pageSize) break;
+    page++;
+  }
+
+  return allNotes;
+}
+
 export async function deleteNote(id: number, authorizedUserId: number) {
   try {
     const response = await fetch(


### PR DESCRIPTION
## Description

A user with 50 enrollments was causing 100 separate database calls (2 per enrollment). Now it makes just 2 calls total and sorts the results in code.      
## Motivation and Context

A user with N enrollments triggered 2N Strapi queries on the notes settings page. This reduces it to 2 total queries regardless of enrollment count.



## Checklist:


- [X] My code follows the code style of this project.
- [X] I have moved the ticket to "In Review"
- [X] I have added reviewers to this PR
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.