### PR TITLE
Improve admin performance: add cache tags, parallelize writes, fix revalidation

### DIFF
--- a/frontend/app/(general)/settings/notes/page.tsx
+++ b/frontend/app/(general)/settings/notes/page.tsx
@@ -62,25 +62,30 @@ export default async function NotesPage() {
     highlightsByDroplet.get(dropletId)!.push(hl);
   }
 
-  // Build allNotes in the same shape as before
-  const allNotes = enrollments
-    .map((enrollment) => {
-      const notes = notesByDroplet.get(enrollment.droplet.id) || [];
-      const highlights = (
-        highlightsByDroplet.get(enrollment.droplet.id) || []
-      ).filter((hl) => !notes.some((n) => n.highlight?.id === hl.id));
-      return { dropletId: enrollment.droplet.id, notes, highlights };
-    })
-    .filter((d) => d.notes.length > 0 || d.highlights.length > 0);
+  // Build per-enrollment note/highlight data (keep all entries so indices align)
+  const allNotesUnfiltered = enrollments.map((enrollment) => {
+    const notes = notesByDroplet.get(enrollment.droplet.id) || [];
+    const highlights = (
+      highlightsByDroplet.get(enrollment.droplet.id) || []
+    ).filter((hl) => !notes.some((n) => n.highlight?.id === hl.id));
+    return { dropletId: enrollment.droplet.id, notes, highlights };
+  });
+
+  // Filtered version for the UI (only droplets with content)
+  const allNotes = allNotesUnfiltered.filter(
+    (d) => d.notes.length > 0 || d.highlights.length > 0,
+  );
 
   const pdfDoc = await PDFDocument.create();
 
   for (let i = 0; i < enrollments.length; i++) {
     const enrollment = enrollments[i];
-    const dropletData = allNotes[i];
+    const dropletData = allNotesUnfiltered[i];
+    if (dropletData.notes.length === 0 && dropletData.highlights.length === 0)
+      continue;
     const sectionPdfBytes = await NoteSummary({
-      filteredHighlights: dropletData?.highlights || [],
-      notes: dropletData?.notes || [],
+      filteredHighlights: dropletData.highlights,
+      notes: dropletData.notes,
       droplet: enrollment.droplet,
     });
 

--- a/frontend/lib/actions.ts
+++ b/frontend/lib/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 import { accessRequestSchema } from "./validations/access-request";
@@ -17,6 +17,7 @@ import { createAuthorizedUser } from "./requests/authorized-user";
 import { creationRequestSchema } from "./validations/creation-request";
 import qs from "qs";
 import { flattenAttributes } from "@/lib/utils";
+import { CACHE_TAGS } from "./cache-tags";
 
 const STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -135,7 +136,7 @@ export async function deleteReport(id: string) {
     return { error: "Failed to delete report" };
   }
 
-  revalidatePath("/admin?adminTab=Reports");
+  revalidateTag(CACHE_TAGS.reports);
   return { success: true };
 }
 
@@ -217,7 +218,7 @@ export async function deleteAccessRequest(formData: FormData) {
     return { error: "Database Error: Failed to delete access request." };
   }
 
-  revalidatePath("/admin");
+  revalidateTag(CACHE_TAGS.accessRequests);
 }
 
 /**
@@ -372,7 +373,8 @@ export async function approveCreationRequest(
       };
     }
 
-    revalidatePath("/admin");
+    revalidateTag(CACHE_TAGS.users);
+    revalidateTag(CACHE_TAGS.creationRequests);
     return { ok: true, error: null, data: null };
   } catch (err) {
     console.error(err);
@@ -408,7 +410,7 @@ export async function deleteCreationRequest(requestId: string) {
       };
     }
 
-    revalidatePath("/admin");
+    revalidateTag(CACHE_TAGS.creationRequests);
     return { ok: true, error: null, data: null };
   } catch (err) {
     console.error(err);
@@ -448,7 +450,7 @@ export async function fetchCreationRequests(): Promise<CreationRequest[]> {
           headers: {
             Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}`,
           },
-          cache: "no-store",
+          next: { tags: [CACHE_TAGS.creationRequests], revalidate: 900 },
         },
       );
 
@@ -504,7 +506,7 @@ export async function fetchCreationRequestByUser(
         headers: {
           Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}`,
         },
-        cache: "no-store",
+        next: { tags: [CACHE_TAGS.creationRequests], revalidate: 900 },
       },
     );
 

--- a/frontend/lib/cache-tags.ts
+++ b/frontend/lib/cache-tags.ts
@@ -51,6 +51,9 @@ export const CACHE_TAGS = {
   lesson: "lesson",
   announcements: "announcements",
   tags: "tags",
+  reports: "reports",
+  accessRequests: "access-requests",
+  creationRequests: "creation-requests",
   allGroups: "groups", // all group queries (getManagedGroups, getGroupBySlug, getGroupByID, getUserGroups, getGroupBySlugV2, fetchAnnouncements)
   allDueDates: "due-dates", // all due date queries (getGroupDueDates, getUserDueDates)
   allEnrollments: "enrollments", // global sweep for content mutations (updateDroplet, addLesson, etc.)

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -2,7 +2,7 @@
 import { fetchAPI, flattenAttributes } from "@/lib/utils";
 import { AuthorizedUser } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import qs from "qs";
 import { AuthorizedUserSchema } from "../validations/authorized-user";
 import { getAuthorizedUserRoleIdByTitle } from "./authorized-user-roles";
@@ -78,6 +78,7 @@ export async function getAuthorizedUsersByEmails(
           fields: ["id", "email"],
           pagination: { pageSize: PAGE_SIZE, page: 1 },
         },
+        next: { tags: [CACHE_TAGS.users], revalidate: 900 },
       }),
     ),
   );
@@ -161,6 +162,7 @@ export async function searchAuthorizedUsers(query: string) {
       fields: ["id", "email", "firstName", "lastName", "profilePhoto"],
       pagination: { pageSize: 20, page: 1 },
     },
+    next: { tags: [CACHE_TAGS.users], revalidate: 900 },
   });
 }
 
@@ -204,7 +206,7 @@ export async function fetchAuthorizedUsersMetadata({
       };
     }>(path, {
       urlParams,
-      cache: "no-store",
+      next: { tags: [CACHE_TAGS.users], revalidate: 900 },
       flattenResponse: false,
     });
 
@@ -366,7 +368,7 @@ export async function fetchIsAuthorizedUser(email: string) {
       NEXT_PUBLIC_STRAPI_API_URL + "/api/authorized-users?" + query,
       {
         headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-        cache: "no-store",
+        next: { tags: [CACHE_TAGS.users], revalidate: 900 },
       },
     );
     const data = await response.json();
@@ -381,12 +383,13 @@ export async function fetchIsAuthorizedUser(email: string) {
 const CreateAuthorizedUser = AuthorizedUserSchema.omit({
   id: true,
 });
-export async function createAuthorizedUser(formData: FormData) {
-  // Determine which parameter is the FormData
-
-  const roleID = await getAuthorizedUserRoleIdByTitle(
-    AuthorizedUserRoleTitle.User,
-  );
+export async function createAuthorizedUser(
+  formData: FormData,
+  roleID?: number,
+) {
+  if (roleID === undefined) {
+    roleID = await getAuthorizedUserRoleIdByTitle(AuthorizedUserRoleTitle.User);
+  }
 
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!formData.get("email")) {
@@ -431,7 +434,7 @@ export async function createAuthorizedUser(formData: FormData) {
     return { error: "Database Error: Failed to Create Authorized User." };
   }
 
-  revalidatePath("/admin");
+  revalidateTag(CACHE_TAGS.users);
   return { message: `User ${email} created!`, ok: true };
 }
 
@@ -489,7 +492,7 @@ export async function createBatchAuthorizedUsers(emails: string[]) {
 
     await Promise.all(createUserPromises);
 
-    revalidatePath("/admin");
+    revalidateTag(CACHE_TAGS.users);
     return {
       ok: true,
       data: results,
@@ -574,7 +577,6 @@ export async function updateUserInfo(
       },
     );
     revalidateTag(CACHE_TAGS.users);
-    revalidatePath("/admin");
     return { success: true };
   } catch (error) {
     console.error("Error updating user info:", error);
@@ -610,7 +612,7 @@ export async function deleteAuthorizedUser(formData: FormData) {
     return { error: "Database Error: Failed to Delete Authorized User." };
   }
 
-  revalidatePath("/admin");
+  revalidateTag(CACHE_TAGS.users);
 }
 
 // fetching content editors
@@ -633,7 +635,9 @@ export async function fetchContentEditors(): Promise<AuthorizedUser[]> {
     },
   });
 
-  const response = await fetch(`/api/authorized-users?${query}`);
+  const response = await fetch(`/api/authorized-users?${query}`, {
+    next: { tags: [CACHE_TAGS.authors], revalidate: 3600 },
+  });
 
   // finally got response, so handle it
   if (!response.ok) {

--- a/frontend/lib/requests/data.ts
+++ b/frontend/lib/requests/data.ts
@@ -128,7 +128,7 @@ export async function fetchAccessRequests() {
         NEXT_PUBLIC_STRAPI_API_URL + "/api/access-requests?" + query,
         {
           headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-          next: { revalidate: 900 },
+          next: { tags: [CACHE_TAGS.accessRequests], revalidate: 900 },
         },
       );
       const data = await response.json();
@@ -166,7 +166,7 @@ export async function fetchReports() {
         NEXT_PUBLIC_STRAPI_API_URL + "/api/reports?" + query,
         {
           headers: { Authorization: "Bearer " + STRAPI_ACCESS_TOKEN },
-          next: { revalidate: 900 },
+          next: { tags: [CACHE_TAGS.reports], revalidate: 900 },
         },
       );
       const data = await response.json();

--- a/frontend/lib/requests/droplet.ts
+++ b/frontend/lib/requests/droplet.ts
@@ -788,68 +788,73 @@ export async function duplicateDroplet(dropletId: number) {
         (a, b) => a.orderIndex - b.orderIndex,
       );
 
-      for (let index = 0; index < sortedLessons.length; index++) {
-        const lesson = sortedLessons[index];
-        const lessonTimestamp = Date.now();
-        const lessonRandomSuffix = Math.random().toString(36).substring(2, 15);
-        const uniqueLessonSlug = `lesson-${lessonTimestamp}-${lessonRandomSuffix}`;
+      await Promise.all(
+        sortedLessons.map(async (lesson, index) => {
+          const lessonTimestamp = Date.now();
+          const lessonRandomSuffix = Math.random()
+            .toString(36)
+            .substring(2, 15);
+          const uniqueLessonSlug = `lesson-${lessonTimestamp}-${lessonRandomSuffix}`;
 
-        // Determine which version of blocks to use
-        const blocksVersion = lesson.blocksVersion || "v1";
-        const isV2 = blocksVersion === "v2";
+          // Determine which version of blocks to use
+          const blocksVersion = lesson.blocksVersion || "v1";
+          const isV2 = blocksVersion === "v2";
 
-        console.log(`Lesson: ${lesson.name}, blocksVersion: ${blocksVersion}`);
-
-        // Prepare lesson data based on version
-        const lessonData: any = {
-          name: lesson.name,
-          slug: uniqueLessonSlug,
-          type: lesson.type,
-          orderIndex: index,
-          blocksVersion: blocksVersion,
-          notes: lesson.notes || null,
-          droplets: [newDropletId],
-        };
-
-        // Add the appropriate blocks field
-        if (isV2 && lesson.blocksV2) {
-          // For v2 lessons, copy the blocksV2 JSON directly
-          lessonData.blocksV2 = lesson.blocksV2;
-          console.log(`Creating v2 lesson: ${lesson.name} with blocksV2 data`);
-        } else {
-          // For v1 lessons, clean the blocks array
-          const cleanedBlocks = cleanBlocks(lesson.blocks || []);
-          lessonData.blocks = cleanedBlocks;
           console.log(
-            `Creating v1 lesson: ${lesson.name} with ${cleanedBlocks.length} blocks`,
+            `Lesson: ${lesson.name}, blocksVersion: ${blocksVersion}`,
           );
-        }
 
-        const response = await fetch(STRAPI_API_URL + "/api/lessons", {
-          method: "POST",
-          body: JSON.stringify({ data: lessonData }),
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: "Bearer " + STRAPI_ACCESS_TOKEN,
-          },
-        });
+          // Prepare lesson data based on version
+          const lessonData: any = {
+            name: lesson.name,
+            slug: uniqueLessonSlug,
+            type: lesson.type,
+            orderIndex: index,
+            blocksVersion: blocksVersion,
+            notes: lesson.notes || null,
+            droplets: [newDropletId],
+          };
 
-        if (!response.ok) {
-          const errorData = await response.json();
-          console.error(
-            "Failed to create lesson:",
-            JSON.stringify(errorData, null, 2),
+          // Add the appropriate blocks field
+          if (isV2 && lesson.blocksV2) {
+            // For v2 lessons, copy the blocksV2 JSON directly
+            lessonData.blocksV2 = lesson.blocksV2;
+            console.log(
+              `Creating v2 lesson: ${lesson.name} with blocksV2 data`,
+            );
+          } else {
+            // For v1 lessons, clean the blocks array
+            const cleanedBlocks = cleanBlocks(lesson.blocks || []);
+            lessonData.blocks = cleanedBlocks;
+            console.log(
+              `Creating v1 lesson: ${lesson.name} with ${cleanedBlocks.length} blocks`,
+            );
+          }
+
+          const response = await fetch(STRAPI_API_URL + "/api/lessons", {
+            method: "POST",
+            body: JSON.stringify({ data: lessonData }),
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: "Bearer " + STRAPI_ACCESS_TOKEN,
+            },
+          });
+
+          if (!response.ok) {
+            const errorData = await response.json();
+            console.error(
+              "Failed to create lesson:",
+              JSON.stringify(errorData, null, 2),
+            );
+            throw new Error(`Failed to create lesson: ${lesson.name}`);
+          }
+
+          const createdLesson = await response.json();
+          console.log(
+            `Created lesson ${createdLesson.data.id} (${blocksVersion})`,
           );
-          throw new Error(`Failed to create lesson: ${lesson.name}`);
-        }
-
-        const createdLesson = await response.json();
-        console.log(
-          `Created lesson ${createdLesson.data.id} (${blocksVersion})`,
-        );
-
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
+        }),
+      );
     }
 
     revalidateTag(CACHE_TAGS.authors);
@@ -1057,23 +1062,25 @@ export async function publishDraftToOriginal(
       console.log("Updating enrollments to point to original droplet");
 
       // Update each enrollment to point to the original droplet
-      for (const enrollment of draftEnrollments.data || []) {
-        await fetch(`${STRAPI_API_URL}/api/enrollments/${enrollment.id}`, {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}`,
-          },
-          body: JSON.stringify({
-            data: {
-              droplet: originalDropletId,
+      await Promise.all(
+        (draftEnrollments.data || []).map(async (enrollment) => {
+          await fetch(`${STRAPI_API_URL}/api/enrollments/${enrollment.id}`, {
+            method: "PUT",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}`,
             },
-          }),
-        });
-        console.log(
-          `Updated enrollment ${enrollment.id} to point to original droplet`,
-        );
-      }
+            body: JSON.stringify({
+              data: {
+                droplet: originalDropletId,
+              },
+            }),
+          });
+          console.log(
+            `Updated enrollment ${enrollment.id} to point to original droplet`,
+          );
+        }),
+      );
     } catch (error) {
       console.error("Error updating enrollments:", error);
     }
@@ -1130,9 +1137,8 @@ export async function publishDraftToOriginal(
         (a, b) => a.orderIndex - b.orderIndex,
       );
 
-      for (let index = 0; index < sortedLessons.length; index++) {
-        const lesson = sortedLessons[index];
-        try {
+      await Promise.all(
+        sortedLessons.map(async (lesson, index) => {
           // Determine which version of blocks to use
           const blocksVersion = lesson.blocksVersion || "v1";
           const isV2 = blocksVersion === "v2";
@@ -1150,7 +1156,7 @@ export async function publishDraftToOriginal(
             name: lesson.name,
             slug: `${lesson.slug}-${timestamp}-${randomSuffix}`,
             type: lesson.type,
-            orderIndex: index, // Use the array index to ensure sequential ordering
+            orderIndex: index,
             blocksVersion: blocksVersion,
             notes: lesson.notes || null,
             droplets: [originalDropletId],
@@ -1196,12 +1202,8 @@ export async function publishDraftToOriginal(
           console.log(
             `Successfully created lesson: ${lesson.name} with orderIndex: ${index}`,
           );
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        } catch (error) {
-          console.error(`Error creating lesson ${lesson.name}:`, error);
-          throw error;
-        }
-      }
+        }),
+      );
     }
 
     console.log("Successfully merged lessons, now deleting draft droplet");

--- a/frontend/lib/requests/groups.ts
+++ b/frontend/lib/requests/groups.ts
@@ -8,6 +8,8 @@ import {
   getAuthorizedUsersByEmails,
   createAuthorizedUser,
 } from "./authorized-user";
+import { getAuthorizedUserRoleIdByTitle } from "./authorized-user-roles";
+import { AuthorizedUserRoleTitle } from "../globals";
 import type { Droplet, DueDate, Playlist } from "@/types";
 import { revalidateTag } from "next/cache";
 import { enrollInPlaylist } from "./playlist-enrollment";
@@ -570,13 +572,16 @@ async function ensureAuthorizedUsers(
   );
 
   if (missingEmails.length > 0) {
+    const roleID = await getAuthorizedUserRoleIdByTitle(
+      AuthorizedUserRoleTitle.User,
+    );
     await Promise.all(
       missingEmails.map(async (email) => {
         try {
           const formData = new FormData();
           formData.append("email", email);
           formData.append("isEnabled", "true");
-          await createAuthorizedUser(formData);
+          await createAuthorizedUser(formData, roleID);
         } catch (error) {
           console.error(`Failed to create user: ${email}`, error);
         }

--- a/frontend/testing/lib/actions.test.ts
+++ b/frontend/testing/lib/actions.test.ts
@@ -42,7 +42,7 @@ jest.mock("next/navigation", () => ({
 }));
 
 const { redirect } = require("next/navigation");
-const { revalidatePath } = require("next/cache");
+const { revalidatePath, revalidateTag } = require("next/cache");
 
 describe("Server Actions", () => {
   let mockS3Send: jest.Mock;
@@ -545,7 +545,7 @@ describe("Server Actions", () => {
           method: "DELETE",
         }),
       );
-      expect(revalidatePath).toHaveBeenCalledWith("/admin?adminTab=Reports");
+      expect(revalidateTag).toHaveBeenCalledWith("reports");
       expect(result).toEqual({ success: true });
     });
 
@@ -736,7 +736,8 @@ describe("Server Actions", () => {
       const result = await approveCreationRequest("123", 1);
 
       expect(result).toEqual({ ok: true, error: null, data: null });
-      expect(revalidatePath).toHaveBeenCalledWith("/admin");
+      expect(revalidateTag).toHaveBeenCalledWith("users");
+      expect(revalidateTag).toHaveBeenCalledWith("creation-requests");
       expect(global.fetch).toHaveBeenCalledTimes(4);
     });
 
@@ -964,7 +965,7 @@ describe("Server Actions", () => {
           method: "DELETE",
         }),
       );
-      expect(revalidatePath).toHaveBeenCalledWith("/admin");
+      expect(revalidateTag).toHaveBeenCalledWith("creation-requests");
       expect(result).toEqual({ ok: true, error: null, data: null });
     });
 
@@ -1155,7 +1156,7 @@ describe("Server Actions", () => {
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining("/api/creation-requests"),
         expect.objectContaining({
-          cache: "no-store",
+          next: { tags: ["creation-requests"], revalidate: 900 },
         }),
       );
       expect(result).toBeTruthy();
@@ -1290,7 +1291,7 @@ describe("Server Actions", () => {
       expect(global.fetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          cache: "no-store",
+          next: { tags: ["creation-requests"], revalidate: 900 },
         }),
       );
     });

--- a/frontend/testing/requests/authorized-users.test.ts
+++ b/frontend/testing/requests/authorized-users.test.ts
@@ -396,7 +396,7 @@ describe("Authorized User Tests", () => {
         urlParams: expect.objectContaining({
           pagination: { pageSize: 50, page: 2 },
         }),
-        cache: "no-store",
+        next: { tags: ["users"], revalidate: 900 },
         flattenResponse: false,
       });
     });

--- a/frontend/testing/requests/requests.test.js
+++ b/frontend/testing/requests/requests.test.js
@@ -274,7 +274,7 @@ describe("Data requests", () => {
           headers: expect.objectContaining({
             Authorization: expect.stringContaining("Bearer"),
           }),
-          next: { revalidate: 900 },
+          next: { tags: ["access-requests"], revalidate: 900 },
         }),
       );
     });


### PR DESCRIPTION
## Description

The admin dashboard was using revalidatePath("/admin") which cleared the entire page cache on every mutation. Replaced all of those with revalidateTag so only the relevant data gets refreshed. Added reports, accessRequests, and creationRequests as new cache tags and added them to the matching fetch calls. Also converted three sequential write loops in droplet.ts to use Promise.all and removed the 100ms delays between iterations. Lastly, ensureAuthorizedUsers now fetches the role ID once instead of looking it up on every call to createAuthorizedUser. 

## Motivation and Context

Admin pages were loading slowly because any mutation wiped the whole admin cache, write operations ran one at a time with artificial delays, and the same role ID was being fetched repeatedly in a loop. These changes make cache invalidation more targeted, speed up bulk writes, and cut out redundant API calls.



## Checklist:


- [X] My code follows the code style of this project.
- [X] I have moved the ticket to "In Review"
- [X] I have added reviewers to this PR
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.