### PR TITLE
ODY-350: Admin Users Page + ODY-360: Sort Button + ODY-361: Filter Bu…

### DIFF
--- a/frontend/app/(general)/admin/layout.tsx
+++ b/frontend/app/(general)/admin/layout.tsx
@@ -1,0 +1,14 @@
+import { AdminNav } from "@/components/admin/admin-nav";
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen">
+      <AdminNav />
+      <main className="min-w-0 flex-1 overflow-auto">{children}</main>
+    </div>
+  );
+}

--- a/frontend/app/(general)/admin/users/page.tsx
+++ b/frontend/app/(general)/admin/users/page.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from "react";
+import { getCurrentUser } from "@/lib/auth/session";
+import { notFound } from "next/navigation";
+import { isAuthorizedUserAdmin } from "@/lib/utils";
+import { UsersPage } from "@/components/admin/users/users-page";
+import { Loader2 } from "lucide-react";
+
+export default async function Page() {
+  const user = await getCurrentUser();
+
+  if (!user || !isAuthorizedUserAdmin(user.roles)) return notFound();
+
+  return (
+    <div className="mx-auto w-full max-w-5xl">
+      <div className="mx-auto mt-4 mb-2 w-full max-w-7xl px-8 pt-4 pb-2">
+        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl dark:text-slate-100">
+          Users
+        </h1>
+        <p className="mt-1 text-lg text-slate-600 dark:text-slate-400">
+          Manage platform users and their roles.
+        </p>
+      </div>
+
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+          </div>
+        }
+      >
+        <UsersPage />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/app/(general)/admin/users/page.tsx
+++ b/frontend/app/(general)/admin/users/page.tsx
@@ -11,8 +11,8 @@ export default async function Page() {
   if (!user || !isAuthorizedUserAdmin(user.roles)) return notFound();
 
   return (
-    <div className="mx-auto w-full max-w-5xl">
-      <div className="mx-auto mt-4 mb-2 w-full max-w-7xl px-8 pt-4 pb-2">
+    <div className="mx-auto w-full px-[100px]">
+      <div className="mt-4 mb-2 px-4 pt-4 pb-2">
         <h1 className="text-3xl font-bold tracking-tight sm:text-4xl dark:text-slate-100">
           Users
         </h1>

--- a/frontend/components/admin/admin-nav.tsx
+++ b/frontend/components/admin/admin-nav.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import {
+  LayoutDashboard,
+  Users,
+  Droplet,
+  ListMusic,
+  UsersRound,
+  ShieldCheck,
+  PenLine,
+  BarChart2,
+} from "lucide-react";
+import type { LucideProps } from "lucide-react";
+
+// ——— Types ———
+export type AdminNavVariant =
+  | "Default"
+  | "Dashboard"
+  | "Users"
+  | "Droplets"
+  | "Playlists"
+  | "Groups"
+  | "Access Manager"
+  | "Creators Manager"
+  | "Reports";
+
+// ——— Per-icon sub-components (Default and active/white variant) ———
+function NavIcon({
+  Icon,
+  active,
+}: {
+  Icon: React.ComponentType<LucideProps>;
+  active: boolean;
+}) {
+  return (
+    <Icon
+      className={cn(
+        "h-[22px] w-[22px] flex-shrink-0",
+        active ? "text-white" : "text-[#344054]",
+      )}
+      strokeWidth={1.8}
+    />
+  );
+}
+
+export function DashboardIcon({ active }: { active: boolean }) {
+  return <NavIcon Icon={LayoutDashboard} active={active} />;
+}
+export function UsersIcon({ active }: { active: boolean }) {
+  return <NavIcon Icon={Users} active={active} />;
+}
+export function DropletIcon({ active }: { active: boolean }) {
+  return <NavIcon Icon={Droplet} active={active} />;
+}
+export function PlaylistIcon({ active }: { active: boolean }) {
+  return <NavIcon Icon={ListMusic} active={active} />;
+}
+export function GroupsIcon({ active }: { active: boolean }) {
+  return <NavIcon Icon={UsersRound} active={active} />;
+}
+export function AccessManagerIcon({ active }: { active: boolean }) {
+  return <NavIcon Icon={ShieldCheck} active={active} />;
+}
+export function CreatorsManagerIcon({ active }: { active: boolean }) {
+  return <NavIcon Icon={PenLine} active={active} />;
+}
+export function ReportsIcon({ active }: { active: boolean }) {
+  return <NavIcon Icon={BarChart2} active={active} />;
+}
+
+// ——— Nav item definitions ———
+const NAV_ITEMS: {
+  label: string;
+  variant: Exclude<AdminNavVariant, "Default">;
+  href: string;
+  Icon: React.ComponentType<{ active: boolean }>;
+}[] = [
+  {
+    label: "Dashboard",
+    variant: "Dashboard",
+    href: "/admin",
+    Icon: DashboardIcon,
+  },
+  { label: "Users", variant: "Users", href: "/admin/users", Icon: UsersIcon },
+  {
+    label: "Droplets",
+    variant: "Droplets",
+    href: "/admin/droplets",
+    Icon: DropletIcon,
+  },
+  {
+    label: "Playlists",
+    variant: "Playlists",
+    href: "/admin/playlists",
+    Icon: PlaylistIcon,
+  },
+  {
+    label: "Groups",
+    variant: "Groups",
+    href: "/admin/groups",
+    Icon: GroupsIcon,
+  },
+  {
+    label: "Access Manager",
+    variant: "Access Manager",
+    href: "/admin/access-manager",
+    Icon: AccessManagerIcon,
+  },
+  {
+    label: "Creators Manager",
+    variant: "Creators Manager",
+    href: "/admin/creators-manager",
+    Icon: CreatorsManagerIcon,
+  },
+  {
+    label: "Reports",
+    variant: "Reports",
+    href: "/admin/reports",
+    Icon: ReportsIcon,
+  },
+];
+
+// ——— Main component ———
+interface AdminNavProps {
+  /**
+   * Explicitly set the active item. Useful for overrides or testing.
+   * When omitted the active item is derived automatically from the current pathname.
+   */
+  property1?: AdminNavVariant;
+}
+
+export function AdminNav({ property1 }: AdminNavProps) {
+  const pathname = usePathname();
+
+  const activeVariant: AdminNavVariant = (() => {
+    // Explicit prop wins (unless "Default")
+    if (property1 && property1 !== "Default") return property1;
+    // Exact match for dashboard root
+    if (pathname === "/admin") return "Dashboard";
+    // Prefix match for sub-pages (longest match first)
+    const match = [...NAV_ITEMS]
+      .reverse()
+      .find((item) => item.href !== "/admin" && pathname.startsWith(item.href));
+    return match?.variant ?? "Default";
+  })();
+
+  return (
+    <nav
+      aria-label="Admin navigation"
+      className="sticky top-0 flex h-screen w-[281px] flex-shrink-0 flex-col bg-[#FCFCFD] shadow-[0px_4px_4px_rgba(0,0,0,0.25)]"
+    >
+      {/* Nav items */}
+      <ul className="mt-2 flex flex-col gap-1 px-3">
+        {NAV_ITEMS.map((item) => {
+          const isActive = activeVariant === item.variant;
+          return (
+            <li key={item.variant}>
+              <Link
+                href={item.href}
+                className={cn(
+                  "relative flex h-12 w-full items-center rounded-xl transition-colors",
+                  isActive ? "bg-[#2D7597]" : "hover:bg-slate-100",
+                )}
+                aria-current={isActive ? "page" : undefined}
+              >
+                {/* Icon — ~15% indent */}
+                <span className="ml-[15%]">
+                  <item.Icon active={isActive} />
+                </span>
+
+                {/* Label — ~27.4% indent, Lato Regular 20px */}
+                <span
+                  className={cn(
+                    "absolute left-[27.4%] text-[18px] leading-none font-normal",
+                    isActive ? "text-white" : "text-black",
+                  )}
+                >
+                  {item.label}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/components/admin/filter-button.tsx
+++ b/frontend/components/admin/filter-button.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { ListFilter } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface FilterButtonProps {
+  /** Called when the user clicks Apply. Commit whatever draft state the children expose. */
+  onApply: () => void;
+  /** Called when the user clicks Reset. Should clear all active filters. */
+  onReset: () => void;
+  /**
+   * Controls active styling:
+   * - `"Active State"` forces the active (teal glow) appearance
+   * - `"Filters Button"` uses default styling
+   * Alternatively leave unset — the component automatically enters active style
+   * when the popout is open or `hasActiveFilters` is true.
+   */
+  property1?: "Filters Button" | "Active State";
+  /**
+   * Set to true when at least one filter is currently applied.
+   * Keeps the button in active state even when the popout is closed.
+   */
+  hasActiveFilters?: boolean;
+  /** Page-specific filter controls rendered inside the popout content area. */
+  children: React.ReactNode;
+}
+
+/**
+ * Reusable Filter Button with a popout panel.
+ * ODY-361 — consistent across all admin pages; page-specific content injected via children.
+ */
+export function FilterButton({
+  onApply,
+  onReset,
+  property1 = "Filters Button",
+  hasActiveFilters = false,
+  children,
+}: FilterButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  // Active when: forced via prop, popout is open, or a filter is currently applied
+  const active = property1 === "Active State" || open || hasActiveFilters;
+
+  const handleApply = () => {
+    onApply();
+    setOpen(false);
+  };
+
+  const handleReset = () => {
+    onReset();
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        {/* Button: 89px × 40px, border-radius 8px, 16px horizontal padding */}
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-haspopup="dialog"
+          className={cn(
+            "flex h-10 w-[89px] items-center justify-center gap-2 rounded-lg border bg-white px-4 text-sm font-medium text-[#344054] transition-all",
+            active
+              ? "border-[#2D7597] shadow-[0px_0px_4px_#2D7597]"
+              : "border-[#D0D5DD] hover:border-slate-400",
+          )}
+        >
+          <ListFilter className="h-4 w-4 flex-shrink-0" />
+          <span>Filter</span>
+        </button>
+      </PopoverTrigger>
+
+      {/* Popout: 216px wide, border-radius 8px, shadow 0px 0px 4px rgba(0,0,0,0.25) */}
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="w-[216px] rounded-lg border-0 p-0 shadow-[0px_0px_4px_rgba(0,0,0,0.25)]"
+      >
+        {/* Title */}
+        <div className="px-4 pt-4 pb-3">
+          <p className="text-[15px] font-medium text-black">Filter</p>
+        </div>
+
+        {/* Divider */}
+        <hr className="border-slate-200" />
+
+        {/* Page-specific filter content */}
+        <div className="px-4 py-3">{children}</div>
+
+        {/* Divider */}
+        <hr className="border-slate-200" />
+
+        {/* Footer */}
+        <div className="flex gap-2 px-4 py-3">
+          <button
+            type="button"
+            onClick={handleReset}
+            className="flex-1 rounded-lg border border-[#D0D5DD] bg-white py-1.5 text-xs font-medium text-[#344054] hover:bg-slate-50"
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            onClick={handleApply}
+            className="flex-1 rounded-lg bg-[#2D7597] py-1.5 text-xs font-medium text-white hover:bg-[#255e78]"
+          >
+            Apply
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/components/admin/search-bar.tsx
+++ b/frontend/components/admin/search-bar.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface SearchBarProps {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+/**
+ * Pill-shaped search input.
+ * ODY-357 — border-radius 30px, bg #FCFCFD, 2px border #EFEFF0,
+ * search icon 20px from left, placeholder Lato Regular 16px #667085.
+ */
+export function SearchBar({
+  value,
+  onChange,
+  placeholder = "Search",
+  className,
+}: SearchBarProps) {
+  return (
+    <div className={cn("relative flex w-full items-center", className)}>
+      {/* Search icon — 20px from left edge */}
+      <Search
+        className="pointer-events-none absolute left-5 h-5 w-5 flex-shrink-0 text-[#667085]"
+        strokeWidth={1.8}
+      />
+
+      <input
+        type="search"
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        className={cn(
+          "h-11 w-full rounded-[30px] border-2 border-[#EFEFF0] bg-[#FCFCFD]",
+          "pr-2 pl-11",
+          "text-base text-slate-900 placeholder:font-normal placeholder:text-[#667085]",
+          "transition-colors outline-none focus:border-[#2D7597] focus:ring-0",
+          "[&::-webkit-search-cancel-button]:hidden [&::-webkit-search-decoration]:hidden",
+        )}
+      />
+    </div>
+  );
+}

--- a/frontend/components/admin/sort-button.tsx
+++ b/frontend/components/admin/sort-button.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowUpDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface SortButtonProps {
+  /** Called when the user clicks Apply. Commit whatever draft state the children expose. */
+  onApply: () => void;
+  /** Called when the user clicks Reset. Should clear the sort selection and close. */
+  onReset: () => void;
+  /**
+   * When true the button renders in its active style (popout open indicator).
+   * If omitted the component manages this automatically via the open state.
+   */
+  isActive?: boolean;
+  /** Page-specific sort controls rendered inside the popout content area. */
+  children: React.ReactNode;
+}
+
+/**
+ * Reusable Sort Button with a popout panel.
+ * ODY-360 — consistent across all admin pages; page-specific content injected via children.
+ */
+export function SortButton({
+  onApply,
+  onReset,
+  isActive,
+  children,
+}: SortButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  const active = isActive ?? open;
+
+  const handleApply = () => {
+    onApply();
+    setOpen(false);
+  };
+
+  const handleReset = () => {
+    onReset();
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        {/* Button: 100px × 40px, border #D0D5DD, border-radius 8px */}
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-haspopup="dialog"
+          className={cn(
+            "flex h-10 w-[100px] items-center justify-center gap-2 rounded-lg border bg-white px-3.5 text-sm font-medium text-[#344054] transition-colors",
+            active
+              ? "border-[#2D7597] shadow-[0px_0px_4px_#2D7597]"
+              : "border-[#D0D5DD] hover:border-slate-400",
+          )}
+        >
+          <ArrowUpDown className="h-4 w-4 flex-shrink-0" />
+          <span>Sort by</span>
+        </button>
+      </PopoverTrigger>
+
+      {/* Popout: 216px wide, border-radius 8px, shadow 0px 0px 4px rgba(0,0,0,0.25) */}
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="w-[216px] rounded-lg border-0 p-0 shadow-[0px_0px_4px_rgba(0,0,0,0.25)]"
+      >
+        {/* Title */}
+        <div className="px-4 pt-4 pb-3">
+          <p className="text-[15px] font-medium text-black">Sort by</p>
+        </div>
+
+        {/* Divider */}
+        <hr className="border-slate-200" />
+
+        {/* Page-specific sort content */}
+        <div className="px-4 py-3">{children}</div>
+
+        {/* Divider */}
+        <hr className="border-slate-200" />
+
+        {/* Footer */}
+        <div className="flex gap-2 px-4 py-3">
+          <button
+            type="button"
+            onClick={handleReset}
+            className="flex-1 rounded-lg border border-[#D0D5DD] bg-white py-1.5 text-xs font-medium text-[#344054] hover:bg-slate-50"
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            onClick={handleApply}
+            className="flex-1 rounded-lg bg-[#2D7597] py-1.5 text-xs font-medium text-white hover:bg-[#255e78]"
+          >
+            Apply
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/components/admin/users/create-user.tsx
+++ b/frontend/components/admin/users/create-user.tsx
@@ -35,7 +35,10 @@ export function CreateUser() {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button className="dark:bg-slate-300" after={<PlusIcon />}>
+        <Button
+          className="bg-[#2D7597] text-white hover:bg-[#255e78] dark:bg-[#2D7597] dark:hover:bg-[#255e78]"
+          before={<PlusIcon />}
+        >
           Create User
         </Button>
       </DialogTrigger>

--- a/frontend/components/admin/users/users-page-client.tsx
+++ b/frontend/components/admin/users/users-page-client.tsx
@@ -197,7 +197,7 @@ function UserTableRow({ user: initialUser }: { user: AuthorizedUser }) {
     <>
       <tr className="border-b border-slate-200 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800/50">
         {/* Name */}
-        <td className="px-4 py-3">
+        <td className="px-6 py-4">
           <div className="flex items-center gap-3">
             <Avatar variant="round" size="sm">
               <AvatarImage src={user.profilePhoto || undefined} />
@@ -206,16 +206,16 @@ function UserTableRow({ user: initialUser }: { user: AuthorizedUser }) {
               </AvatarFallback>
             </Avatar>
             <div className="min-w-0">
-              <p className="truncate font-medium text-slate-900 dark:text-slate-100">
+              <p className="truncate text-base font-medium text-slate-900 dark:text-slate-100">
                 {displayName}
                 {!user.isEnabled && (
-                  <span className="ml-1 text-xs font-normal text-slate-400">
+                  <span className="ml-1 text-sm font-normal text-slate-400">
                     (Disabled)
                   </span>
                 )}
               </p>
               {user.firstName && user.lastName && (
-                <p className="truncate text-xs text-slate-500 dark:text-slate-400">
+                <p className="truncate text-sm text-slate-500 dark:text-slate-400">
                   {user.email}
                 </p>
               )}
@@ -224,10 +224,10 @@ function UserTableRow({ user: initialUser }: { user: AuthorizedUser }) {
         </td>
 
         {/* Roles */}
-        <td className="px-4 py-3">
-          <div className="flex flex-wrap gap-1">
+        <td className="px-6 py-4">
+          <div className="flex flex-wrap gap-1.5">
             {user.roles.length === 0 ? (
-              <span className="text-sm text-slate-400">—</span>
+              <span className="text-base text-slate-400">—</span>
             ) : (
               user.roles.map((role) => {
                 const config = ROLE_CONFIG[role.title];
@@ -235,7 +235,7 @@ function UserTableRow({ user: initialUser }: { user: AuthorizedUser }) {
                   <Badge
                     key={role.title}
                     variant="outline"
-                    className={cn("text-xs font-medium", config.className)}
+                    className={cn("text-sm font-medium", config.className)}
                   >
                     {config.label}
                   </Badge>
@@ -246,7 +246,7 @@ function UserTableRow({ user: initialUser }: { user: AuthorizedUser }) {
         </td>
 
         {/* Actions */}
-        <td className="px-4 py-3">
+        <td className="px-6 py-4">
           <div className="flex items-center gap-2">
             <Button
               size="sm"
@@ -600,16 +600,16 @@ export function UsersPageClient({ users }: { users: AuthorizedUser[] }) {
 
       {/* Table */}
       <div className="overflow-hidden rounded-md border border-slate-200 dark:border-slate-700">
-        <table className="w-full text-sm">
+        <table className="w-full text-base">
           <thead className="bg-slate-50 dark:bg-slate-800">
             <tr>
-              <th className="px-4 py-3 text-left font-semibold text-slate-700 dark:text-slate-300">
+              <th className="px-6 py-4 text-left text-base font-semibold text-slate-700 dark:text-slate-300">
                 Name
               </th>
-              <th className="px-4 py-3 text-left font-semibold text-slate-700 dark:text-slate-300">
+              <th className="px-6 py-4 text-left text-base font-semibold text-slate-700 dark:text-slate-300">
                 Roles
               </th>
-              <th className="px-4 py-3 text-left font-semibold text-slate-700 dark:text-slate-300">
+              <th className="px-6 py-4 text-left text-base font-semibold text-slate-700 dark:text-slate-300">
                 Actions
               </th>
             </tr>

--- a/frontend/components/admin/users/users-page-client.tsx
+++ b/frontend/components/admin/users/users-page-client.tsx
@@ -1,0 +1,710 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { debounce } from "lodash";
+import { AuthorizedUser } from "@/types";
+import { AuthorizedUserRoleTitle } from "@/lib/globals";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { SearchBar } from "@/components/admin/search-bar";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input as TextInput } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { BarChart2, Pencil, User2Icon, Activity, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { updateUserInfo } from "@/lib/requests/authorized-user";
+import { useFormStatus } from "react-dom";
+import { SortButton } from "@/components/admin/sort-button";
+import { FilterButton } from "@/components/admin/filter-button";
+import { CreateUser } from "./create-user";
+
+const ITEMS_PER_PAGE = 10;
+
+// ——— Role display config ———
+const ROLE_CONFIG: Record<
+  AuthorizedUserRoleTitle,
+  { label: string; className: string }
+> = {
+  [AuthorizedUserRoleTitle.SysAdmin]: {
+    label: "Admin",
+    className:
+      "bg-rose-100 text-rose-700 border-rose-200 dark:bg-rose-900/30 dark:text-rose-400 dark:border-rose-800",
+  },
+  [AuthorizedUserRoleTitle.Faculty]: {
+    label: "Faculty",
+    className:
+      "bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-800",
+  },
+  [AuthorizedUserRoleTitle.ContentCreator]: {
+    label: "Content Creator",
+    className:
+      "bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800",
+  },
+  [AuthorizedUserRoleTitle.ContentEditor]: {
+    label: "Content Editor",
+    className:
+      "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-400 dark:border-amber-800",
+  },
+  [AuthorizedUserRoleTitle.User]: {
+    label: "User",
+    className:
+      "bg-slate-100 text-slate-600 border-slate-200 dark:bg-slate-700/50 dark:text-slate-300 dark:border-slate-600",
+  },
+};
+
+const DEFAULT_SORT = "name-asc";
+
+const SORT_GROUPS = [
+  {
+    header: "Name",
+    options: [
+      { value: "name-asc", label: "A–Z" },
+      { value: "name-desc", label: "Z–A" },
+    ],
+  },
+  {
+    header: "Email",
+    options: [{ value: "email-asc", label: "A–Z" }],
+  },
+] as const;
+
+const FILTER_ROLE_OPTIONS = [
+  { value: AuthorizedUserRoleTitle.SysAdmin, label: "Admin" },
+  { value: AuthorizedUserRoleTitle.Faculty, label: "Faculty" },
+  { value: AuthorizedUserRoleTitle.ContentCreator, label: "Content Creator" },
+  { value: AuthorizedUserRoleTitle.ContentEditor, label: "Content Editor" },
+  { value: AuthorizedUserRoleTitle.User, label: "User" },
+] as const;
+
+// ——— Activity types ———
+interface UserActivity {
+  timestamp: string;
+  type:
+    | "enrollment"
+    | "page_view"
+    | "lesson_view"
+    | "completion"
+    | "rating"
+    | "quiz";
+  description: string;
+  details?: {
+    properties?: {
+      $pathname?: string;
+      pathname?: string;
+      $current_url?: string;
+    };
+    source?: string;
+  };
+}
+
+// ——— UserTableRow ———
+function UserTableRow({ user: initialUser }: { user: AuthorizedUser }) {
+  const [user, setUser] = useState(initialUser);
+  const [editOpen, setEditOpen] = useState(false);
+  const [activityOpen, setActivityOpen] = useState(false);
+  const [activities, setActivities] = useState<UserActivity[]>([]);
+  const [loadingActivities, setLoadingActivities] = useState(false);
+
+  // Edit form state
+  const [firstName, setFirstName] = useState(user.firstName || "");
+  const [lastName, setLastName] = useState(user.lastName || "");
+  const [bio, setBio] = useState(user.bio || "");
+  const [selectedRoles, setSelectedRoles] = useState<AuthorizedUserRoleTitle[]>(
+    user.roles.map((r) => r.title),
+  );
+
+  const roleOptions = [
+    { value: AuthorizedUserRoleTitle.Faculty, label: "Faculty" },
+    { value: AuthorizedUserRoleTitle.ContentCreator, label: "Content Creator" },
+    { value: AuthorizedUserRoleTitle.ContentEditor, label: "Content Editor" },
+    { value: AuthorizedUserRoleTitle.SysAdmin, label: "System Admin" },
+  ] as const;
+
+  const toggleRole = (role: AuthorizedUserRoleTitle) => {
+    setSelectedRoles((current) =>
+      current.includes(role)
+        ? current.filter((r) => r !== role)
+        : [...current, role],
+    );
+  };
+
+  const handleEditUser = async (formData: FormData) => {
+    const result = await updateUserInfo(user.id, {
+      first: formData.get("firstName") as string,
+      last: formData.get("lastName") as string,
+      bio: formData.get("bio") as string,
+      roles: selectedRoles,
+    });
+
+    if (result.success) {
+      setUser((prev) => ({
+        ...prev,
+        firstName: formData.get("firstName") as string,
+        lastName: formData.get("lastName") as string,
+        bio: formData.get("bio") as string,
+        roles: selectedRoles.map((title) => ({ id: 0, title })),
+      }));
+      toast.success("User updated successfully");
+      setEditOpen(false);
+    } else {
+      toast.error("Failed to update user");
+    }
+  };
+
+  const handleToggleEnabled = async () => {
+    const next = !user.isEnabled;
+    setUser((prev) => ({ ...prev, isEnabled: next }));
+    await updateUserInfo(user.id, { isEnabled: next });
+  };
+
+  const handleViewActivity = async () => {
+    setActivityOpen(true);
+    setLoadingActivities(true);
+    try {
+      const response = await fetch(`/api/user-activity/${user.id}`, {
+        method: "GET",
+        cache: "no-store",
+      });
+      if (!response.ok) throw new Error("Failed to fetch activity");
+      setActivities(await response.json());
+    } catch {
+      toast.error("Failed to load user activity");
+    } finally {
+      setLoadingActivities(false);
+    }
+  };
+
+  const displayName =
+    user.firstName && user.lastName
+      ? `${user.firstName} ${user.lastName}`
+      : user.email;
+
+  const initials =
+    user.firstName && user.lastName
+      ? user.firstName[0] + user.lastName[0]
+      : null;
+
+  return (
+    <>
+      <tr className="border-b border-slate-200 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800/50">
+        {/* Name */}
+        <td className="px-4 py-3">
+          <div className="flex items-center gap-3">
+            <Avatar variant="round" size="sm">
+              <AvatarImage src={user.profilePhoto || undefined} />
+              <AvatarFallback>
+                {initials ?? <User2Icon className="h-4 w-4" />}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0">
+              <p className="truncate font-medium text-slate-900 dark:text-slate-100">
+                {displayName}
+                {!user.isEnabled && (
+                  <span className="ml-1 text-xs font-normal text-slate-400">
+                    (Disabled)
+                  </span>
+                )}
+              </p>
+              {user.firstName && user.lastName && (
+                <p className="truncate text-xs text-slate-500 dark:text-slate-400">
+                  {user.email}
+                </p>
+              )}
+            </div>
+          </div>
+        </td>
+
+        {/* Roles */}
+        <td className="px-4 py-3">
+          <div className="flex flex-wrap gap-1">
+            {user.roles.length === 0 ? (
+              <span className="text-sm text-slate-400">—</span>
+            ) : (
+              user.roles.map((role) => {
+                const config = ROLE_CONFIG[role.title];
+                return config ? (
+                  <Badge
+                    key={role.title}
+                    variant="outline"
+                    className={cn("text-xs font-medium", config.className)}
+                  >
+                    {config.label}
+                  </Badge>
+                ) : null;
+              })
+            )}
+          </div>
+        </td>
+
+        {/* Actions */}
+        <td className="px-4 py-3">
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleViewActivity}
+              aria-label="view activity"
+              className="h-8 w-8 p-0"
+            >
+              <BarChart2 className="h-4 w-4 text-sky-600" />
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setEditOpen(true)}
+              aria-label="edit user"
+              className="h-8 w-8 p-0"
+            >
+              <Pencil className="h-4 w-4 text-sky-600" />
+            </Button>
+          </div>
+        </td>
+      </tr>
+
+      {/* Edit Dialog */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent className="scale-75 sm:scale-100">
+          <DialogHeader>
+            <DialogTitle>Edit User</DialogTitle>
+            <DialogDescription>Update user information</DialogDescription>
+          </DialogHeader>
+          <form action={handleEditUser} className="space-y-3">
+            <input type="hidden" name="id" value={user.id} />
+            <TextInput
+              name="firstName"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              placeholder="First Name"
+            />
+            <TextInput
+              name="lastName"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              placeholder="Last Name"
+            />
+            <Textarea
+              name="bio"
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+              placeholder="Bio"
+            />
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Roles</label>
+              <div className="space-y-2">
+                {roleOptions.map((role) => (
+                  <div key={role.value} className="flex items-center space-x-2">
+                    <Checkbox
+                      id={`edit-role-${role.value}`}
+                      checked={selectedRoles.includes(role.value)}
+                      onCheckedChange={() => toggleRole(role.value)}
+                      className="border-sky-500 focus-visible:ring-sky-500 data-[state=checked]:border-sky-500 data-[state=checked]:bg-sky-500"
+                    />
+                    <label
+                      htmlFor={`edit-role-${role.value}`}
+                      className="text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                    >
+                      {role.label}
+                    </label>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="flex items-center justify-between pt-1">
+              <SaveButton />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className={
+                  user.isEnabled
+                    ? "border-red-200 text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400"
+                    : "border-green-200 text-green-600 hover:bg-green-50 dark:border-green-800 dark:text-green-400"
+                }
+                onClick={handleToggleEnabled}
+              >
+                {user.isEnabled ? "Disable Access" : "Enable Access"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Activity Dialog */}
+      <Dialog open={activityOpen} onOpenChange={setActivityOpen}>
+        <DialogContent className="max-h-[80vh] max-w-3xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Activity className="h-5 w-5" />
+              Activity Timeline — {user.firstName} {user.lastName}
+            </DialogTitle>
+            <DialogDescription>
+              Chronological view of all website activity
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-4">
+            {loadingActivities ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-8 w-8 animate-spin text-sky-600" />
+              </div>
+            ) : activities.length === 0 ? (
+              <p className="py-8 text-center text-slate-500">
+                No activity recorded yet
+              </p>
+            ) : (
+              <div className="space-y-3">
+                {activities.map((activity, index) => {
+                  let pathname: string | null = null;
+                  if (
+                    activity.type === "page_view" &&
+                    activity.details?.properties
+                  ) {
+                    const props = activity.details.properties;
+                    pathname =
+                      props.$pathname ||
+                      props.pathname ||
+                      (props.$current_url
+                        ? new URL(props.$current_url, "https://example.com")
+                            .pathname
+                        : null);
+                  }
+                  const isCompletion = activity.type === "completion";
+                  const isQuiz = activity.type === "quiz";
+
+                  return (
+                    <div
+                      key={index}
+                      className={cn(
+                        "flex gap-4 rounded-lg border p-3",
+                        isCompletion
+                          ? "border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950"
+                          : isQuiz
+                            ? "border-purple-200 bg-purple-50 dark:border-purple-800 dark:bg-purple-950"
+                            : "border-slate-200 dark:border-slate-700",
+                      )}
+                    >
+                      <div className="w-32 flex-shrink-0 text-xs text-slate-500">
+                        {new Date(activity.timestamp).toLocaleString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </div>
+                      <div className="flex-1 text-sm">
+                        <p className="font-medium text-slate-900 dark:text-slate-100">
+                          {activity.description}
+                        </p>
+                        {pathname && (
+                          <p className="mt-0.5 font-mono text-xs text-slate-500">
+                            {pathname}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function SaveButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" aria-disabled={pending}>
+      Save Changes
+    </Button>
+  );
+}
+
+// ——— Main Client Component ———
+export function UsersPageClient({ users }: { users: AuthorizedUser[] }) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [filteredUsers, setFilteredUsers] = useState<AuthorizedUser[]>(users);
+
+  // Active (committed) sort/filter
+  const [activeSortBy, setActiveSortBy] = useState(DEFAULT_SORT);
+  const [activeFilterRoles, setActiveFilterRoles] = useState<string[]>([]);
+
+  // Draft (in-popout) sort/filter — only committed on Apply
+  const [draftSortBy, setDraftSortBy] = useState(DEFAULT_SORT);
+  const [draftFilterRoles, setDraftFilterRoles] = useState<string[]>([]);
+
+  const applyFiltersAndSort = useCallback(
+    (search: string, sort: string, roles: string[]) => {
+      let result = [...users];
+
+      if (search.trim()) {
+        const q = search.toLowerCase();
+        result = result.filter(
+          (u) =>
+            u.firstName?.toLowerCase().includes(q) ||
+            u.lastName?.toLowerCase().includes(q) ||
+            u.email?.toLowerCase().includes(q),
+        );
+      }
+
+      if (roles.length > 0) {
+        result = result.filter((u) =>
+          u.roles.some((r) => roles.includes(r.title)),
+        );
+      }
+
+      if (sort === "name-asc") {
+        result.sort((a, b) =>
+          (a.lastName || a.email).localeCompare(b.lastName || b.email),
+        );
+      } else if (sort === "name-desc") {
+        result.sort((a, b) =>
+          (b.lastName || b.email).localeCompare(a.lastName || a.email),
+        );
+      } else if (sort === "email-asc") {
+        result.sort((a, b) => a.email.localeCompare(b.email));
+      }
+
+      setFilteredUsers(result);
+      setCurrentPage(1);
+    },
+    [users],
+  );
+
+  const debouncedSearch = useCallback(
+    debounce((value: string) => {
+      applyFiltersAndSort(value, activeSortBy, activeFilterRoles);
+    }, 400),
+    [applyFiltersAndSort, activeSortBy, activeFilterRoles],
+  );
+
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(e.target.value);
+    debouncedSearch(e.target.value);
+  };
+
+  const handleSortApply = () => {
+    setActiveSortBy(draftSortBy);
+    applyFiltersAndSort(searchTerm, draftSortBy, activeFilterRoles);
+  };
+
+  const handleSortReset = () => {
+    setDraftSortBy(DEFAULT_SORT);
+    setActiveSortBy(DEFAULT_SORT);
+    applyFiltersAndSort(searchTerm, DEFAULT_SORT, activeFilterRoles);
+  };
+
+  const handleFilterApply = () => {
+    setActiveFilterRoles(draftFilterRoles);
+    applyFiltersAndSort(searchTerm, activeSortBy, draftFilterRoles);
+  };
+
+  const handleFilterReset = () => {
+    setDraftFilterRoles([]);
+    setActiveFilterRoles([]);
+    applyFiltersAndSort(searchTerm, activeSortBy, []);
+  };
+
+  const toggleDraftFilterRole = (role: string) => {
+    setDraftFilterRoles((current) =>
+      current.includes(role)
+        ? current.filter((r) => r !== role)
+        : [...current, role],
+    );
+  };
+
+  const totalPages = Math.ceil(filteredUsers.length / ITEMS_PER_PAGE);
+  const start = (currentPage - 1) * ITEMS_PER_PAGE;
+  const pageUsers = filteredUsers.slice(start, start + ITEMS_PER_PAGE);
+
+  return (
+    <div className="space-y-4">
+      {/* Controls — search left, sort+filter+create right */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <SearchBar
+          placeholder="Search by name or email…"
+          value={searchTerm}
+          onChange={handleSearch}
+          className="max-w-[560px]"
+        />
+        <div className="flex items-center gap-2">
+          <SortButton onApply={handleSortApply} onReset={handleSortReset}>
+            <div className="space-y-3">
+              {SORT_GROUPS.map((group) => (
+                <div key={group.header}>
+                  <p className="mb-1.5 text-xs font-semibold tracking-wide text-slate-400 uppercase">
+                    {group.header}
+                  </p>
+                  <div className="space-y-1.5">
+                    {group.options.map((opt) => (
+                      <label
+                        key={opt.value}
+                        className="flex cursor-pointer items-center gap-2 text-sm text-[#344054]"
+                      >
+                        <input
+                          type="radio"
+                          name="sort-option"
+                          value={opt.value}
+                          checked={draftSortBy === opt.value}
+                          onChange={() => setDraftSortBy(opt.value)}
+                          className="accent-[#2D7597]"
+                        />
+                        {opt.label}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </SortButton>
+
+          <FilterButton
+            onApply={handleFilterApply}
+            onReset={handleFilterReset}
+            hasActiveFilters={activeFilterRoles.length > 0}
+          >
+            <div className="space-y-2">
+              {FILTER_ROLE_OPTIONS.map((opt) => (
+                <label
+                  key={opt.value}
+                  className="flex cursor-pointer items-center gap-2 text-sm text-[#344054]"
+                >
+                  <input
+                    type="checkbox"
+                    value={opt.value}
+                    checked={draftFilterRoles.includes(opt.value)}
+                    onChange={() => toggleDraftFilterRole(opt.value)}
+                    className="accent-[#2D7597]"
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
+          </FilterButton>
+
+          <CreateUser />
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-hidden rounded-md border border-slate-200 dark:border-slate-700">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 dark:bg-slate-800">
+            <tr>
+              <th className="px-4 py-3 text-left font-semibold text-slate-700 dark:text-slate-300">
+                Name
+              </th>
+              <th className="px-4 py-3 text-left font-semibold text-slate-700 dark:text-slate-300">
+                Roles
+              </th>
+              <th className="px-4 py-3 text-left font-semibold text-slate-700 dark:text-slate-300">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-slate-900">
+            {pageUsers.length > 0 ? (
+              pageUsers.map((user) => (
+                <UserTableRow key={user.id} user={user} />
+              ))
+            ) : (
+              <tr>
+                <td
+                  colSpan={3}
+                  className="px-4 py-8 text-center text-slate-500 dark:text-slate-400"
+                >
+                  No users found.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="grid grid-cols-3 items-center border-t border-slate-200 pt-3 dark:border-slate-700">
+          {/* Previous — far left */}
+          <div>
+            <button
+              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+              disabled={currentPage === 1}
+              className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              Previous
+            </button>
+          </div>
+
+          {/* Page numbers — centre */}
+          <div className="flex justify-center gap-1">
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map(
+              (pageNum) => {
+                const isEllipsis =
+                  totalPages > 5 &&
+                  pageNum !== 1 &&
+                  pageNum !== totalPages &&
+                  (pageNum < currentPage - 1 || pageNum > currentPage + 1);
+                const prevWasEllipsis =
+                  totalPages > 5 &&
+                  pageNum - 1 !== 1 &&
+                  pageNum - 1 !== totalPages &&
+                  (pageNum - 1 < currentPage - 1 ||
+                    pageNum - 1 > currentPage + 1);
+
+                if (isEllipsis) {
+                  // Only render one ellipsis per gap
+                  return prevWasEllipsis ? null : (
+                    <span
+                      key={`ellipsis-${pageNum}`}
+                      className="flex items-end pb-0.5 text-slate-400"
+                    >
+                      …
+                    </span>
+                  );
+                }
+
+                return (
+                  <button
+                    key={pageNum}
+                    onClick={() => setCurrentPage(pageNum)}
+                    className={cn(
+                      "h-8 min-w-8 rounded-md px-2 text-sm font-medium transition-colors",
+                      pageNum === currentPage
+                        ? "bg-[#2D7597] text-white"
+                        : "text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800",
+                    )}
+                  >
+                    {pageNum}
+                  </button>
+                );
+              },
+            )}
+          </div>
+
+          {/* Next — far right */}
+          <div className="flex justify-end">
+            <button
+              onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+              disabled={currentPage === totalPages}
+              className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/admin/users/users-page.tsx
+++ b/frontend/components/admin/users/users-page.tsx
@@ -1,0 +1,17 @@
+import { fetchAuthorizedUsers } from "@/lib/requests/authorized-user";
+import { UsersPageClient } from "./users-page-client";
+
+export async function UsersPage() {
+  const users = await fetchAuthorizedUsers();
+  const sortedUsers = [...users].sort((a, b) => {
+    const aValue = a.lastName || a.email;
+    const bValue = b.lastName || b.email;
+    return aValue.localeCompare(bValue);
+  });
+
+  return (
+    <div className="p-4">
+      <UsersPageClient users={sortedUsers} />
+    </div>
+  );
+}

--- a/frontend/tests/components/admin/admin-nav.test.tsx
+++ b/frontend/tests/components/admin/admin-nav.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import { AdminNav } from "@/components/admin/admin-nav";
+
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(() => "/admin"),
+}));
+
+const { usePathname } = jest.requireMock("next/navigation");
+
+describe("AdminNav", () => {
+  const NAV_LABELS = [
+    "Dashboard",
+    "Users",
+    "Droplets",
+    "Playlists",
+    "Groups",
+    "Access Manager",
+    "Creators Manager",
+    "Reports",
+  ];
+
+  beforeEach(() => {
+    usePathname.mockReturnValue("/admin");
+  });
+
+  it("renders all 8 nav items", () => {
+    render(<AdminNav />);
+    NAV_LABELS.forEach((label) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  it("marks Dashboard active when pathname is /admin", () => {
+    usePathname.mockReturnValue("/admin");
+    render(<AdminNav />);
+    const link = screen.getByRole("link", { name: /dashboard/i });
+    expect(link).toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks Users active when pathname is /admin/users", () => {
+    usePathname.mockReturnValue("/admin/users");
+    render(<AdminNav />);
+    const link = screen.getByRole("link", { name: /^users$/i });
+    expect(link).toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks no item active when property1 is 'Default' and pathname has no match", () => {
+    usePathname.mockReturnValue("/some/other/path");
+    render(<AdminNav property1="Default" />);
+    const links = screen.getAllByRole("link");
+    links.forEach((link) => {
+      expect(link).not.toHaveAttribute("aria-current", "page");
+    });
+  });
+
+  it("overrides pathname detection when property1 is set", () => {
+    usePathname.mockReturnValue("/admin"); // would normally make Dashboard active
+    render(<AdminNav property1="Reports" />);
+
+    const reportsLink = screen.getByRole("link", { name: /reports/i });
+    expect(reportsLink).toHaveAttribute("aria-current", "page");
+
+    const dashboardLink = screen.getByRole("link", { name: /dashboard/i });
+    expect(dashboardLink).not.toHaveAttribute("aria-current", "page");
+  });
+
+  it("each nav item links to the correct href", () => {
+    render(<AdminNav />);
+    expect(screen.getByRole("link", { name: /dashboard/i })).toHaveAttribute(
+      "href",
+      "/admin",
+    );
+    expect(screen.getByRole("link", { name: /^users$/i })).toHaveAttribute(
+      "href",
+      "/admin/users",
+    );
+    expect(screen.getByRole("link", { name: /droplets/i })).toHaveAttribute(
+      "href",
+      "/admin/droplets",
+    );
+    expect(screen.getByRole("link", { name: /playlists/i })).toHaveAttribute(
+      "href",
+      "/admin/playlists",
+    );
+    expect(screen.getByRole("link", { name: /groups/i })).toHaveAttribute(
+      "href",
+      "/admin/groups",
+    );
+    expect(
+      screen.getByRole("link", { name: /access manager/i }),
+    ).toHaveAttribute("href", "/admin/access-manager");
+    expect(
+      screen.getByRole("link", { name: /creators manager/i }),
+    ).toHaveAttribute("href", "/admin/creators-manager");
+    expect(screen.getByRole("link", { name: /reports/i })).toHaveAttribute(
+      "href",
+      "/admin/reports",
+    );
+  });
+});

--- a/frontend/tests/components/admin/filter-button.test.tsx
+++ b/frontend/tests/components/admin/filter-button.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FilterButton } from "@/components/admin/filter-button";
+
+describe("FilterButton", () => {
+  it("renders the button with 'Filter' label", () => {
+    render(
+      <FilterButton onApply={jest.fn()} onReset={jest.fn()}>
+        <div>filter options</div>
+      </FilterButton>,
+    );
+    expect(screen.getByText("Filter")).toBeInTheDocument();
+  });
+
+  it("opens the popout when clicked", async () => {
+    render(
+      <FilterButton onApply={jest.fn()} onReset={jest.fn()}>
+        <div>filter options</div>
+      </FilterButton>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(await screen.findByText("filter options")).toBeInTheDocument();
+  });
+
+  it("renders Reset and Apply buttons inside the popout", async () => {
+    render(
+      <FilterButton onApply={jest.fn()} onReset={jest.fn()}>
+        <div>options</div>
+      </FilterButton>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(await screen.findByText("Reset")).toBeInTheDocument();
+    expect(await screen.findByText("Apply")).toBeInTheDocument();
+  });
+
+  it("calls onApply and closes popout when Apply is clicked", async () => {
+    const onApply = jest.fn();
+    render(
+      <FilterButton onApply={onApply} onReset={jest.fn()}>
+        <div>options</div>
+      </FilterButton>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(await screen.findByText("Apply"));
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("options")).not.toBeInTheDocument();
+  });
+
+  it("calls onReset and closes popout when Reset is clicked", async () => {
+    const onReset = jest.fn();
+    render(
+      <FilterButton onApply={jest.fn()} onReset={onReset}>
+        <div>options</div>
+      </FilterButton>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(await screen.findByText("Reset"));
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("options")).not.toBeInTheDocument();
+  });
+
+  it("renders injected children inside the popout", async () => {
+    render(
+      <FilterButton onApply={jest.fn()} onReset={jest.fn()}>
+        <p data-testid="custom-filter-content">Role checkboxes here</p>
+      </FilterButton>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(
+      await screen.findByTestId("custom-filter-content"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows active styling when hasActiveFilters is true", () => {
+    const { container } = render(
+      <FilterButton
+        onApply={jest.fn()}
+        onReset={jest.fn()}
+        hasActiveFilters={true}
+      >
+        <div>options</div>
+      </FilterButton>,
+    );
+
+    const button = container.querySelector("button");
+    // The teal border class is applied when active
+    expect(button?.className).toContain("border-[#2D7597]");
+  });
+
+  it("shows active styling when property1 is 'Active State'", () => {
+    const { container } = render(
+      <FilterButton
+        onApply={jest.fn()}
+        onReset={jest.fn()}
+        property1="Active State"
+      >
+        <div>options</div>
+      </FilterButton>,
+    );
+
+    const button = container.querySelector("button");
+    expect(button?.className).toContain("border-[#2D7597]");
+  });
+
+  it("shows default styling when no filters are active and popout is closed", () => {
+    const { container } = render(
+      <FilterButton onApply={jest.fn()} onReset={jest.fn()}>
+        <div>options</div>
+      </FilterButton>,
+    );
+
+    const button = container.querySelector("button");
+    expect(button?.className).toContain("border-[#D0D5DD]");
+    expect(button?.className).not.toContain("border-[#2D7597]");
+  });
+});

--- a/frontend/tests/components/admin/sort-button.test.tsx
+++ b/frontend/tests/components/admin/sort-button.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SortButton } from "@/components/admin/sort-button";
+
+describe("SortButton", () => {
+  it("renders the button with 'Sort by' label", () => {
+    render(
+      <SortButton onApply={jest.fn()} onReset={jest.fn()}>
+        <div>sort options</div>
+      </SortButton>,
+    );
+    expect(screen.getByText("Sort by")).toBeInTheDocument();
+  });
+
+  it("opens the popout when clicked", async () => {
+    render(
+      <SortButton onApply={jest.fn()} onReset={jest.fn()}>
+        <div>sort options</div>
+      </SortButton>,
+    );
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(await screen.findByText("sort options")).toBeInTheDocument();
+  });
+
+  it("renders the popout title 'Sort by'", async () => {
+    render(
+      <SortButton onApply={jest.fn()} onReset={jest.fn()}>
+        <div>content</div>
+      </SortButton>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    // Both the button label and the popout title say "Sort by"
+    const allSortBy = await screen.findAllByText("Sort by");
+    expect(allSortBy.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders Reset and Apply buttons inside the popout", async () => {
+    render(
+      <SortButton onApply={jest.fn()} onReset={jest.fn()}>
+        <div>options</div>
+      </SortButton>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(await screen.findByText("Reset")).toBeInTheDocument();
+    expect(await screen.findByText("Apply")).toBeInTheDocument();
+  });
+
+  it("calls onApply and closes popout when Apply is clicked", async () => {
+    const onApply = jest.fn();
+    render(
+      <SortButton onApply={onApply} onReset={jest.fn()}>
+        <div>options</div>
+      </SortButton>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(await screen.findByText("Apply"));
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("options")).not.toBeInTheDocument();
+  });
+
+  it("calls onReset and closes popout when Reset is clicked", async () => {
+    const onReset = jest.fn();
+    render(
+      <SortButton onApply={jest.fn()} onReset={onReset}>
+        <div>options</div>
+      </SortButton>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(await screen.findByText("Reset"));
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("options")).not.toBeInTheDocument();
+  });
+
+  it("renders injected children inside the popout", async () => {
+    render(
+      <SortButton onApply={jest.fn()} onReset={jest.fn()}>
+        <p data-testid="custom-sort-content">Custom sort options here</p>
+      </SortButton>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(
+      await screen.findByTestId("custom-sort-content"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/admin/users-page-client.test.tsx
+++ b/frontend/tests/components/admin/users-page-client.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { UsersPageClient } from "@/components/admin/users/users-page-client";
+import { AuthorizedUserRoleTitle } from "@/lib/globals";
+import { AuthorizedUser, TimeZone } from "@/types";
+
+// Mock updateUserInfo to avoid "use server" issues in tests
+jest.mock("@/lib/requests/authorized-user", () => ({
+  updateUserInfo: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const makeUser = (overrides: Partial<AuthorizedUser> = {}): AuthorizedUser => ({
+  id: 1,
+  email: "user@example.com",
+  isEnabled: true,
+  firstName: "Jane",
+  lastName: "Doe",
+  bio: "",
+  profilePhoto: "",
+  linkedin: "",
+  github: "",
+  website: "",
+  firstTime: false,
+  isPublic: true,
+  friendships: [],
+  sent_requests: [],
+  received_requests: [],
+  blocked: [],
+  was_blocked: [],
+  timeZone: "America/New_York" as TimeZone,
+  roles: [],
+  ...overrides,
+});
+
+const mockUsers = [
+  makeUser({
+    id: 1,
+    email: "alice@example.com",
+    firstName: "Alice",
+    lastName: "Smith",
+    roles: [{ id: 1, title: AuthorizedUserRoleTitle.SysAdmin }],
+  }),
+  makeUser({
+    id: 2,
+    email: "bob@example.com",
+    firstName: "Bob",
+    lastName: "Jones",
+    roles: [{ id: 2, title: AuthorizedUserRoleTitle.Faculty }],
+  }),
+  makeUser({
+    id: 3,
+    email: "carol@example.com",
+    firstName: "Carol",
+    lastName: "Lee",
+    roles: [{ id: 3, title: AuthorizedUserRoleTitle.ContentCreator }],
+  }),
+];
+
+describe("UsersPageClient", () => {
+  it("renders the table with column headers", () => {
+    render(<UsersPageClient users={mockUsers} />);
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Roles")).toBeInTheDocument();
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+  });
+
+  it("renders all users in the table", () => {
+    render(<UsersPageClient users={mockUsers} />);
+
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    expect(screen.getByText("Bob Jones")).toBeInTheDocument();
+    expect(screen.getByText("Carol Lee")).toBeInTheDocument();
+  });
+
+  it("shows role badges for each user", () => {
+    render(<UsersPageClient users={mockUsers} />);
+
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+    expect(screen.getByText("Faculty")).toBeInTheDocument();
+    expect(screen.getByText("Content Creator")).toBeInTheDocument();
+  });
+
+  it("renders edit and activity action buttons for each user", () => {
+    render(<UsersPageClient users={mockUsers} />);
+
+    const editButtons = screen.getAllByRole("button", { name: /edit user/i });
+    const activityButtons = screen.getAllByRole("button", {
+      name: /view activity/i,
+    });
+
+    expect(editButtons).toHaveLength(mockUsers.length);
+    expect(activityButtons).toHaveLength(mockUsers.length);
+  });
+
+  it("shows email when no name is set", () => {
+    const users = [
+      makeUser({
+        id: 4,
+        email: "noname@example.com",
+        firstName: "",
+        lastName: "",
+      }),
+    ];
+    render(<UsersPageClient users={users} />);
+    expect(screen.getByText("noname@example.com")).toBeInTheDocument();
+  });
+
+  it("displays empty state when no users found", () => {
+    render(<UsersPageClient users={[]} />);
+    expect(screen.getByText("No users found.")).toBeInTheDocument();
+  });
+
+  it("filters users by search term", async () => {
+    render(<UsersPageClient users={mockUsers} />);
+
+    const searchInput = screen.getByPlaceholderText(/search by name or email/i);
+    fireEvent.change(searchInput, { target: { value: "alice" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+      expect(screen.queryByText("Bob Jones")).not.toBeInTheDocument();
+    });
+  });
+
+  it("paginates with 10 items per page", () => {
+    const manyUsers = Array.from({ length: 15 }, (_, i) =>
+      makeUser({
+        id: i + 1,
+        email: `user${i + 1}@example.com`,
+        firstName: `First${i + 1}`,
+        lastName: `Last${i + 1}`,
+        roles: [],
+      }),
+    );
+
+    render(<UsersPageClient users={manyUsers} />);
+
+    // First 10 should be visible
+    expect(screen.getByText("First1 Last1")).toBeInTheDocument();
+    expect(screen.getByText("First10 Last10")).toBeInTheDocument();
+    // 11th should not be visible
+    expect(screen.queryByText("First11 Last11")).not.toBeInTheDocument();
+  });
+
+  it("shows Previous and Next pagination buttons when there are multiple pages", () => {
+    const manyUsers = Array.from({ length: 15 }, (_, i) =>
+      makeUser({
+        id: i + 10,
+        email: `u${i}@example.com`,
+        firstName: `F${i}`,
+        lastName: `L${i}`,
+      }),
+    );
+    render(<UsersPageClient users={manyUsers} />);
+    expect(
+      screen.getByRole("button", { name: /previous/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

  Implements a dedicated Admin Users management page at /admin/users with reusable admin UI components.

  Admin Users Page (ODY-350)
  - New route at /admin/users — server-side auth guard redirects non-admins to 404
  - Paginated table (10 rows/page) with Name, Roles, and Actions columns
  - Role badges color-coded per role: Admin (red), Faculty (blue), Content Creator (green), Content Editor (amber), User (gray)
  - Per-row edit dialog (update name, bio, roles, enable/disable) and activity timeline dialog (bar chart icon)
  - Custom pagination bar: "Previous" button far left, page numbers centered (no arrows, active page in teal), "Next" button far right

  Sort Button (ODY-360)
  - Reusable <SortButton> component with popout panel anchored below button, dismisses on outside click
  - Grouped sort options with category headers (e.g. Name → A–Z / Z–A, Email → A–Z)
  - Active state (teal glow) when popout is open; Reset/Apply footer

  Filter Button (ODY-361)
  - Reusable <FilterButton> component with same popout shell
  - Active state (teal border + glow) when popout is open or filters are applied (hasActiveFilters)
  - property1 prop: "Filters Button" | "Active State"

  Search Bar (ODY-357)
  - Pill-shaped input (border-radius 30px), bg #FCFCFD, 2px border #EFEFF0
  - Search icon 20px from left, placeholder in Lato Regular #667085
  - Focus ring in Odyssey teal #2D7597

  Create User button updated to Odyssey blue (#2D7597) with + icon before label.

## Motivation and Context

  Part of the Admin Redesign epic (ODY-291). The existing admin panel manages users through a tab on the main admin dashboard with a card/list layout. This adds a dedicated, purpose-built Users
  page with a proper table UI, reusable sort/filter components that can be adopted by other admin pages, and a spec-compliant search bar.