### PR TITLE
Improvement/ody 335 admin loading issues

### DIFF
--- a/frontend/app/(general)/admin/loading.tsx
+++ b/frontend/app/(general)/admin/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/components/ui/page-spinner";

--- a/frontend/app/(general)/admin/page.tsx
+++ b/frontend/app/(general)/admin/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { AccessManager } from "@/components/shared/access-manager/access-manager";
 import { Reports } from "@/components/admin/reports/reports";
 import { AdminSelector } from "@/components/shared/selector";
@@ -24,9 +25,20 @@ import { StatisticsSelector } from "@/components/admin/statistics-selector";
 import { WeeklyActiveUsersChart } from "@/components/admin/weekly-active-users-chart";
 import { UniquePageviewChart } from "@/components/admin/unique-pageview";
 import { CreationRequestManager } from "@/components/shared/creation-request-manager/creation-manager";
+import { Loader2 } from "lucide-react";
+
+function TabFallback() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+    </div>
+  );
+}
 
 export default async function Page() {
   const user = await getCurrentUser();
+
+  if (!user || !isAuthorizedUserAdmin(user.roles)) return notFound();
 
   const [
     authorizedUsers,
@@ -47,17 +59,45 @@ export default async function Page() {
   const { retentionRate, totalEnrollments, incompleteEnrollments } =
     retentionData;
 
-  if (!user || !isAuthorizedUserAdmin(user.roles)) return notFound();
-
-  // Content for admin section
+  // Each tab is wrapped in Suspense so it streams independently.
+  // Async server components fetch their own data; the revalidate cache
+  // deduplicates any overlapping calls (e.g. fetchAuthorizedUsers, fetchDroplets).
   const pageContent = {
-    Users: <AuthorizedUsers />,
-    Droplets: <Droplets />,
-    Playlists: <Playlists />,
-    Groups: <Groups />,
-    "Access Manager": <AccessManager user={user} />,
-    "Creators Manager": <CreationRequestManager user={user} />,
-    Reports: <Reports />,
+    Users: (
+      <Suspense fallback={<TabFallback />}>
+        <AuthorizedUsers />
+      </Suspense>
+    ),
+    Droplets: (
+      <Suspense fallback={<TabFallback />}>
+        <Droplets />
+      </Suspense>
+    ),
+    Playlists: (
+      <Suspense fallback={<TabFallback />}>
+        <Playlists />
+      </Suspense>
+    ),
+    Groups: (
+      <Suspense fallback={<TabFallback />}>
+        <Groups />
+      </Suspense>
+    ),
+    "Access Manager": (
+      <Suspense fallback={<TabFallback />}>
+        <AccessManager user={user} />
+      </Suspense>
+    ),
+    "Creators Manager": (
+      <Suspense fallback={<TabFallback />}>
+        <CreationRequestManager user={user} />
+      </Suspense>
+    ),
+    Reports: (
+      <Suspense fallback={<TabFallback />}>
+        <Reports />
+      </Suspense>
+    ),
   };
 
   // Content for statistics section

--- a/frontend/app/(general)/faculty/page.tsx
+++ b/frontend/app/(general)/faculty/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { AccessManager } from "@/components/shared/access-manager/access-manager";
 import { AdminSelector } from "@/components/shared/selector";
 import { getCurrentUser } from "@/lib/auth/session";
@@ -8,10 +9,18 @@ import { Droplets } from "@/components/admin/droplets/droplets";
 import { Playlists } from "@/components/admin/playlists/playlists";
 import { Reports } from "@/components/admin/reports/reports";
 import { Groups } from "@/components/admin/groups/groups";
+import { Loader2 } from "lucide-react";
+
+function TabFallback() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+    </div>
+  );
+}
 
 export default async function Page() {
   const user = await getCurrentUser();
-  await new Promise((resolve) => setTimeout(resolve, 1000));
 
   if (!user || !isAuthorizedUserFaculty(user.roles)) return notFound();
 
@@ -25,12 +34,36 @@ export default async function Page() {
       {/* <Session /> */}
       <AdminSelector
         content={{
-          Users: <AuthorizedUsers />,
-          Droplets: <Droplets />,
-          Playlists: <Playlists />,
-          Groups: <Groups />,
-          "Access Manager": <AccessManager user={user} />,
-          Reports: <Reports />,
+          Users: (
+            <Suspense fallback={<TabFallback />}>
+              <AuthorizedUsers />
+            </Suspense>
+          ),
+          Droplets: (
+            <Suspense fallback={<TabFallback />}>
+              <Droplets />
+            </Suspense>
+          ),
+          Playlists: (
+            <Suspense fallback={<TabFallback />}>
+              <Playlists />
+            </Suspense>
+          ),
+          Groups: (
+            <Suspense fallback={<TabFallback />}>
+              <Groups />
+            </Suspense>
+          ),
+          "Access Manager": (
+            <Suspense fallback={<TabFallback />}>
+              <AccessManager user={user} />
+            </Suspense>
+          ),
+          Reports: (
+            <Suspense fallback={<TabFallback />}>
+              <Reports />
+            </Suspense>
+          ),
         }}
       />
     </div>

--- a/frontend/components/admin/statistics-selector.tsx
+++ b/frontend/components/admin/statistics-selector.tsx
@@ -1,27 +1,16 @@
 "use client";
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 
 // A component that displays a tab selector for different statistics views.
 // It takes a `content` prop, which is an object where keys are tab names and values are React nodes to display for each tab.
-// The selected tab is determined by the `statsTab` query parameter in the URL.
-// When a tab is clicked, it updates the URL with the corresponding `statsTab` value.
+// Uses local state for instant tab switching without server re-renders.
 export function StatisticsSelector({
   content,
 }: {
   content: Record<string, React.ReactNode>;
 }) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const currentTab = searchParams.get("statsTab") || "General Statistics";
-
-  // Function to create a new query string with the updated statsTab parameter
-  const createQueryString = (value: string) => {
-    const params = new URLSearchParams(searchParams);
-    params.set("statsTab", value);
-    return params.toString();
-  };
+  const [currentTab, setCurrentTab] = useState(Object.keys(content)[0]);
 
   return (
     <div>
@@ -36,9 +25,7 @@ export function StatisticsSelector({
                   ? "bg-slate-200 dark:text-black"
                   : "hover:bg-slate-100 dark:hover:text-black")
               }
-              onClick={() => {
-                router.push(`${pathname}?${createQueryString(key)}`);
-              }}
+              onClick={() => setCurrentTab(key)}
             >
               {key}
             </div>

--- a/frontend/components/shared/access-manager/access-requests/access-requests.tsx
+++ b/frontend/components/shared/access-manager/access-requests/access-requests.tsx
@@ -16,23 +16,19 @@ export function accessFilter(
   requests: AccessRequest[],
   users: AuthorizedUser[],
 ) {
+  const userEmails = new Set(
+    users.map((user) => user.email?.toLowerCase()?.trim()),
+  );
   return requests.filter(
-    (req) =>
-      !users.some(
-        (user) =>
-          user.firstName?.toLowerCase()?.trim() ===
-            req.givenName?.toLowerCase()?.trim() &&
-          user.lastName?.toLowerCase()?.trim() ===
-            req.familyName?.toLowerCase()?.trim() &&
-          user.email?.toLowerCase()?.trim() ===
-            req.email?.toLowerCase()?.trim(),
-      ),
+    (req) => !userEmails.has(req.email?.toLowerCase()?.trim()),
   );
 }
 
 export async function AccessRequests() {
-  const accessRequests = await fetchAccessRequests();
-  const authorizedUsers = await fetchAuthorizedUsers();
+  const [accessRequests, authorizedUsers] = await Promise.all([
+    fetchAccessRequests(),
+    fetchAuthorizedUsers(),
+  ]);
 
   const filteredRequests = accessFilter(accessRequests, authorizedUsers);
 

--- a/frontend/components/shared/selector.tsx
+++ b/frontend/components/shared/selector.tsx
@@ -1,27 +1,16 @@
 "use client";
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 
 // A component that displays a tab selector for different admin views.
 // It takes a `content` prop, which is an object where keys are tab names and values are React nodes to display for each tab.
-// The selected tab is determined by the `adminTab` query parameter in the URL.
-// When a tab is clicked, it updates the URL with the corresponding `adminTab` value.
+// Uses local state for instant tab switching without server re-renders.
 export function AdminSelector({
   content,
 }: {
   content: Record<string, React.ReactNode>;
 }) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const currentTab = searchParams.get("adminTab") || Object.keys(content)[0];
-
-  // Function to create a new query string with the updated adminTab parameter
-  const createQueryString = (value: string) => {
-    const params = new URLSearchParams(searchParams);
-    params.set("adminTab", value);
-    return params.toString();
-  };
+  const [currentTab, setCurrentTab] = useState(Object.keys(content)[0]);
 
   return (
     <div>
@@ -36,9 +25,7 @@ export function AdminSelector({
                   ? "bg-slate-200 dark:text-black"
                   : "hover:bg-slate-100 dark:hover:text-black")
               }
-              onClick={() => {
-                router.push(`${pathname}?${createQueryString(key)}`);
-              }}
+              onClick={() => setCurrentTab(key)}
             >
               {key}
             </div>

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -93,7 +93,7 @@ export async function fetchAuthorizedUsers(): Promise<AuthorizedUser[]> {
 
     while (true) {
       const query = qs.stringify({
-        sort: ["lastName"],
+        sort: ["id"],
         fields: [
           "id",
           "email",
@@ -119,7 +119,7 @@ export async function fetchAuthorizedUsers(): Promise<AuthorizedUser[]> {
         `${NEXT_PUBLIC_STRAPI_API_URL}/api/authorized-users?${query}`,
         {
           headers: { Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}` },
-          cache: "no-store",
+          next: { tags: [CACHE_TAGS.users], revalidate: 900 },
         },
       );
       const data = await response.json();
@@ -132,6 +132,14 @@ export async function fetchAuthorizedUsers(): Promise<AuthorizedUser[]> {
 
       page++; // fetch next page
     }
+
+    // Deduplicate by id in case of overlapping pages
+    const seen = new Set<number>();
+    allUsers = allUsers.filter((user) => {
+      if (seen.has(user.id)) return false;
+      seen.add(user.id);
+      return true;
+    });
 
     return allUsers;
   } catch (error) {

--- a/frontend/lib/requests/data.ts
+++ b/frontend/lib/requests/data.ts
@@ -15,7 +15,7 @@ export async function fetchDroplets() {
     let allDroplets: Droplet[] = [];
     while (true) {
       const query = qs.stringify({
-        sort: ["name"],
+        sort: ["id"],
         fields: ["id", "name", "type", "slug", "isHidden"],
         pagination: {
           pageSize,
@@ -52,7 +52,7 @@ export async function fetchGroups() {
     let allGroups: Group[] = [];
     while (true) {
       const query = qs.stringify({
-        sort: ["groupName:asc"],
+        sort: ["id"],
         fields: ["id", "groupName", "slug", "isArchived"],
         populate: {
           members: {
@@ -78,7 +78,7 @@ export async function fetchGroups() {
         `${NEXT_PUBLIC_STRAPI_API_URL}/api/groups?${query}`,
         {
           headers: { Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}` },
-          cache: "no-store",
+          next: { tags: [CACHE_TAGS.allGroups], revalidate: 900 },
         },
       );
 
@@ -110,7 +110,7 @@ export async function fetchAccessRequests() {
 
     while (true) {
       const query = qs.stringify({
-        sort: ["email"],
+        sort: ["id"],
         fields: [
           "id",
           "givenName",
@@ -128,7 +128,7 @@ export async function fetchAccessRequests() {
         NEXT_PUBLIC_STRAPI_API_URL + "/api/access-requests?" + query,
         {
           headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-          cache: "no-store",
+          next: { revalidate: 900 },
         },
       );
       const data = await response.json();
@@ -155,7 +155,7 @@ export async function fetchReports() {
 
     while (true) {
       const query = qs.stringify({
-        sort: "createdAt:desc",
+        sort: ["id:desc"],
         fields: "*",
         pagination: {
           pageSize,
@@ -166,7 +166,7 @@ export async function fetchReports() {
         NEXT_PUBLIC_STRAPI_API_URL + "/api/reports?" + query,
         {
           headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-          cache: "no-store",
+          next: { revalidate: 900 },
         },
       );
       const data = await response.json();

--- a/frontend/testing/requests/authorized-users.test.ts
+++ b/frontend/testing/requests/authorized-users.test.ts
@@ -43,6 +43,8 @@ jest.mock("next/cache", () => ({
 global.fetch = jest.fn();
 
 beforeEach(() => {
+  process.env.NEXT_PUBLIC_STRAPI_API_URL = "http://test-api-url";
+  process.env.STRAPI_ACCESS_TOKEN = "test-token";
   jest.spyOn(console, "error").mockImplementation(() => {});
   jest.spyOn(console, "warn").mockImplementation(() => {});
   mockGetRoleId.mockResolvedValue(1);
@@ -321,7 +323,7 @@ describe("Authorized User Tests", () => {
           headers: expect.objectContaining({
             Authorization: expect.stringContaining("Bearer"),
           }),
-          cache: "no-store",
+          next: { tags: ["users"], revalidate: 900 },
         }),
       );
 

--- a/frontend/testing/requests/requests.test.js
+++ b/frontend/testing/requests/requests.test.js
@@ -49,6 +49,8 @@ jest.mock("../../lib/utils", () => ({
 global.fetch = jest.fn();
 
 beforeEach(() => {
+  process.env.NEXT_PUBLIC_STRAPI_API_URL = "http://test-api-url";
+  process.env.STRAPI_ACCESS_TOKEN = "test-token";
   jest.spyOn(console, "error").mockImplementation(() => {});
   jest.spyOn(console, "warn").mockImplementation(() => {});
 });
@@ -189,13 +191,13 @@ describe("Data requests", () => {
           headers: expect.objectContaining({
             Authorization: expect.stringContaining("Bearer"),
           }),
-          cache: "no-store",
+          next: { tags: ["groups"], revalidate: 900 },
         }),
       );
 
       const callUrl = global.fetch.mock.calls[0][0];
 
-      expect(callUrl).toMatch(/sort%5B0%5D=groupName%3Aasc/);
+      expect(callUrl).toMatch(/sort%5B0%5D=id/);
 
       expect(callUrl).toMatch(
         /fields%5B0%5D=id&fields%5B1%5D=groupName&fields%5B2%5D=slug&fields%5B3%5D=isArchived/,
@@ -272,7 +274,7 @@ describe("Data requests", () => {
           headers: expect.objectContaining({
             Authorization: expect.stringContaining("Bearer"),
           }),
-          cache: "no-store",
+          next: { revalidate: 900 },
         }),
       );
     });

--- a/frontend/tests/components/admin/statistics-selector.test.tsx
+++ b/frontend/tests/components/admin/statistics-selector.test.tsx
@@ -118,9 +118,7 @@ describe("StatisticsSelector", () => {
     it("handles empty content object", () => {
       render(<StatisticsSelector content={{}} />);
 
-      expect(
-        screen.queryByText("General Statistics"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("General Statistics")).not.toBeInTheDocument();
     });
 
     it("handles single tab", () => {

--- a/frontend/tests/components/admin/statistics-selector.test.tsx
+++ b/frontend/tests/components/admin/statistics-selector.test.tsx
@@ -1,22 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { StatisticsSelector } from "@/components/admin/statistics-selector";
-import { useRouter, usePathname, useSearchParams } from "next/navigation";
-
-// Create a variable to track the current statsTab
-let currentStatsTab = "General Statistics";
-const mockPush = jest.fn((url) => {
-  const match = url.match(/statsTab=([^&]*)/);
-  if (match) {
-    currentStatsTab = decodeURIComponent(match[1]);
-  }
-});
-
-// Mock Next.js navigation hooks
-jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(),
-  usePathname: jest.fn(),
-  useSearchParams: jest.fn(),
-}));
 
 describe("StatisticsSelector", () => {
   const mockContent = {
@@ -24,21 +7,6 @@ describe("StatisticsSelector", () => {
     "Daily Active Users": <div>DAU Content</div>,
     "Weekly Active Users": <div>WAU Content</div>,
   };
-
-  beforeEach(() => {
-    currentStatsTab = "General Statistics";
-    mockPush.mockClear();
-
-    (useRouter as jest.Mock).mockReturnValue({
-      push: mockPush,
-    });
-
-    (usePathname as jest.Mock).mockReturnValue("/admin");
-
-    (useSearchParams as jest.Mock).mockReturnValue(
-      new URLSearchParams(currentStatsTab ? `statsTab=${currentStatsTab}` : ""),
-    );
-  });
 
   describe("Rendering", () => {
     it("renders all tabs", () => {
@@ -57,14 +25,10 @@ describe("StatisticsSelector", () => {
       expect(screen.queryByText("WAU Content")).not.toBeInTheDocument();
     });
 
-    it("renders correct content for current tab from URL", () => {
-      currentStatsTab = "Daily Active Users";
-
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams("statsTab=Daily Active Users"),
-      );
-
+    it("renders correct content when clicking a different tab", () => {
       render(<StatisticsSelector content={mockContent} />);
+
+      fireEvent.click(screen.getByText("Daily Active Users"));
 
       expect(screen.getByText("DAU Content")).toBeInTheDocument();
       expect(screen.queryByText("Stats Content")).not.toBeInTheDocument();
@@ -105,46 +69,48 @@ describe("StatisticsSelector", () => {
   });
 
   describe("Tab Navigation", () => {
-    it("updates URL when clicking on a different tab", () => {
+    it("switches content when clicking on a different tab", () => {
       render(<StatisticsSelector content={mockContent} />);
 
       fireEvent.click(screen.getByText("Daily Active Users"));
 
-      expect(mockPush).toHaveBeenCalledWith(
-        "/admin?statsTab=Daily+Active+Users",
-      );
+      expect(screen.getByText("DAU Content")).toBeInTheDocument();
+      expect(screen.queryByText("Stats Content")).not.toBeInTheDocument();
     });
 
-    it("updates URL when clicking on another tab", () => {
+    it("switches content when clicking on another tab", () => {
       render(<StatisticsSelector content={mockContent} />);
 
       fireEvent.click(screen.getByText("Weekly Active Users"));
 
-      expect(mockPush).toHaveBeenCalledWith(
-        "/admin?statsTab=Weekly+Active+Users",
-      );
+      expect(screen.getByText("WAU Content")).toBeInTheDocument();
+      expect(screen.queryByText("Stats Content")).not.toBeInTheDocument();
     });
 
-    it("preserves pathname when updating statsTab", () => {
-      (usePathname as jest.Mock).mockReturnValue("/admin/dashboard");
-
+    it("updates selected tab styling on click", () => {
       render(<StatisticsSelector content={mockContent} />);
 
       fireEvent.click(screen.getByText("Daily Active Users"));
 
-      expect(mockPush).toHaveBeenCalledWith(
-        expect.stringContaining("/admin/dashboard"),
+      expect(screen.getByText("Daily Active Users")).toHaveClass(
+        "bg-slate-200",
+      );
+      expect(screen.getByText("General Statistics")).not.toHaveClass(
+        "bg-slate-200",
       );
     });
 
-    it("creates query string correctly", () => {
+    it("can navigate through all tabs", () => {
       render(<StatisticsSelector content={mockContent} />);
 
       fireEvent.click(screen.getByText("Daily Active Users"));
+      expect(screen.getByText("DAU Content")).toBeInTheDocument();
 
-      expect(mockPush).toHaveBeenCalledWith(
-        expect.stringContaining("statsTab="),
-      );
+      fireEvent.click(screen.getByText("Weekly Active Users"));
+      expect(screen.getByText("WAU Content")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("General Statistics"));
+      expect(screen.getByText("Stats Content")).toBeInTheDocument();
     });
   });
 
@@ -152,8 +118,9 @@ describe("StatisticsSelector", () => {
     it("handles empty content object", () => {
       render(<StatisticsSelector content={{}} />);
 
-      // Should render without crashing
-      expect(screen.queryByText("General Statistics")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("General Statistics"),
+      ).not.toBeInTheDocument();
     });
 
     it("handles single tab", () => {
@@ -161,26 +128,10 @@ describe("StatisticsSelector", () => {
         "Only Tab": <div>Single Content</div>,
       };
 
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams("statsTab=Only Tab"),
-      );
-
       render(<StatisticsSelector content={singleTabContent} />);
 
       expect(screen.getByText("Only Tab")).toBeInTheDocument();
       expect(screen.getByText("Single Content")).toBeInTheDocument();
-    });
-
-    it("defaults to first tab when statsTab param is invalid", () => {
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams("statsTab=Invalid Tab Name"),
-      );
-
-      render(<StatisticsSelector content={mockContent} />);
-
-      // Should show nothing since invalid tab doesn't exist
-      expect(screen.queryByText("Stats Content")).not.toBeInTheDocument();
-      expect(screen.queryByText("DAU Content")).not.toBeInTheDocument();
     });
 
     it("handles tabs with special characters in names", () => {
@@ -190,27 +141,18 @@ describe("StatisticsSelector", () => {
 
       render(<StatisticsSelector content={specialContent} />);
 
-      fireEvent.click(screen.getByText("Tab & Special"));
-
-      expect(mockPush).toHaveBeenCalledWith(
-        expect.stringContaining("Tab+%26+Special"),
-      );
+      expect(screen.getByText("Tab & Special")).toBeInTheDocument();
+      expect(screen.getByText("Special Content")).toBeInTheDocument();
     });
   });
 
   describe("Multiple Renders", () => {
     it("updates content when tab changes", () => {
-      const { rerender } = render(<StatisticsSelector content={mockContent} />);
+      render(<StatisticsSelector content={mockContent} />);
 
       expect(screen.getByText("Stats Content")).toBeInTheDocument();
 
-      // Simulate tab change by updating the mock
-      currentStatsTab = "Daily Active Users";
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams("statsTab=Daily Active Users"),
-      );
-
-      rerender(<StatisticsSelector content={mockContent} />);
+      fireEvent.click(screen.getByText("Daily Active Users"));
 
       expect(screen.getByText("DAU Content")).toBeInTheDocument();
       expect(screen.queryByText("Stats Content")).not.toBeInTheDocument();

--- a/frontend/tests/components/shared/selector.test.tsx
+++ b/frontend/tests/components/shared/selector.test.tsx
@@ -1,17 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AdminSelector } from "@/components/shared/selector";
-import { useRouter, usePathname, useSearchParams } from "next/navigation";
-
-// Mock Next.js navigation hooks
-const mockPush = jest.fn();
-let mockSearchParamsValue: string | null = null;
-
-jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(),
-  usePathname: jest.fn(),
-  useSearchParams: jest.fn(),
-}));
 
 describe("AdminSelector", () => {
   const mockContent = {
@@ -19,23 +8,6 @@ describe("AdminSelector", () => {
     "Tab 2": <div>Content 2</div>,
     "Tab 3": <div>Content 3</div>,
   };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockSearchParamsValue = null;
-
-    (useRouter as jest.Mock).mockReturnValue({
-      push: mockPush,
-    });
-
-    (usePathname as jest.Mock).mockReturnValue("/admin");
-
-    (useSearchParams as jest.Mock).mockReturnValue(
-      new URLSearchParams(
-        mockSearchParamsValue ? `adminTab=${mockSearchParamsValue}` : "",
-      ),
-    );
-  });
 
   describe("Rendering", () => {
     it("renders all tabs from content object", () => {
@@ -62,24 +34,11 @@ describe("AdminSelector", () => {
       expect(tabs[2]).toHaveTextContent("Tab 3");
     });
 
-    it("shows first tab content by default when no adminTab param", () => {
+    it("shows first tab content by default", () => {
       render(<AdminSelector content={mockContent} />);
 
       expect(screen.getByText("Content 1")).toBeInTheDocument();
       expect(screen.queryByText("Content 2")).not.toBeInTheDocument();
-      expect(screen.queryByText("Content 3")).not.toBeInTheDocument();
-    });
-
-    it("renders content based on adminTab query parameter", () => {
-      mockSearchParamsValue = "Tab 2";
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams(`adminTab=${mockSearchParamsValue}`),
-      );
-
-      render(<AdminSelector content={mockContent} />);
-
-      expect(screen.getByText("Content 2")).toBeInTheDocument();
-      expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
       expect(screen.queryByText("Content 3")).not.toBeInTheDocument();
     });
 
@@ -170,13 +129,10 @@ describe("AdminSelector", () => {
       expect(tabContainer).toBeInTheDocument();
     });
 
-    it("updates selected tab styling when adminTab changes", () => {
-      mockSearchParamsValue = "Tab 2";
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams(`adminTab=${mockSearchParamsValue}`),
-      );
-
+    it("updates selected tab styling when clicking a different tab", () => {
       render(<AdminSelector content={mockContent} />);
+
+      fireEvent.click(screen.getByText("Tab 2"));
 
       const tab1 = screen.getByText("Tab 1");
       const tab2 = screen.getByText("Tab 2");
@@ -191,20 +147,20 @@ describe("AdminSelector", () => {
       const user = userEvent.setup();
       render(<AdminSelector content={mockContent} />);
 
-      const tab2 = screen.getByText("Tab 2");
-      await user.click(tab2);
+      await user.click(screen.getByText("Tab 2"));
 
-      expect(mockPush).toHaveBeenCalledWith("/admin?adminTab=Tab+2");
+      expect(screen.getByText("Content 2")).toBeInTheDocument();
+      expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
     });
 
-    it("updates URL with correct adminTab parameter on click", async () => {
+    it("switches content on click", async () => {
       const user = userEvent.setup();
       render(<AdminSelector content={mockContent} />);
 
-      const tab3 = screen.getByText("Tab 3");
-      await user.click(tab3);
+      await user.click(screen.getByText("Tab 3"));
 
-      expect(mockPush).toHaveBeenCalledWith("/admin?adminTab=Tab+3");
+      expect(screen.getByText("Content 3")).toBeInTheDocument();
+      expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
     });
 
     it("handles multiple tab clicks", async () => {
@@ -212,59 +168,38 @@ describe("AdminSelector", () => {
       render(<AdminSelector content={mockContent} />);
 
       await user.click(screen.getByText("Tab 2"));
-      await user.click(screen.getByText("Tab 3"));
-      await user.click(screen.getByText("Tab 1"));
+      expect(screen.getByText("Content 2")).toBeInTheDocument();
 
-      expect(mockPush).toHaveBeenCalledTimes(3);
-      expect(mockPush).toHaveBeenNthCalledWith(1, "/admin?adminTab=Tab+2");
-      expect(mockPush).toHaveBeenNthCalledWith(2, "/admin?adminTab=Tab+3");
-      expect(mockPush).toHaveBeenNthCalledWith(3, "/admin?adminTab=Tab+1");
+      await user.click(screen.getByText("Tab 3"));
+      expect(screen.getByText("Content 3")).toBeInTheDocument();
+
+      await user.click(screen.getByText("Tab 1"));
+      expect(screen.getByText("Content 1")).toBeInTheDocument();
     });
 
     it("navigates using fireEvent click", () => {
       render(<AdminSelector content={mockContent} />);
 
-      const tab2 = screen.getByText("Tab 2");
-      fireEvent.click(tab2);
+      fireEvent.click(screen.getByText("Tab 2"));
 
-      expect(mockPush).toHaveBeenCalledWith("/admin?adminTab=Tab+2");
-    });
-
-    it("preserves existing query parameters when navigating", () => {
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams("otherParam=value"),
-      );
-
-      render(<AdminSelector content={mockContent} />);
-
-      const tab2 = screen.getByText("Tab 2");
-      fireEvent.click(tab2);
-
-      const calledUrl = mockPush.mock.calls[0][0];
-      expect(calledUrl).toContain("adminTab=Tab+2");
-      expect(calledUrl).toContain("otherParam=value");
+      expect(screen.getByText("Content 2")).toBeInTheDocument();
+      expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
     });
 
     it("uses correct pathname in navigation", () => {
-      (usePathname as jest.Mock).mockReturnValue("/different/path");
-
       render(<AdminSelector content={mockContent} />);
 
-      const tab2 = screen.getByText("Tab 2");
-      fireEvent.click(tab2);
+      fireEvent.click(screen.getByText("Tab 2"));
 
-      expect(mockPush).toHaveBeenCalledWith("/different/path?adminTab=Tab+2");
+      expect(screen.getByText("Content 2")).toBeInTheDocument();
     });
   });
 
   describe("Content Display", () => {
     it("displays only the selected tab content", () => {
-      mockSearchParamsValue = "Tab 2";
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams(`adminTab=${mockSearchParamsValue}`),
-      );
-
       render(<AdminSelector content={mockContent} />);
+
+      fireEvent.click(screen.getByText("Tab 2"));
 
       expect(screen.getByText("Content 2")).toBeInTheDocument();
       expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
@@ -273,32 +208,13 @@ describe("AdminSelector", () => {
 
     it("switches content when tab is clicked", async () => {
       const user = userEvent.setup();
-      const { rerender } = render(<AdminSelector content={mockContent} />);
+      render(<AdminSelector content={mockContent} />);
 
       expect(screen.getByText("Content 1")).toBeInTheDocument();
 
-      // Simulate clicking Tab 2 and updating state
       await user.click(screen.getByText("Tab 2"));
-      mockSearchParamsValue = "Tab 2";
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams(`adminTab=${mockSearchParamsValue}`),
-      );
-
-      rerender(<AdminSelector content={mockContent} />);
 
       expect(screen.getByText("Content 2")).toBeInTheDocument();
-      expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
-    });
-
-    it("falls back to first tab when adminTab param is invalid", () => {
-      mockSearchParamsValue = "Invalid Tab";
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams(`adminTab=${mockSearchParamsValue}`),
-      );
-
-      render(<AdminSelector content={mockContent} />);
-
-      // Should show nothing or undefined content for invalid tab
       expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
     });
 
@@ -335,7 +251,7 @@ describe("AdminSelector", () => {
       expect(screen.getByText("Tab #2")).toBeInTheDocument();
     });
 
-    it("URL encodes tab names with spaces when navigating", async () => {
+    it("switches to tab with spaces when clicked", async () => {
       const user = userEvent.setup();
       const contentWithSpaces = {
         "Tab One": <div>Content One</div>,
@@ -346,12 +262,10 @@ describe("AdminSelector", () => {
 
       await user.click(screen.getByText("Tab With Spaces"));
 
-      const calledUrl = mockPush.mock.calls[0][0];
-      expect(calledUrl).toContain("adminTab=Tab");
-      expect(calledUrl).toContain("Spaces");
+      expect(screen.getByText("Spaced Content")).toBeInTheDocument();
     });
 
-    it("URL encodes tab names with special characters when navigating", async () => {
+    it("switches to tab with special characters when clicked", async () => {
       const user = userEvent.setup();
       const contentWithSpecialChars = {
         "Tab #1": <div>Content</div>,
@@ -362,8 +276,7 @@ describe("AdminSelector", () => {
 
       await user.click(screen.getByText("Tab & More"));
 
-      const calledUrl = mockPush.mock.calls[0][0];
-      expect(calledUrl).toContain("adminTab=");
+      expect(screen.getByText("More Content")).toBeInTheDocument();
     });
   });
 
@@ -372,22 +285,20 @@ describe("AdminSelector", () => {
       const user = userEvent.setup();
       render(<AdminSelector content={mockContent} />);
 
-      const tab1 = screen.getByText("Tab 1");
-      await user.click(tab1);
+      await user.click(screen.getByText("Tab 1"));
 
-      expect(mockPush).toHaveBeenCalledWith("/admin?adminTab=Tab+1");
+      expect(screen.getByText("Content 1")).toBeInTheDocument();
     });
 
     it("handles rapid successive clicks", async () => {
       const user = userEvent.setup();
       render(<AdminSelector content={mockContent} />);
 
-      const tab2 = screen.getByText("Tab 2");
-      await user.click(tab2);
-      await user.click(tab2);
-      await user.click(tab2);
+      await user.click(screen.getByText("Tab 2"));
+      await user.click(screen.getByText("Tab 3"));
+      await user.click(screen.getByText("Tab 1"));
 
-      expect(mockPush).toHaveBeenCalledTimes(3);
+      expect(screen.getByText("Content 1")).toBeInTheDocument();
     });
 
     it("handles empty content object gracefully", () => {
@@ -395,19 +306,7 @@ describe("AdminSelector", () => {
 
       render(<AdminSelector content={emptyContent} />);
 
-      // Should render without crashing
       expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
-    });
-
-    it("renders when pathname is root", () => {
-      (usePathname as jest.Mock).mockReturnValue("/");
-
-      render(<AdminSelector content={mockContent} />);
-
-      const tab2 = screen.getByText("Tab 2");
-      fireEvent.click(tab2);
-
-      expect(mockPush).toHaveBeenCalledWith("/?adminTab=Tab+2");
     });
 
     it("handles null content in tab", () => {
@@ -427,21 +326,15 @@ describe("AdminSelector", () => {
 
       const tab1 = screen.getByText("Tab 1");
       expect(tab1).toBeInTheDocument();
-
-      // Tabs should be clickable elements with cursor-pointer class
       expect(tab1).toHaveClass("cursor-pointer");
     });
 
     it("content area updates when tab changes", () => {
-      const { rerender } = render(<AdminSelector content={mockContent} />);
+      render(<AdminSelector content={mockContent} />);
 
       expect(screen.getByText("Content 1")).toBeInTheDocument();
 
-      mockSearchParamsValue = "Tab 3";
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams(`adminTab=${mockSearchParamsValue}`),
-      );
-      rerender(<AdminSelector content={mockContent} />);
+      fireEvent.click(screen.getByText("Tab 3"));
 
       expect(screen.getByText("Content 3")).toBeInTheDocument();
     });
@@ -450,11 +343,9 @@ describe("AdminSelector", () => {
       const user = userEvent.setup();
       render(<AdminSelector content={mockContent} />);
 
-      const tab2 = screen.getByText("Tab 2");
-      await user.click(tab2);
+      await user.click(screen.getByText("Tab 2"));
 
-      // Verify navigation was triggered
-      expect(mockPush).toHaveBeenCalled();
+      expect(screen.getByText("Content 2")).toBeInTheDocument();
     });
   });
 
@@ -470,7 +361,7 @@ describe("AdminSelector", () => {
         "Set 2 Tab 2": <div>Set 2 Content 2</div>,
       };
 
-      const { container } = render(
+      render(
         <>
           <AdminSelector content={content1} />
           <AdminSelector content={content2} />
@@ -485,28 +376,21 @@ describe("AdminSelector", () => {
   });
 
   describe("Query String Creation", () => {
-    it("creates query string with adminTab parameter", () => {
+    it("clicking tab updates displayed content", () => {
       render(<AdminSelector content={mockContent} />);
 
       fireEvent.click(screen.getByText("Tab 2"));
 
-      expect(mockPush).toHaveBeenCalledWith(
-        expect.stringContaining("adminTab=Tab"),
-      );
+      expect(screen.getByText("Content 2")).toBeInTheDocument();
     });
 
-    it("preserves other search parameters", () => {
-      (useSearchParams as jest.Mock).mockReturnValue(
-        new URLSearchParams("other=value"),
-      );
-
+    it("clicking tab switches away from previous content", () => {
       render(<AdminSelector content={mockContent} />);
 
       fireEvent.click(screen.getByText("Tab 2"));
 
-      const calledUrl = mockPush.mock.calls[0][0];
-      expect(calledUrl).toContain("adminTab=Tab");
-      expect(calledUrl).toContain("other=value");
+      expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
+      expect(screen.getByText("Content 2")).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Description
Tab navigation on the admin dashboard was really slow because every tab click was doing a full server re-render and re fetching all data for every tab. Switched to useState for tab state so switching is instant. Wrapped each tab in <Suspense> so the page loads progressively instead of blocking on everything. Also added caching to the paginated fetches that were using no-store, and fixed the duplicate key warnings by sorting pagination by id instead of non-unique fields. 

## Motivation and Context
Admin page was painfully slow to navigate and load. No loading feedback, duplicate key console errors, and every tab click hammered the backend with redundant API calls.





## Checklist:


- [X] My code follows the code style of this project.
- [X] I have moved the ticket to "In Review"
- [X] I have added reviewers to this PR
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.