### PR TITLE
Bug/playlist fix

### DIFF
--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -78,7 +78,16 @@ export default async function GroupDetailPage({ params }: Props) {
     { completionPercentage: number; completionDate: Date | undefined }
   > = {};
 
-  if (group.members && group.droplets) {
+  const allDropletIds = [
+    ...new Set([
+      ...(group.droplets?.map((d) => d.id) || []),
+      ...(group.playlists?.flatMap(
+        (p) => p.droplets?.map((d) => d.id) || [],
+      ) || []),
+    ]),
+  ];
+
+  if (group.members && allDropletIds.length > 0) {
     sortedMembers = [...group.members].sort((a, b) => {
       const aValue = a.lastName || a.email;
       const bValue = b.lastName || b.email;
@@ -87,11 +96,10 @@ export default async function GroupDetailPage({ params }: Props) {
 
     try {
       const memberIds = sortedMembers.map((m) => m.id);
-      const dropletIds = group.droplets.map((d) => d.id);
 
       const allEnrollments = await getEnrollmentsForGroupMembers(
         memberIds,
-        dropletIds,
+        allDropletIds,
       );
 
       allEnrollments.forEach((enrollment) => {

--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -81,9 +81,8 @@ export default async function GroupDetailPage({ params }: Props) {
   const allDropletIds = [
     ...new Set([
       ...(group.droplets?.map((d) => d.id) || []),
-      ...(group.playlists?.flatMap(
-        (p) => p.droplets?.map((d) => d.id) || [],
-      ) || []),
+      ...(group.playlists?.flatMap((p) => p.droplets?.map((d) => d.id) || []) ||
+        []),
     ]),
   ];
 


### PR DESCRIPTION

## Description

Progress calculation in the group page only fetched enrollment data for direct droplets (`group.droplets`), ignoring droplets nested inside playlists (`group.playlists[].droplets`). Now collects droplet IDs from both sources before querying enrollments.

## Motivation and Context

Instructors reported that the Progress tab shows 0% for all students when viewing playlist progress. This affected all groups across both Spring 2026 and Fall 2025 semesters. The root cause was that `getEnrollmentsForGroupMembers` was only called with direct droplet IDs, so playlist droplet enrollments were never fetched. 

## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed enrollment and completion tracking for groups to now properly include droplets from playlists alongside directly assigned droplets, ensuring all group content is tracked and visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->