### PR TITLE
Bug/playlist progress fix

### DIFF
--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -78,7 +78,16 @@ export default async function GroupDetailPage({ params }: Props) {
     { completionPercentage: number; completionDate: Date | undefined }
   > = {};
 
-  if (group.members && group.droplets) {
+  const allDropletIds = [
+    ...new Set([
+      ...(group.droplets?.map((d) => d.id) || []),
+      ...(group.playlists?.flatMap(
+        (p) => p.droplets?.map((d) => d.id) || [],
+      ) || []),
+    ]),
+  ];
+
+  if (group.members && allDropletIds.length > 0) {
     sortedMembers = [...group.members].sort((a, b) => {
       const aValue = a.lastName || a.email;
       const bValue = b.lastName || b.email;
@@ -87,11 +96,10 @@ export default async function GroupDetailPage({ params }: Props) {
 
     try {
       const memberIds = sortedMembers.map((m) => m.id);
-      const dropletIds = group.droplets.map((d) => d.id);
 
       const allEnrollments = await getEnrollmentsForGroupMembers(
         memberIds,
-        dropletIds,
+        allDropletIds,
       );
 
       allEnrollments.forEach((enrollment) => {

--- a/frontend/app/(groups)/g/[slug]/page.tsx
+++ b/frontend/app/(groups)/g/[slug]/page.tsx
@@ -81,9 +81,8 @@ export default async function GroupDetailPage({ params }: Props) {
   const allDropletIds = [
     ...new Set([
       ...(group.droplets?.map((d) => d.id) || []),
-      ...(group.playlists?.flatMap(
-        (p) => p.droplets?.map((d) => d.id) || [],
-      ) || []),
+      ...(group.playlists?.flatMap((p) => p.droplets?.map((d) => d.id) || []) ||
+        []),
     ]),
   ];
 


### PR DESCRIPTION
## Description

Cherry-picks two commits that fix playlist progress always showing 0% in the group Progress tab.

## Motivation and Context

Playlist progress was not being calculated correctly when viewed from the group Progress tab, causing it to always display 0%. This fix resolves the incorrect progress display so users see accurate completion percentages.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enrollment data retrieval to properly account for droplets from all available sources within a group, ensuring complete and accurate member enrollment information is fetched and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->