### PR TITLE
Add Slack notifications for droplet review, access requests, and crea…

### DIFF
--- a/backend/src/api/access-request/content-types/access-request/lifecycles.ts
+++ b/backend/src/api/access-request/content-types/access-request/lifecycles.ts
@@ -1,4 +1,4 @@
-import { sendSlackNotification, SlackBlock } from '../../../../lib/slack';
+import { sendSlackNotification, escapeSlackMrkdwn, SlackBlock } from '../../../../lib/slack';
 import { formatPersonName } from '../../../../lib/lifecycle-utils';
 import { AccessRequest, AFFILIATION_LABELS } from '../../types';
 
@@ -6,13 +6,13 @@ module.exports = {
   async afterCreate(event) {
     const result = event.result as AccessRequest;
 
-    const name = formatPersonName({
+    const name = escapeSlackMrkdwn(formatPersonName({
       firstName: result.givenName,
       lastName: result.familyName,
       email: result.email,
-    });
-    const affiliation = AFFILIATION_LABELS[result.affiliation] ?? result.affiliation ?? 'Unknown';
-    const college = result.college ?? 'Unknown';
+    }));
+    const affiliation = escapeSlackMrkdwn(AFFILIATION_LABELS[result.affiliation] ?? result.affiliation ?? 'Unknown');
+    const college = escapeSlackMrkdwn(result.college ?? 'Unknown');
 
     const blocks: SlackBlock[] = [
       {
@@ -23,7 +23,7 @@ module.exports = {
         type: 'section',
         fields: [
           { type: 'mrkdwn', text: `*Name:* ${name}` },
-          { type: 'mrkdwn', text: `*Email:* ${result.email}` },
+          { type: 'mrkdwn', text: `*Email:* ${escapeSlackMrkdwn(result.email)}` },
           { type: 'mrkdwn', text: `*Affiliation:* ${affiliation}` },
           { type: 'mrkdwn', text: `*College:* ${college}` },
         ],

--- a/backend/src/api/access-request/content-types/access-request/lifecycles.ts
+++ b/backend/src/api/access-request/content-types/access-request/lifecycles.ts
@@ -1,0 +1,40 @@
+import { sendSlackNotification, SlackBlock } from '../../../../lib/slack';
+import { formatPersonName } from '../../../../lib/lifecycle-utils';
+import { AccessRequest, AFFILIATION_LABELS } from '../../types';
+
+module.exports = {
+  async afterCreate(event) {
+    const result = event.result as AccessRequest;
+
+    const name = formatPersonName({
+      firstName: result.givenName,
+      lastName: result.familyName,
+      email: result.email,
+    });
+    const affiliation = AFFILIATION_LABELS[result.affiliation] ?? result.affiliation ?? 'Unknown';
+    const college = result.college ?? 'Unknown';
+
+    const blocks: SlackBlock[] = [
+      {
+        type: 'header',
+        text: { type: 'plain_text', text: 'New Access Request', emoji: true },
+      },
+      {
+        type: 'section',
+        fields: [
+          { type: 'mrkdwn', text: `*Name:* ${name}` },
+          { type: 'mrkdwn', text: `*Email:* ${result.email}` },
+          { type: 'mrkdwn', text: `*Affiliation:* ${affiliation}` },
+          { type: 'mrkdwn', text: `*College:* ${college}` },
+        ],
+      },
+      { type: 'divider' },
+    ];
+
+    // Fire-and-forget — sendSlackNotification handles its own errors and timeouts.
+    sendSlackNotification({
+      text: `New access request from ${name} (${result.email}).`,
+      blocks,
+    });
+  },
+};

--- a/backend/src/api/access-request/types.ts
+++ b/backend/src/api/access-request/types.ts
@@ -1,0 +1,21 @@
+import schema from './content-types/access-request/schema.json';
+
+export type AccessRequestAffiliation = (typeof schema.attributes.affiliation.enum)[number];
+export type AccessRequestCollege = (typeof schema.attributes.college.enum)[number];
+
+export interface AccessRequest {
+  id: number;
+  givenName: string;
+  familyName: string;
+  email: string;
+  affiliation: AccessRequestAffiliation;
+  college: AccessRequestCollege;
+}
+
+export const AFFILIATION_LABELS: Record<AccessRequestAffiliation, string> = {
+  undergraduateStudent: 'Undergraduate Student',
+  graduateStudent: 'Graduate Student',
+  faculty: 'Faculty',
+  staff: 'Staff',
+  other: 'Other',
+};

--- a/backend/src/api/creation-request/content-types/creation-request/lifecycles.ts
+++ b/backend/src/api/creation-request/content-types/creation-request/lifecycles.ts
@@ -1,0 +1,54 @@
+import { sendSlackNotification, SlackBlock } from '../../../../lib/slack';
+import { formatPersonName } from '../../../../lib/lifecycle-utils';
+import { CreationRequestWithUser } from '../../types';
+
+module.exports = {
+  async afterCreate(event) {
+    const { result } = event;
+
+    const creationRequest = (await strapi.entityService.findOne(
+      'api::creation-request.creation-request',
+      result.id,
+      { populate: { user: { fields: ['firstName', 'lastName', 'email'] } } }
+    )) as CreationRequestWithUser | null;
+
+    const user = creationRequest?.user;
+    const userName = user ? formatPersonName(user) : 'Unknown';
+
+    const blocks: SlackBlock[] = [
+      {
+        type: 'header',
+        text: { type: 'plain_text', text: 'New Creator Access Request', emoji: true },
+      },
+      {
+        type: 'section',
+        fields: [
+          { type: 'mrkdwn', text: `*User:* ${userName}` },
+          { type: 'mrkdwn', text: `*Email:* ${user?.email ?? 'Unknown'}` },
+        ],
+      },
+    ];
+
+    if (result.motivation) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: `*Motivation:*\n> ${result.motivation}` },
+      });
+    }
+
+    if (result.dropletIdea) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: `*Droplet Idea:*\n> ${result.dropletIdea}` },
+      });
+    }
+
+    blocks.push({ type: 'divider' });
+
+    // Fire-and-forget — sendSlackNotification handles its own errors and timeouts.
+    sendSlackNotification({
+      text: `New creator access request from ${userName}.`,
+      blocks,
+    });
+  },
+};

--- a/backend/src/api/creation-request/content-types/creation-request/lifecycles.ts
+++ b/backend/src/api/creation-request/content-types/creation-request/lifecycles.ts
@@ -1,4 +1,4 @@
-import { sendSlackNotification, SlackBlock } from '../../../../lib/slack';
+import { sendSlackNotification, escapeSlackMrkdwn, SlackBlock } from '../../../../lib/slack';
 import { formatPersonName } from '../../../../lib/lifecycle-utils';
 import { CreationRequestWithUser } from '../../types';
 
@@ -13,7 +13,7 @@ module.exports = {
     )) as CreationRequestWithUser | null;
 
     const user = creationRequest?.user;
-    const userName = user ? formatPersonName(user) : 'Unknown';
+    const userName = escapeSlackMrkdwn(user ? formatPersonName(user) : 'Unknown');
 
     const blocks: SlackBlock[] = [
       {
@@ -24,7 +24,7 @@ module.exports = {
         type: 'section',
         fields: [
           { type: 'mrkdwn', text: `*User:* ${userName}` },
-          { type: 'mrkdwn', text: `*Email:* ${user?.email ?? 'Unknown'}` },
+          { type: 'mrkdwn', text: `*Email:* ${escapeSlackMrkdwn(user?.email ?? 'Unknown')}` },
         ],
       },
     ];
@@ -32,14 +32,14 @@ module.exports = {
     if (result.motivation) {
       blocks.push({
         type: 'section',
-        text: { type: 'mrkdwn', text: `*Motivation:*\n> ${result.motivation}` },
+        text: { type: 'mrkdwn', text: `*Motivation:*\n> ${escapeSlackMrkdwn(result.motivation)}` },
       });
     }
 
     if (result.dropletIdea) {
       blocks.push({
         type: 'section',
-        text: { type: 'mrkdwn', text: `*Droplet Idea:*\n> ${result.dropletIdea}` },
+        text: { type: 'mrkdwn', text: `*Droplet Idea:*\n> ${escapeSlackMrkdwn(result.dropletIdea)}` },
       });
     }
 

--- a/backend/src/api/creation-request/types.ts
+++ b/backend/src/api/creation-request/types.ts
@@ -1,0 +1,8 @@
+import { PopulatedUser } from '../../lib/types';
+
+export interface CreationRequestWithUser {
+  id: number;
+  motivation: string | null;
+  dropletIdea: string | null;
+  user: PopulatedUser | null;
+}

--- a/backend/src/api/droplet/content-types/droplet/lifecycles.ts
+++ b/backend/src/api/droplet/content-types/droplet/lifecycles.ts
@@ -1,4 +1,4 @@
-import { sendSlackNotification, SlackBlock } from '../../../../lib/slack';
+import { sendSlackNotification, escapeSlackMrkdwn, SlackBlock } from '../../../../lib/slack';
 import { generateSlug, formatPersonName, capitalize } from '../../../../lib/lifecycle-utils';
 import { DropletStatus, DropletWithRelations } from '../../types';
 
@@ -41,14 +41,14 @@ module.exports = {
 
     if (!droplet) return;
 
-    const lessonNames = droplet.lessons.map((l) => l.name);
-    const tagNames = droplet.tags.map((t) => t.name);
+    const lessonNames = droplet.lessons.map((l) => escapeSlackMrkdwn(l.name));
+    const tagNames = droplet.tags.map((t) => escapeSlackMrkdwn(t.name));
     const authorText =
       droplet.authorized_users.length > 0
-        ? droplet.authorized_users.map(formatPersonName).join(', ')
+        ? droplet.authorized_users.map((u) => escapeSlackMrkdwn(formatPersonName(u))).join(', ')
         : 'Unknown';
 
-    const dropletName = result.name ?? 'Unknown droplet';
+    const dropletName = escapeSlackMrkdwn(result.name ?? 'Unknown droplet');
     const frontendUrl = process.env.FRONTEND_URL;
     const reviewUrl =
       frontendUrl && result.slug ? `${frontendUrl}/draft/d/${result.slug}` : null;
@@ -67,7 +67,7 @@ module.exports = {
     if (result.description) {
       blocks.push({
         type: 'section',
-        text: { type: 'mrkdwn', text: `> ${result.description}` },
+        text: { type: 'mrkdwn', text: `> ${escapeSlackMrkdwn(result.description)}` },
       });
     }
 
@@ -75,8 +75,8 @@ module.exports = {
       {
         type: 'section',
         fields: [
-          { type: 'mrkdwn', text: `*Type:* ${capitalize(result.type ?? 'unknown')}` },
-          { type: 'mrkdwn', text: `*Focus:* ${capitalize(result.focusArea ?? 'unknown')}` },
+          { type: 'mrkdwn', text: `*Type:* ${escapeSlackMrkdwn(capitalize(result.type ?? 'unknown'))}` },
+          { type: 'mrkdwn', text: `*Focus:* ${escapeSlackMrkdwn(capitalize(result.focusArea ?? 'unknown'))}` },
           { type: 'mrkdwn', text: `*Author:* ${authorText}` },
           {
             type: 'mrkdwn',

--- a/backend/src/api/droplet/content-types/droplet/lifecycles.ts
+++ b/backend/src/api/droplet/content-types/droplet/lifecycles.ts
@@ -49,8 +49,9 @@ module.exports = {
         : 'Unknown';
 
     const dropletName = result.name ?? 'Unknown droplet';
-    const frontendUrl = process.env.FRONTEND_URL ?? 'https://khouryodyssey.org';
-    const reviewUrl = `${frontendUrl}/draft/d/${result.slug ?? ''}`;
+    const frontendUrl = process.env.FRONTEND_URL;
+    const reviewUrl =
+      frontendUrl && result.slug ? `${frontendUrl}/draft/d/${result.slug}` : null;
 
     const blocks: SlackBlock[] = [
       {

--- a/backend/src/api/droplet/content-types/droplet/lifecycles.ts
+++ b/backend/src/api/droplet/content-types/droplet/lifecycles.ts
@@ -1,19 +1,104 @@
+import { sendSlackNotification, SlackBlock } from '../../../../lib/slack';
+import { generateSlug, formatPersonName, capitalize } from '../../../../lib/lifecycle-utils';
+import { DropletStatus, DropletWithRelations } from '../../types';
+
 module.exports = {
   async beforeCreate(event) {
-    event.params.data.slug = await strapi.service('plugin::content-manager.uid').generateUIDField({
-        contentTypeUID: "api::droplet.droplet",
-        field: "slug",
-        data: event.params.data
-    })
+    event.params.data.slug = await generateSlug('api::droplet.droplet', event.params.data);
   },
+
   async beforeUpdate(event) {
-    if(event.params.data.regenerateSlug) {
-      event.params.data.slug = await strapi.service('plugin::content-manager.uid').generateUIDField({
-        contentTypeUID: "api::droplet.droplet",
-        field: "slug",
-        data: event.params.data
-      })
+    if (event.params.data.regenerateSlug) {
+      event.params.data.slug = await generateSlug('api::droplet.droplet', event.params.data);
     }
     delete event.params.data.regenerateSlug;
+
+    // Only capture previous status when the update touches the status field.
+    if ('status' in event.params.data) {
+      const existing = await strapi.entityService.findOne(
+        'api::droplet.droplet',
+        event.params.where.id,
+        { fields: ['status'] }
+      );
+      event.state = { previousStatus: existing ? (existing.status as DropletStatus) : null };
+    }
+  },
+
+  async afterUpdate(event) {
+    const { result } = event;
+    const prevStatus = event.state?.previousStatus as DropletStatus | null | undefined;
+
+    // Only fire when status transitions *into* 'edit'.
+    if (result.status !== 'edit' || prevStatus === 'edit' || prevStatus === undefined) return;
+
+    const droplet = (await strapi.entityService.findOne('api::droplet.droplet', result.id, {
+      populate: {
+        lessons: { fields: ['name'] },
+        authorized_users: { fields: ['firstName', 'lastName', 'email'] },
+        tags: { fields: ['name'] },
+      },
+    })) as DropletWithRelations | null;
+
+    if (!droplet) return;
+
+    const lessonNames = droplet.lessons.map((l) => l.name);
+    const tagNames = droplet.tags.map((t) => t.name);
+    const authorText =
+      droplet.authorized_users.length > 0
+        ? droplet.authorized_users.map(formatPersonName).join(', ')
+        : 'Unknown';
+
+    const dropletName = result.name ?? 'Unknown droplet';
+    const frontendUrl = process.env.FRONTEND_URL ?? 'https://khouryodyssey.org';
+    const reviewUrl = `${frontendUrl}/draft/d/${result.slug ?? ''}`;
+
+    const blocks: SlackBlock[] = [
+      {
+        type: 'header',
+        text: { type: 'plain_text', text: 'New Droplet Ready for Review', emoji: true },
+      },
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: `*<${reviewUrl}|${dropletName}>*` },
+      },
+    ];
+
+    if (result.description) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: `> ${result.description}` },
+      });
+    }
+
+    blocks.push(
+      {
+        type: 'section',
+        fields: [
+          { type: 'mrkdwn', text: `*Type:* ${capitalize(result.type ?? 'unknown')}` },
+          { type: 'mrkdwn', text: `*Focus:* ${capitalize(result.focusArea ?? 'unknown')}` },
+          { type: 'mrkdwn', text: `*Author:* ${authorText}` },
+          {
+            type: 'mrkdwn',
+            text: `*Lessons:* ${lessonNames.length} — ${lessonNames.length > 0 ? lessonNames.join(', ') : 'None'}`,
+          },
+        ],
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `*Tags:* ${tagNames.length > 0 ? tagNames.join(', ') : 'None'}`,
+          },
+        ],
+      },
+      { type: 'divider' }
+    );
+
+    // Fire-and-forget — sendSlackNotification handles its own errors and timeouts.
+    sendSlackNotification({
+      text: `Droplet "${dropletName}" has been submitted for review.`,
+      blocks,
+    });
   },
 };

--- a/backend/src/api/droplet/types.ts
+++ b/backend/src/api/droplet/types.ts
@@ -1,0 +1,29 @@
+import schema from './content-types/droplet/schema.json';
+import { PopulatedUser } from '../../lib/types';
+
+export type DropletStatus = (typeof schema.attributes.status.enum)[number];
+export type DropletType = (typeof schema.attributes.type.enum)[number];
+export type DropletFocusArea = (typeof schema.attributes.focusArea.enum)[number];
+
+export interface PopulatedLesson {
+  id: number;
+  name: string;
+}
+
+export interface PopulatedTag {
+  id: number;
+  name: string;
+}
+
+export interface DropletWithRelations {
+  id: number;
+  name: string;
+  slug: string;
+  status: DropletStatus;
+  type: DropletType;
+  focusArea: DropletFocusArea;
+  description: string | null;
+  lessons: PopulatedLesson[];
+  authorized_users: PopulatedUser[];
+  tags: PopulatedTag[];
+}

--- a/backend/src/api/lesson/content-types/lesson/lifecycles.ts
+++ b/backend/src/api/lesson/content-types/lesson/lifecycles.ts
@@ -24,8 +24,11 @@ module.exports = {
 
       const finalBlocks = 'blocks' in data ? data.blocks : existing?.blocks;
       const finalBlocksV2 = 'blocksV2' in data ? data.blocksV2 : existing?.blocksV2;
+      const hasBlocks = Array.isArray(finalBlocks)
+        ? finalBlocks.length > 0
+        : Boolean(finalBlocks);
 
-      if (!finalBlocks && !finalBlocksV2) {
+      if (!hasBlocks && !finalBlocksV2) {
         throw new Error('Lesson must have either blocks or blocksV2 content');
       }
     }

--- a/backend/src/api/lesson/content-types/lesson/lifecycles.ts
+++ b/backend/src/api/lesson/content-types/lesson/lifecycles.ts
@@ -1,48 +1,37 @@
+import { generateSlug } from '../../../../lib/lifecycle-utils';
+import { Lesson } from '../../types';
+
 module.exports = {
   async beforeCreate(event) {
     const { data } = event.params;
-    
-    // Validate that at least one content field exists
+
     if (!data.blocks && !data.blocksV2) {
       throw new Error('Lesson must have either blocks or blocksV2 content');
     }
-    
-    // Generate slug
-    event.params.data.slug = await strapi.service('plugin::content-manager.uid').generateUIDField({
-      contentTypeUID: "api::lesson.lesson",
-      field: "slug",
-      data: event.params.data
-    });
+
+    event.params.data.slug = await generateSlug('api::lesson.lesson', event.params.data);
   },
-  
+
   async beforeUpdate(event) {
     const { data } = event.params;
-    
-    // Validate content fields if either is being updated
+
     if ('blocks' in data || 'blocksV2' in data) {
-      // Fetch existing lesson to check final state
-      const existingLesson = await strapi.entityService.findOne(
+      const existing = (await strapi.entityService.findOne(
         'api::lesson.lesson',
-        event.params.where.id
-      );
-      
-      // Determine final state after update
-      const existingLessonAny = existingLesson as any;
-      const finalBlocks = 'blocks' in data ? data.blocks : existingLessonAny?.blocks;
-      const finalBlocksV2 = 'blocksV2' in data ? data.blocksV2 : existingLessonAny?.blocksV2;
-      
+        event.params.where.id,
+        { fields: ['blocksV2'], populate: { blocks: true } }
+      )) as Lesson | null;
+
+      const finalBlocks = 'blocks' in data ? data.blocks : existing?.blocks;
+      const finalBlocksV2 = 'blocksV2' in data ? data.blocksV2 : existing?.blocksV2;
+
       if (!finalBlocks && !finalBlocksV2) {
         throw new Error('Lesson must have either blocks or blocksV2 content');
       }
     }
-    
-    // Handle slug regeneration
-    if (event.params.data.regenerateSlug) { 
-      event.params.data.slug = await strapi.service('plugin::content-manager.uid').generateUIDField({
-        contentTypeUID: "api::lesson.lesson",
-        field: "slug",
-        data: event.params.data
-      });
+
+    if (event.params.data.regenerateSlug) {
+      event.params.data.slug = await generateSlug('api::lesson.lesson', event.params.data);
     }
     delete event.params.data.regenerateSlug;
   },

--- a/backend/src/api/lesson/types.ts
+++ b/backend/src/api/lesson/types.ts
@@ -1,0 +1,12 @@
+import schema from './content-types/lesson/schema.json';
+
+export type LessonBlocksVersion = (typeof schema.attributes.blocksVersion.enum)[number];
+
+export interface Lesson {
+  id: number;
+  name: string;
+  slug: string;
+  blocks: unknown[] | null;
+  blocksV2: unknown | null;
+  blocksVersion: LessonBlocksVersion;
+}

--- a/backend/src/api/playlist/content-types/playlist/lifecycles.ts
+++ b/backend/src/api/playlist/content-types/playlist/lifecycles.ts
@@ -1,18 +1,13 @@
+import { generateSlug } from '../../../../lib/lifecycle-utils';
+
 module.exports = {
   async beforeCreate(event) {
-    event.params.data.slug = await strapi.service('plugin::content-manager.uid').generateUIDField({
-        contentTypeUID: "api::playlist.playlist",
-        field: "slug",
-        data: event.params.data
-    })
+    event.params.data.slug = await generateSlug('api::playlist.playlist', event.params.data);
   },
+
   async beforeUpdate(event) {
-    if(event.params.data.regenerateSlug) {
-      event.params.data.slug = await strapi.service('plugin::content-manager.uid').generateUIDField({
-        contentTypeUID: "api::playlist.playlist",
-        field: "slug",
-        data: event.params.data
-      })
+    if (event.params.data.regenerateSlug) {
+      event.params.data.slug = await generateSlug('api::playlist.playlist', event.params.data);
     }
     delete event.params.data.regenerateSlug;
   },

--- a/backend/src/lib/lifecycle-utils.ts
+++ b/backend/src/lib/lifecycle-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared lifecycle utilities
+ */
+
+/**
+ * Generates a UID slug for a given content type and data payload.
+ * Wraps the content-manager UID service so lifecycle files don't repeat the call.
+ */
+export async function generateSlug(contentTypeUID: string, data: object): Promise<string> {
+  return strapi.service('plugin::content-manager.uid').generateUIDField({
+    contentTypeUID,
+    field: 'slug',
+    data,
+  });
+}
+
+/** Capitalizes the first character of a string. */
+export function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ * Formats a person's display name from optional first/last name fields with an
+ * email fallback. Shared across lifecycle files that deal with user relations.
+ */
+export function formatPersonName({
+  firstName,
+  lastName,
+  email,
+}: {
+  firstName?: string | null;
+  lastName?: string | null;
+  email: string;
+}): string {
+  const full = `${firstName ?? ''} ${lastName ?? ''}`.trim();
+  return full.length > 0 ? full : email;
+}

--- a/backend/src/lib/slack.ts
+++ b/backend/src/lib/slack.ts
@@ -1,0 +1,53 @@
+/**
+ * Slack webhook utility
+ *
+ * Sends a structured Block Kit message to the configured SLACK_WEBHOOK_URL.
+ * Set SLACK_WEBHOOK_URL in backend/.env (or the ECS task environment) to
+ * enable notifications; if the variable is absent the function is a no-op so
+ * the app never fails due to a missing webhook.
+ */
+
+export interface SlackBlock {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface SlackPayload {
+  text: string; // Fallback text (notifications / accessibility)
+  blocks?: SlackBlock[];
+}
+
+/**
+ * Post a message to the admin Slack channel via an Incoming Webhook.
+ * Silently swallows errors so a Slack outage never breaks a Strapi request.
+ * Aborts after 5 s to avoid hanging lifecycle hooks.
+ */
+export async function sendSlackNotification(payload: SlackPayload): Promise<void> {
+  if (process.env.NODE_ENV !== 'production') return;
+
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+
+  if (!webhookUrl) {
+    return;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      strapi.log.warn(`[slack] Webhook responded with ${res.status}: ${await res.text()}`);
+    }
+  } catch (err) {
+    strapi.log.warn('[slack] Failed to send notification:', err);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/backend/src/lib/slack.ts
+++ b/backend/src/lib/slack.ts
@@ -7,6 +7,17 @@
  * the app never fails due to a missing webhook.
  */
 
+/**
+ * Escape user-controlled text for use in Slack mrkdwn blocks.
+ * Slack treats &, <, and > as special characters; replace them with their
+ * HTML entities so they render as literals instead of being interpreted.
+ * Do NOT apply this to URLs or explicit <url|label> link constructs —
+ * only escape the user-supplied label portion.
+ */
+export function escapeSlackMrkdwn(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 export interface SlackBlock {
   type: string;
   [key: string]: unknown;

--- a/backend/src/lib/types.ts
+++ b/backend/src/lib/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared types for populated Strapi relations.
+ */
+
+/** Populated authorized-user fields used across lifecycle notifications. */
+export interface PopulatedUser {
+  id: number;
+  firstName: string | null;
+  lastName: string | null;
+  email: string;
+}


### PR DESCRIPTION
## Description

Wired up Slack notifications so the team gets pinged when things happen in the CMS instead of having to check manually:

- **Droplet submitted for review** — sends a message when status changes to `edit` with the droplet name, type, focus area, author, lessons, and tags
- **New access request** — sends on creation with name, email, affiliation, college
- **New creator access request** — sends on creation with user info, motivation, and droplet idea

Built some shared utilities along the way:
- `lib/slack.ts` — sends Block Kit messages via webhook, 5s timeout so it never hangs, only runs in prod, silent no-op if `SLACK_WEBHOOK_URL` isn't set
- `lib/types.ts` — shared `PopulatedUser` interface used across droplet and creation-request types
- `lib/lifecycle-utils.ts` — `generateSlug()`, `capitalize()`, `formatPersonName()`
- Added typed interfaces for droplet, access-request, and lesson derived from their schema enums (no more `any`)

## Motivation and Context

Right now there's no way to know when a droplet gets submitted for review or when someone requests access without checking the admin. dash. 

`SLACK_WEBHOOK_URL` needs to be added to the ECS task definition for staging/prod before this does anything.

## Screenshots (if appropriate):

N/A — messages show up once the webhook is configured in the environment.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack notifications for new access requests, creation requests, and when a droplet moves into "edit", summarizing key details.
* **Refactor**
  * Centralized slug generation and shared formatting utilities for consistent content handling.
  * Added stronger type definitions for several content entities to improve consistency.
* **Bug Fixes**
  * Improved lesson create/update validation to ensure content (blocks or blocksV2) is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->