### PR TITLE
droplet analytics changes and friends fixes

### DIFF
--- a/frontend/app/(general)/admin/droplets/page.tsx
+++ b/frontend/app/(general)/admin/droplets/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 export default function Page() {
   return (
     <div className="w-full px-[56px] py-8">
-      <div className="mb-4">
+      <div className="mb-6">
         <h1 className="text-[40px] leading-tight font-semibold text-black dark:text-white">
           Droplets
         </h1>

--- a/frontend/app/(general)/admin/groups/page.tsx
+++ b/frontend/app/(general)/admin/groups/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 export default function Page() {
   return (
     <div className="w-full px-[56px] py-8">
-      <div className="mb-4">
+      <div className="mb-6">
         <h1 className="text-[40px] leading-tight font-semibold text-black dark:text-white">
           Groups
         </h1>

--- a/frontend/app/(general)/admin/page.tsx
+++ b/frontend/app/(general)/admin/page.tsx
@@ -10,7 +10,6 @@ import { ActiveUsersChart } from "@/components/admin/charts/active-users-chart";
 import { AvgSessionDurationChart } from "@/components/admin/charts/avg-session-duration-chart";
 import { UniquePageviewBarChart } from "@/components/admin/charts/unique-pageview-chart";
 import { IconTrendingDown, IconTrendingUp } from "@tabler/icons-react";
-import { RefreshButton } from "@/components/admin/refresh-button";
 
 export const dynamic = "force-dynamic";
 
@@ -156,7 +155,6 @@ export default function Page() {
             View Odyssey statistics and edit existing information.
           </p>
         </div>
-        <RefreshButton />
       </div>
 
       {/* Top row: stat cards + pageviews — streams in */}

--- a/frontend/app/(general)/admin/playlists/page.tsx
+++ b/frontend/app/(general)/admin/playlists/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 export default function Page() {
   return (
     <div className="w-full px-[56px] py-8">
-      <div className="mb-4">
+      <div className="mb-6">
         <h1 className="text-[40px] leading-tight font-semibold text-black dark:text-white">
           Playlists
         </h1>

--- a/frontend/app/(general)/admin/reports/page.tsx
+++ b/frontend/app/(general)/admin/reports/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 export default function Page() {
   return (
     <div className="w-full px-[56px] py-8">
-      <div className="mb-4">
+      <div className="mb-6">
         <h1 className="text-[40px] leading-tight font-semibold text-black dark:text-white">
           Reports
         </h1>

--- a/frontend/app/(general)/admin/requests/page.tsx
+++ b/frontend/app/(general)/admin/requests/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 export default function Page() {
   return (
     <div className="w-full px-[56px] py-8">
-      <div className="mb-4">
+      <div className="mb-6">
         <h1 className="text-[40px] leading-tight font-semibold text-black dark:text-white">
           Requests
         </h1>

--- a/frontend/app/(general)/admin/users/page.tsx
+++ b/frontend/app/(general)/admin/users/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 export default function Page() {
   return (
     <div className="w-full px-[56px] py-8">
-      <div className="mb-4">
+      <div className="mb-6">
         <h1 className="text-[40px] leading-tight font-semibold text-black dark:text-white">
           Users
         </h1>

--- a/frontend/app/(general)/prof/[username]/page.tsx
+++ b/frontend/app/(general)/prof/[username]/page.tsx
@@ -6,6 +6,7 @@ import { getEnrollmentsByAuthorizedUser } from "@/lib/requests/enrollment";
 import { fetchFriends } from "@/lib/requests/friends";
 import { fetchUserAnnouncements } from "@/lib/requests/feed";
 import { getCurrentUser } from "@/lib/auth/session";
+import { isAuthorizedUserAdmin } from "@/lib/utils";
 import { ProfileContent } from "./profile-content";
 import { PrivateProfileError } from "./private-profile-error";
 
@@ -32,7 +33,11 @@ export default async function PublicProfilePage({
     ]);
     const isViewingOwnProfile = currentUser?.email === userEmail;
 
-    if (!userData.isPublic && !isViewingOwnProfile) {
+    if (
+      !userData.isPublic &&
+      !isViewingOwnProfile &&
+      !isAuthorizedUserAdmin(currentUser?.roles)
+    ) {
       return <PrivateProfileError />;
     }
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -74,6 +74,33 @@
   background-color: rgb(15 23 42) !important;
 }
 
+@keyframes slideInLeft {
+  from {
+    opacity: 0;
+    transform: translateX(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+@keyframes slideInRight {
+  from {
+    opacity: 0;
+    transform: translateX(-40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+.slide-left {
+  animation: slideInLeft 0.28s ease;
+}
+.slide-right {
+  animation: slideInRight 0.28s ease;
+}
+
 @property --border-angle {
   inherits: false;
   initial-value: 0deg;

--- a/frontend/components/admin/charts/active-users-chart.tsx
+++ b/frontend/components/admin/charts/active-users-chart.tsx
@@ -88,7 +88,7 @@ export function ActiveUsersChart({
           <ChartContainer config={chartConfig} className="h-full w-full">
             <AreaChart
               data={formatted}
-              margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
+              margin={{ top: 5, right: 10, left: 10, bottom: 5 }}
             >
               <defs>
                 <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
@@ -102,7 +102,8 @@ export function ActiveUsersChart({
                 tickLine={false}
                 axisLine={false}
                 tick={{ fontSize: 12, fill: "#60646c" }}
-                interval="preserveStartEnd"
+                interval={Math.max(0, Math.floor(formatted.length / 7) - 1)}
+                padding={{ left: 24, right: 10 }}
               />
               <YAxis
                 tickLine={false}

--- a/frontend/components/admin/charts/avg-session-duration-chart.tsx
+++ b/frontend/components/admin/charts/avg-session-duration-chart.tsx
@@ -105,7 +105,7 @@ export function AvgSessionDurationChart({
           <ChartContainer config={chartConfig} className="h-full w-full">
             <AreaChart
               data={formatted}
-              margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
+              margin={{ top: 5, right: 10, left: 10, bottom: 5 }}
             >
               <defs>
                 <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
@@ -119,7 +119,8 @@ export function AvgSessionDurationChart({
                 tickLine={false}
                 axisLine={false}
                 tick={{ fontSize: 12, fill: "#60646c" }}
-                interval="preserveStartEnd"
+                interval={Math.max(0, Math.floor(formatted.length / 7) - 1)}
+                padding={{ left: 24, right: 10 }}
               />
               <YAxis
                 tickLine={false}

--- a/frontend/components/admin/charts/timeframe-selector.tsx
+++ b/frontend/components/admin/charts/timeframe-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useLayoutEffect } from "react";
 import { IconCalendar } from "@tabler/icons-react";
 import { type TimeframeOption } from "@/lib/chart-utils";
 import {
@@ -47,16 +47,38 @@ export function TimeframeSelector({
 
   const calendarActive = !!activeDateRange;
 
+  // ——— Sliding pill ———
+  const buttonRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
+  const calendarRef = useRef<HTMLButtonElement | null>(null);
+  const [pill, setPill] = useState({ left: 0, width: 0 });
+
+  useLayoutEffect(() => {
+    const el = calendarActive
+      ? calendarRef.current
+      : buttonRefs.current.get(value) ?? null;
+    if (el) setPill({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [value, calendarActive]);
+
   return (
-    <div className="flex gap-1 rounded-lg border border-slate-200 bg-white p-0.5 dark:border-slate-700 dark:bg-slate-900">
+    <div className="relative flex gap-1 rounded-lg border border-slate-200 bg-white p-0.5 dark:border-slate-700 dark:bg-slate-900">
+      {/* Sliding indicator */}
+      <div
+        className="absolute rounded-md bg-[#2D7597] transition-all duration-200 ease-in-out"
+        style={{ left: pill.left, width: pill.width, top: 2, bottom: 2 }}
+      />
+
       {options.map((tf) => (
         <button
           key={tf.value}
+          ref={(el) => {
+            if (el) buttonRefs.current.set(tf.value, el);
+            else buttonRefs.current.delete(tf.value);
+          }}
           onClick={() => onChange(tf.value)}
-          className={`rounded-md px-2 py-1 text-[12px] transition-colors ${
+          className={`relative z-10 rounded-md px-2 py-1 text-[12px] transition-colors duration-200 ${
             value === tf.value && !calendarActive
-              ? "bg-[#2D7597] text-white"
-              : "text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+              ? "text-white"
+              : "text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
           }`}
         >
           {tf.label}
@@ -67,13 +89,14 @@ export function TimeframeSelector({
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
             <button
-              className={`rounded-md px-2 py-1 text-[12px] transition-colors ${
+              ref={calendarRef}
+              className={`relative z-10 rounded-md px-2 py-1 text-[12px] transition-colors duration-200 ${
                 calendarActive
-                  ? "bg-[#2D7597] text-white"
-                  : "text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+                  ? "text-white"
+                  : "text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
               }`}
             >
-              <IconCalendar className="h-3 w-3" />
+              <IconCalendar className="h-4 w-4" />
             </button>
           </PopoverTrigger>
           <PopoverContent className="w-auto p-3" align="end">

--- a/frontend/components/admin/droplets/droplet-analytics-modal.tsx
+++ b/frontend/components/admin/droplets/droplet-analytics-modal.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { useState, useEffect, useRef, useLayoutEffect } from "react";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import {
   BarChart,
@@ -15,15 +20,12 @@ import {
   Tooltip,
   type LabelProps,
 } from "recharts";
+import { IconTrendingUp, IconTrendingDown, IconX } from "@tabler/icons-react";
 import {
   getDropletAnalytics,
   type DropletAnalyticsData,
   type LessonScrollDepth,
 } from "@/lib/requests/droplet-analytics";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
 
 interface DropletAnalyticsModalProps {
   droplet: {
@@ -36,26 +38,62 @@ interface DropletAnalyticsModalProps {
   onOpenChange: (open: boolean) => void;
 }
 
-// ---------------------------------------------------------------------------
-// Stat Card
-// ---------------------------------------------------------------------------
-
-function StatCard({ title, value }: { title: string; value: string }) {
+function StatCard({
+  title,
+  value,
+  lastMonth,
+  trend,
+}: {
+  title: string;
+  value: string;
+  lastMonth: string;
+  trend?: { value: string; direction: "up" | "down" } | null;
+}) {
   return (
-    <div className="flex h-[200px] w-[361px] flex-col justify-between rounded-[20px] bg-[#fcfcfd] p-6 shadow dark:bg-slate-800">
-      <p className="text-[16px] font-medium text-[#475569] dark:text-slate-400">
+    <div className="flex h-[135px] flex-1 flex-col justify-between rounded-[20px] bg-[#fcfcfd] px-[20px] py-[14px] shadow-[0px_0px_4px_0px_rgba(0,0,0,0.25)] dark:bg-slate-800">
+      <p className="text-[16px] leading-none font-normal text-black dark:text-white">
         {title}
       </p>
-      <p className="text-[64px] leading-none font-semibold text-black dark:text-white">
-        {value}
+      <div className="flex items-center gap-[6px]">
+        <span className="text-[40px] leading-none font-semibold text-black dark:text-white">
+          {value}
+        </span>
+        {trend && (
+          <span
+            className={cn(
+              "flex items-center gap-[5px] rounded-[36px] px-[8px] py-[4px] text-[12px] font-normal",
+              trend.direction === "up"
+                ? "bg-[#f0f9f5] text-[#1ea438] dark:bg-[#1ea438]/10"
+                : "bg-[#fcefe9] text-[#ce3131] dark:bg-[#ce3131]/10",
+            )}
+          >
+            {trend.direction === "up" ? (
+              <IconTrendingUp className="h-[9px] w-[7px]" />
+            ) : (
+              <IconTrendingDown className="h-[9px] w-[7px]" />
+            )}
+            {trend.value}
+          </span>
+        )}
+      </div>
+      <p className="text-[16px] font-normal text-black dark:text-slate-300">
+        Last month: {lastMonth}
       </p>
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Custom bar label (white text inside bar)
-// ---------------------------------------------------------------------------
+function computeTrend(
+  current: number,
+  last: number,
+): { value: string; direction: "up" | "down" } | null {
+  if (last === 0) return null;
+  const pct = ((current - last) / last) * 100;
+  return {
+    value: `${Math.abs(pct).toFixed(1)}%`,
+    direction: pct >= 0 ? "up" : "down",
+  };
+}
 
 function BarInsideLabel(props: LabelProps) {
   const { x, y, width, height, value } = props as {
@@ -80,10 +118,6 @@ function BarInsideLabel(props: LabelProps) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Scroll Depth Chart
-// ---------------------------------------------------------------------------
-
 function ScrollDepthChart({
   scrollDepth,
   activeIndex,
@@ -99,6 +133,26 @@ function ScrollDepthChart({
     users: p.count,
   }));
 
+  // Sliding pill for tab selector
+  const tabRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
+  const [pill, setPill] = useState({ left: 0, width: 0 });
+  useLayoutEffect(() => {
+    const el = tabRefs.current.get(activeIndex);
+    if (el) setPill({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [activeIndex]);
+
+  const prevIndexRef = useRef(activeIndex);
+  const [animClass, setAnimClass] = useState("");
+  useEffect(() => {
+    if (prevIndexRef.current === activeIndex) return;
+    const dir =
+      activeIndex > prevIndexRef.current ? "slide-left" : "slide-right";
+    prevIndexRef.current = activeIndex;
+    setAnimClass(dir);
+    const t = setTimeout(() => setAnimClass(""), 300);
+    return () => clearTimeout(t);
+  }, [activeIndex]);
+
   return (
     <div className="mt-6 rounded-[20px] bg-[#fcfcfd] p-8 shadow dark:bg-slate-800">
       <h4 className="text-[22px] font-bold text-black dark:text-white">
@@ -108,16 +162,24 @@ function ScrollDepthChart({
         Showing growth/decline in users as they progress through a lesson
       </p>
 
-      {/* Pill tab selector */}
-      <div className="mt-5 inline-flex gap-1 rounded-[97px] bg-[#eaecf0] p-1 dark:bg-slate-700">
+      {/* Sliding pill tab selector */}
+      <div className="relative mt-5 inline-flex rounded-[97px] bg-[#eaecf0] p-1 dark:bg-slate-700">
+        <div
+          className="absolute rounded-[97px] bg-[#2D7597] shadow transition-all duration-200 ease-in-out"
+          style={{ left: pill.left, width: pill.width, top: 4, bottom: 4 }}
+        />
         {scrollDepth.map((lesson, i) => (
           <button
             key={lesson.lessonId}
+            ref={(el) => {
+              if (el) tabRefs.current.set(i, el);
+              else tabRefs.current.delete(i);
+            }}
             onClick={() => onTabChange(i)}
             className={cn(
-              "rounded-[97px] px-4 py-1.5 text-[14px] font-medium transition-colors",
+              "relative z-10 rounded-[97px] px-4 py-1.5 text-[14px] font-medium transition-colors duration-200",
               i === activeIndex
-                ? "bg-[#2D7597] text-white shadow"
+                ? "text-white"
                 : "text-[#475569] hover:text-black dark:text-slate-300 dark:hover:text-white",
             )}
           >
@@ -126,9 +188,8 @@ function ScrollDepthChart({
         ))}
       </div>
 
-      <div className="mt-6 w-full overflow-x-auto">
+      <div className={cn("mt-6 w-full overflow-x-auto", animClass)}>
         <LineChart
-          key={active.lessonId}
           width={1100}
           height={320}
           data={chartData}
@@ -167,10 +228,6 @@ function ScrollDepthChart({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
-
 export function DropletAnalyticsModal({
   droplet,
   open,
@@ -186,139 +243,185 @@ export function DropletAnalyticsModal({
     setActiveScrollLesson(0);
     getDropletAnalytics(droplet.id, droplet.lessons ?? [])
       .then(setAnalytics)
+      .catch(() => setAnalytics(null))
       .finally(() => setLoading(false));
-  }, [open, droplet.id, droplet.lessons]);
+  }, [open, droplet.id]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] max-w-[1260px] overflow-y-auto !rounded-[20px] border-0 p-0 dark:border-slate-700 dark:bg-slate-900">
+      <DialogContent className="max-h-[90vh] max-w-[1260px] overflow-hidden !rounded-[20px] border-0 p-0 dark:border-slate-700 dark:bg-slate-900">
         <DialogTitle className="sr-only">
           Droplet Analytics - {droplet.name}
         </DialogTitle>
 
-        {/* ---- Header ---- */}
-        <div className="sticky top-0 z-10 rounded-t-[20px] bg-white px-14 pt-10 pb-0 dark:bg-slate-900">
-          <div className="flex items-start justify-between">
-            <div>
-              <h2 className="text-[40px] font-semibold text-black dark:text-white">
-                Analytics
-              </h2>
-              <p className="text-[20px] text-[#475569] dark:text-slate-400">
-                View droplet-level analytics
-              </p>
-            </div>
-            <div className="text-right">
-              <p className="text-[32px] font-semibold text-black dark:text-white">
-                {droplet.name}
-              </p>
-              <p className="text-[14px] text-[#94a3b8] dark:text-slate-500">
-                Last updated:{" "}
-                {new Date().toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })}
-              </p>
-            </div>
-          </div>
-          <hr className="mt-6 border-[#eaecf0] dark:border-slate-700" />
-        </div>
-
-        {/* ---- Body ---- */}
-        <div className="px-14 pb-10">
-          {loading || !analytics ? (
-            <div className="mt-12 flex items-center justify-center py-20">
-              <p className="text-[18px] text-[#475569] dark:text-slate-400">
-                {loading ? "Loading analytics…" : "No data available."}
-              </p>
-            </div>
-          ) : (
-            <>
-              {/* Stat cards */}
-              <div className="mt-8 flex flex-wrap gap-6">
-                <StatCard
-                  title="Total Enrolled"
-                  value={analytics.totalEnrolled.toLocaleString()}
-                />
-                <StatCard
-                  title="Completed"
-                  value={analytics.completedCount.toLocaleString()}
-                />
-                <StatCard
-                  title="Completion Rate"
-                  value={`${analytics.completionRate.toFixed(1)}%`}
-                />
+        <div className="flex max-h-[90vh] flex-col overflow-y-auto [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-transparent [&::-webkit-scrollbar-track]:bg-transparent [&:hover::-webkit-scrollbar-thumb]:bg-slate-300 dark:[&:hover::-webkit-scrollbar-thumb]:bg-slate-600">
+          {/* ---- Header ---- */}
+          <div className="sticky top-0 z-10 rounded-t-[20px] bg-white pt-10 pr-10 pb-0 pl-14 dark:bg-slate-900">
+            <DialogClose className="absolute top-4 right-5 rounded-full p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300">
+              <IconX className="h-5 w-5" />
+            </DialogClose>
+            <div className="flex items-start justify-between pr-8">
+              <div>
+                <h2 className="text-[40px] font-semibold text-black dark:text-white">
+                  Analytics
+                </h2>
+                <p className="text-[20px] text-[#475569] dark:text-slate-400">
+                  View droplet-level analytics
+                </p>
               </div>
+              <div className="text-right">
+                <p className="text-[32px] font-semibold text-black dark:text-white">
+                  {droplet.name}
+                </p>
+                <p className="text-[14px] text-[#94a3b8] dark:text-slate-500">
+                  Last updated:{" "}
+                  {new Date().toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })}
+                </p>
+              </div>
+            </div>
+            <hr className="mt-6 border-[#eaecf0] dark:border-slate-700" />
+          </div>
 
-              {/* Lesson-level analytics */}
-              {analytics.lessonCompletion.length > 0 && (
-                <>
-                  <h3 className="mt-12 text-[32px] font-semibold text-black dark:text-white">
-                    Lesson-level Analytics
-                  </h3>
+          {/* ---- Body ---- */}
+          <div className="px-14 pb-10">
+            {loading || !analytics ? (
+              <div className="mt-12 flex items-center justify-center py-20">
+                <p className="text-[18px] text-[#475569] dark:text-slate-400">
+                  {loading ? "Loading analytics…" : "No data available."}
+                </p>
+              </div>
+            ) : (
+              <>
+                {/* Stat cards */}
+                <div className="mt-8 flex gap-4">
+                  <StatCard
+                    title="Total Enrolled"
+                    value={analytics.totalEnrolled.toLocaleString()}
+                    lastMonth={analytics.lastMonthEnrolled.toLocaleString()}
+                    trend={computeTrend(
+                      analytics.totalEnrolled,
+                      analytics.lastMonthEnrolled,
+                    )}
+                  />
+                  <StatCard
+                    title="Completed"
+                    value={analytics.completedCount.toLocaleString()}
+                    lastMonth={analytics.lastMonthCompleted.toLocaleString()}
+                    trend={computeTrend(
+                      analytics.completedCount,
+                      analytics.lastMonthCompleted,
+                    )}
+                  />
+                  <StatCard
+                    title="Completion Rate"
+                    value={`${analytics.completionRate.toFixed(1)}%`}
+                    lastMonth={`${analytics.lastMonthCompletionRate.toFixed(1)}%`}
+                    trend={computeTrend(
+                      analytics.completionRate,
+                      analytics.lastMonthCompletionRate,
+                    )}
+                  />
+                  <StatCard
+                    title="Average Rating"
+                    value={
+                      analytics.averageRating === null
+                        ? "N/A"
+                        : `${analytics.averageRating} / 5`
+                    }
+                    lastMonth={
+                      analytics.lastMonthAverageRating === null
+                        ? "N/A"
+                        : `${analytics.lastMonthAverageRating} / 5`
+                    }
+                    trend={
+                      analytics.averageRating !== null &&
+                      analytics.lastMonthAverageRating !== null
+                        ? computeTrend(
+                            analytics.averageRating,
+                            analytics.lastMonthAverageRating,
+                          )
+                        : null
+                    }
+                  />
+                </div>
 
-                  <div className="mt-6 rounded-[20px] bg-[#fcfcfd] p-8 shadow dark:bg-slate-800">
-                    <h4 className="text-[22px] font-bold text-[#1c2024] dark:text-white">
-                      Marked Complete
-                    </h4>
-                    <p className="mt-1 text-[20px] text-[#60646c] dark:text-slate-400">
-                      Showing the number of users who marked a lesson complete
-                    </p>
+                {/* Lesson-level analytics */}
+                {analytics.lessonCompletion.length > 0 && (
+                  <>
+                    <h3 className="mt-12 text-[32px] font-semibold text-black dark:text-white">
+                      Lesson-level Analytics
+                    </h3>
 
-                    <div className="mt-6 w-full overflow-x-auto">
-                      <BarChart
-                        layout="vertical"
-                        width={1100}
-                        height={analytics.lessonCompletion.length * 60 + 40}
-                        data={analytics.lessonCompletion}
-                        margin={{ top: 10, right: 60, left: 0, bottom: 10 }}
-                        barCategoryGap="20%"
-                      >
-                        <CartesianGrid
-                          strokeDasharray="3 3"
-                          horizontal={false}
-                          stroke="#e2e8f0"
-                        />
-                        <XAxis type="number" hide />
-                        <YAxis type="category" dataKey="name" hide />
-                        <Tooltip
-                          contentStyle={{
-                            borderRadius: 12,
-                            border: "none",
-                            boxShadow: "0 4px 12px rgba(0,0,0,.1)",
-                          }}
-                        />
-                        <Bar
-                          dataKey="count"
-                          fill="#2D7597"
-                          radius={[16, 16, 16, 16]}
-                          barSize={36}
+                    <div className="mt-6 rounded-[20px] bg-[#fcfcfd] p-8 shadow dark:bg-slate-800">
+                      <h4 className="text-[22px] font-bold text-[#1c2024] dark:text-white">
+                        Marked Complete
+                      </h4>
+                      <p className="mt-1 text-[20px] text-[#60646c] dark:text-slate-400">
+                        Showing the number of users who marked a lesson complete
+                      </p>
+
+                      <div className="mt-6 w-full overflow-x-auto">
+                        <BarChart
+                          layout="vertical"
+                          width={1100}
+                          height={analytics.lessonCompletion.length * 60 + 40}
+                          data={analytics.lessonCompletion}
+                          margin={{ top: 10, right: 60, left: 0, bottom: 10 }}
+                          barCategoryGap="20%"
                         >
-                          <LabelList dataKey="name" content={BarInsideLabel} />
-                          <LabelList
-                            dataKey="count"
-                            position="right"
-                            fill="#334155"
-                            fontSize={14}
-                            fontWeight={600}
+                          <CartesianGrid
+                            strokeDasharray="3 3"
+                            horizontal={false}
+                            stroke="#e2e8f0"
                           />
-                        </Bar>
-                      </BarChart>
+                          <XAxis type="number" hide />
+                          <YAxis type="category" dataKey="name" hide />
+                          <Tooltip
+                            contentStyle={{
+                              borderRadius: 12,
+                              border: "none",
+                              boxShadow: "0 4px 12px rgba(0,0,0,.1)",
+                            }}
+                          />
+                          <Bar
+                            dataKey="count"
+                            fill="#2D7597"
+                            radius={[16, 16, 16, 16]}
+                            barSize={36}
+                          >
+                            <LabelList
+                              dataKey="name"
+                              content={BarInsideLabel}
+                            />
+                            <LabelList
+                              dataKey="count"
+                              position="right"
+                              fill="#334155"
+                              fontSize={14}
+                              fontWeight={600}
+                            />
+                          </Bar>
+                        </BarChart>
+                      </div>
                     </div>
-                  </div>
 
-                  {/* ---- Scroll Depth chart ---- */}
-                  {analytics.scrollDepth.length > 0 && (
-                    <ScrollDepthChart
-                      scrollDepth={analytics.scrollDepth}
-                      activeIndex={activeScrollLesson}
-                      onTabChange={setActiveScrollLesson}
-                    />
-                  )}
-                </>
-              )}
-            </>
-          )}
+                    {/* ---- Scroll Depth chart ---- */}
+                    {analytics.scrollDepth.length > 0 && (
+                      <ScrollDepthChart
+                        scrollDepth={analytics.scrollDepth}
+                        activeIndex={activeScrollLesson}
+                        onTabChange={setActiveScrollLesson}
+                      />
+                    )}
+                  </>
+                )}
+              </>
+            )}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/frontend/components/admin/reports/reports-page-client.tsx
+++ b/frontend/components/admin/reports/reports-page-client.tsx
@@ -14,8 +14,15 @@ import {
 import { SortRadioGroup } from "@/components/admin/sort-radio-group";
 import { deleteReport } from "@/lib/actions";
 import { toast } from "sonner";
-import { IconTrash } from "@tabler/icons-react";
+import { IconTrash, IconExternalLink } from "@tabler/icons-react";
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 // ——— Sort config ———
 const SORT_GROUPS = [
@@ -129,23 +136,39 @@ function ReportRow({ report }: { report: Report }) {
 
       {/* Actions */}
       <td className="h-[80px] px-6 py-3">
-        <div className="flex items-center gap-[10px]">
-          <Link
-            href={report.path}
-            target="_blank"
-            className="inline-flex items-center rounded-[16px] bg-[#2D7597] px-[9px] py-[4px] text-[14px] leading-[18px] font-medium text-white transition-colors hover:bg-[#255e78]"
-          >
-            Visit Page
-          </Link>
-          <button
-            onClick={handleDelete}
-            disabled={isPending}
-            className="flex h-[26px] w-[26px] items-center justify-center rounded-md text-red-500 transition-colors hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-950"
-            title="Delete report"
-          >
-            <IconTrash className="h-4 w-4" />
-          </button>
-        </div>
+        <TooltipProvider delayDuration={300}>
+          <div className="flex items-center gap-[10px]">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-[30px] w-[30px] p-0"
+                  asChild
+                >
+                  <Link href={report.path} target="_blank">
+                    <IconExternalLink className="h-4 w-4 text-[#2D7597]" />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Visit page</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleDelete}
+                  disabled={isPending}
+                  className="h-[30px] w-[30px] p-0 text-red-500 hover:bg-slate-100 hover:text-red-500 dark:text-red-400 dark:hover:bg-slate-800 dark:hover:text-red-400"
+                >
+                  <IconTrash className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Delete report</TooltipContent>
+            </Tooltip>
+          </div>
+        </TooltipProvider>
       </td>
     </tr>
   );
@@ -205,7 +228,7 @@ export function ReportsPageClient({ reports }: { reports: Report[] }) {
           placeholder="Search reports…"
           value={searchTerm}
           onChange={handleSearch}
-          className="max-w-[560px]"
+          className="max-w-[818px]"
         />
         <div className="flex items-center gap-2">
           <SortButton onApply={handleSortApply} onReset={handleSortReset}>

--- a/frontend/components/admin/requests/requests-page-client.tsx
+++ b/frontend/components/admin/requests/requests-page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useRef, useLayoutEffect } from "react";
 import type { AccessRequest } from "@/components/shared/access-manager/access-requests/access-requests";
 import type { CreationRequest } from "@/types";
 import { useAdminTableFilters } from "@/hooks/use-admin-table-filters";
@@ -333,7 +333,7 @@ function AccessRequestsTable({
           placeholder="Search by name or email…"
           value={searchTerm}
           onChange={handleSearch}
-          className="max-w-[560px]"
+          className="max-w-[818px]"
         />
         <div className="flex items-center gap-2">
           <SortButton onApply={handleSortApply} onReset={handleSortReset}>
@@ -431,7 +431,7 @@ function CreationRequestsTable({
           placeholder="Search by name or email…"
           value={searchTerm}
           onChange={handleSearch}
-          className="max-w-[560px]"
+          className="max-w-[818px]"
         />
         <div className="flex items-center gap-2">
           <SortButton onApply={handleSortApply} onReset={handleSortReset}>
@@ -470,22 +470,40 @@ export function RequestsPageClient({
   creationRequests: CreationRequest[];
 }) {
   const [activeTab, setActiveTab] = useState<Tab>("access");
+  const tabRefs = useRef<Record<Tab, HTMLButtonElement | null>>({
+    access: null,
+    creators: null,
+  });
+  const [pill, setPill] = useState({ left: 0, width: 0 });
+
+  useLayoutEffect(() => {
+    const el = tabRefs.current[activeTab];
+    if (el) setPill({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [activeTab]);
 
   return (
     <div className="space-y-6">
       {/* Tabs */}
-      <div className="inline-flex h-[45px] items-center rounded-[97px] bg-[#fcfcfd] shadow-[0px_0px_4px_0px_rgba(0,0,0,0.25)] dark:bg-slate-800">
+      <div className="relative inline-flex h-[45px] items-center rounded-[97px] bg-[#fcfcfd] shadow-[0px_0px_4px_0px_rgba(0,0,0,0.25)] dark:bg-slate-800">
+        {/* Sliding indicator */}
+        <div
+          className="absolute h-[37px] rounded-[35px] bg-[#2D7597] transition-all duration-200 ease-in-out"
+          style={{ left: pill.left, width: pill.width }}
+        />
         {[
           { key: "access" as Tab, label: "Access Requests" },
           { key: "creators" as Tab, label: "Creators Request" },
         ].map((tab) => (
           <button
             key={tab.key}
+            ref={(el) => {
+              tabRefs.current[tab.key] = el;
+            }}
             onClick={() => setActiveTab(tab.key)}
             className={cn(
-              "h-[37px] rounded-[35px] px-5 text-[16px] font-semibold transition-colors",
+              "relative z-10 mx-1 h-[37px] rounded-[35px] px-5 text-[16px] font-semibold transition-colors duration-200",
               activeTab === tab.key
-                ? "mx-1 bg-[#2D7597] text-white"
+                ? "text-white"
                 : "text-[#202630] hover:text-[#2D7597] dark:text-slate-300",
             )}
           >

--- a/frontend/components/admin/users/authorized-user.tsx
+++ b/frontend/components/admin/users/authorized-user.tsx
@@ -5,12 +5,13 @@ import { useDropzone } from "react-dropzone";
 import { Button } from "@/components/ui/button";
 import { uploadImage } from "@/lib/actions";
 import { AuthorizedUser } from "@/types";
-import { IconPencil, IconUser, IconActivity } from "@tabler/icons-react";
+import { IconPencil, IconUser, IconActivity, IconX } from "@tabler/icons-react";
 import { useFormStatus } from "react-dom";
 import { isAuthorizedUserAdmin } from "@/lib/utils";
 import {
   DialogHeader,
   Dialog,
+  DialogClose,
   DialogTrigger,
   DialogContent,
   DialogTitle,
@@ -268,6 +269,9 @@ export function AuthorizedUserBlock({
             </DialogTrigger>
 
             <DialogContent className="scale-75 sm:scale-100">
+              <DialogClose className="absolute top-3 right-3 rounded-full p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300">
+                <IconX className="h-4 w-4" />
+              </DialogClose>
               <DialogHeader>
                 <DialogTitle>Edit User</DialogTitle>
                 <DialogDescription>Update user information</DialogDescription>
@@ -392,7 +396,10 @@ export function AuthorizedUserBlock({
 
       {/* Activity Timeline Dialog */}
       <Dialog open={activityOpen} onOpenChange={setActivityOpen}>
-        <DialogContent className="max-h-[80vh] max-w-3xl overflow-y-auto">
+        <DialogContent className="max-h-[80vh] max-w-3xl overflow-y-auto [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-transparent [&::-webkit-scrollbar-track]:bg-transparent [&:hover::-webkit-scrollbar-thumb]:bg-slate-300 dark:[&:hover::-webkit-scrollbar-thumb]:bg-slate-600">
+          <DialogClose className="absolute top-3 right-3 rounded-full p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300">
+            <IconX className="h-4 w-4" />
+          </DialogClose>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <IconActivity className="h-5 w-5" />

--- a/frontend/components/admin/users/create-user.tsx
+++ b/frontend/components/admin/users/create-user.tsx
@@ -4,12 +4,13 @@ import { useState, useRef, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { createAuthorizedUserWithState } from "@/lib/actions";
-import { IconPlus, IconUpload } from "@tabler/icons-react";
+import { IconPlus, IconUpload, IconX } from "@tabler/icons-react";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 
@@ -116,6 +117,9 @@ export function CreateUser() {
       </DialogTrigger>
       <DialogContent className="max-w-[1260px] overflow-hidden !rounded-[20px] border-0 p-0">
         <DialogTitle className="sr-only">Create User</DialogTitle>
+        <DialogClose className="absolute top-4 right-4 z-10 rounded-full p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300">
+          <IconX className="h-5 w-5" />
+        </DialogClose>
         <div className="px-14 py-10">
           {/* Title */}
           <h2 className="text-[40px] font-semibold text-black">Create User</h2>

--- a/frontend/components/admin/users/users-page-client.tsx
+++ b/frontend/components/admin/users/users-page-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { AuthorizedUser } from "@/types";
 import { useAdminTableFilters } from "@/hooks/use-admin-table-filters";
 import { AuthorizedUserRoleTitle } from "@/lib/globals";
@@ -10,6 +11,7 @@ import { SearchBar } from "@/components/admin/search-bar";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogHeader,
@@ -25,6 +27,7 @@ import {
   IconUser,
   IconActivity,
   IconLoader2,
+  IconX,
 } from "@tabler/icons-react";
 import { toast } from "sonner";
 import { updateUserInfo } from "@/lib/requests/authorized-user";
@@ -38,6 +41,12 @@ import {
 import { SortRadioGroup } from "@/components/admin/sort-radio-group";
 import { FilterCheckboxGroup } from "@/components/admin/filter-checkbox-group";
 import { CreateUser } from "./create-user";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const USER_COLUMNS: AdminColumnDef[] = [
   { label: "Name", width: "w-[45%]" },
@@ -223,14 +232,17 @@ function UserTableRow({ user: initialUser }: { user: AuthorizedUser }) {
                 {initial ?? <IconUser className="h-4 w-4" />}
               </AvatarFallback>
             </Avatar>
-            <p className="truncate text-[16px] font-medium text-[#101828] underline dark:text-white">
+            <Link
+              href={`/prof/${user.email.split("@")[0]}`}
+              className="truncate text-[16px] font-medium text-[#101828] underline transition-colors hover:text-[#2D7597] dark:text-white dark:hover:text-[#5aadc9]"
+            >
               {displayName}
               {!user.isEnabled && (
                 <span className="ml-1 text-sm font-normal text-slate-400 no-underline">
                   (Disabled)
                 </span>
               )}
-            </p>
+            </Link>
           </div>
         </td>
 
@@ -261,32 +273,47 @@ function UserTableRow({ user: initialUser }: { user: AuthorizedUser }) {
 
         {/* Actions */}
         <td className="h-[56px] px-6 py-3">
-          <div className="flex items-center gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={handleViewActivity}
-              aria-label="view activity"
-              className="h-8 w-8 p-0"
-            >
-              <IconChartBar className="h-4 w-4 text-sky-600" />
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setEditOpen(true)}
-              aria-label="edit user"
-              className="h-8 w-8 p-0"
-            >
-              <IconPencil className="h-4 w-4 text-sky-600" />
-            </Button>
-          </div>
+          <TooltipProvider delayDuration={300}>
+            <div className="flex items-center gap-2">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setEditOpen(true)}
+                    aria-label="edit user"
+                    className="h-8 w-8 p-0"
+                  >
+                    <IconPencil className="h-4 w-4 text-sky-600" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Edit user</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleViewActivity}
+                    aria-label="view activity"
+                    className="h-8 w-8 p-0"
+                  >
+                    <IconChartBar className="h-4 w-4 text-sky-600" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>View activity</TooltipContent>
+              </Tooltip>
+            </div>
+          </TooltipProvider>
         </td>
       </tr>
 
       {/* Edit Dialog */}
       <Dialog open={editOpen} onOpenChange={setEditOpen}>
         <DialogContent className="scale-75 sm:scale-100">
+          <DialogClose className="absolute top-3 right-3 rounded-full p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300">
+            <IconX className="h-4 w-4" />
+          </DialogClose>
           <DialogHeader>
             <DialogTitle>Edit User</DialogTitle>
             <DialogDescription>Update user information</DialogDescription>
@@ -354,7 +381,10 @@ function UserTableRow({ user: initialUser }: { user: AuthorizedUser }) {
 
       {/* Activity Dialog */}
       <Dialog open={activityOpen} onOpenChange={setActivityOpen}>
-        <DialogContent className="max-h-[80vh] max-w-3xl overflow-y-auto">
+        <DialogContent className="max-h-[80vh] max-w-3xl overflow-y-auto [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-transparent [&::-webkit-scrollbar-track]:bg-transparent [&:hover::-webkit-scrollbar-thumb]:bg-slate-300 dark:[&:hover::-webkit-scrollbar-thumb]:bg-slate-600">
+          <DialogClose className="absolute top-3 right-3 rounded-full p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300">
+            <IconX className="h-4 w-4" />
+          </DialogClose>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <IconActivity className="h-5 w-5" />
@@ -498,7 +528,7 @@ export function UsersPageClient({ users }: { users: AuthorizedUser[] }) {
           placeholder="Search by name or email…"
           value={searchTerm}
           onChange={handleSearch}
-          className="max-w-[560px]"
+          className="max-w-[818px]"
         />
         <div className="flex items-center gap-2">
           <SortButton onApply={handleSortApply} onReset={handleSortReset}>

--- a/frontend/components/friends/friend-suggestions.tsx
+++ b/frontend/components/friends/friend-suggestions.tsx
@@ -13,7 +13,7 @@ export async function FriendSuggestions({ user }: { user: AuthorizedUser }) {
       <div className="mt-4 rounded-md bg-slate-100 p-1 md:p-4 dark:bg-slate-800">
         {suggestions.length > 0 ? (
           <ul className="divide-y divide-slate-200 md:space-y-4 dark:divide-slate-700">
-            {(await fetchSuggestionsById(user.id)).map((suggestedUser) => (
+            {suggestions.map((suggestedUser) => (
               <FriendSuggestionsBlock
                 curUser={user}
                 suggUser={suggestedUser}

--- a/frontend/components/friends/friends-selector.tsx
+++ b/frontend/components/friends/friends-selector.tsx
@@ -19,7 +19,7 @@ export function FriendsSelector({
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
-  const currentTab = searchParams.get("tab") || "droplets";
+  const currentTab = searchParams.get("tab") || "friends";
 
   const tabs = [
     { name: `Friends (${friends})`, value: "friends" },

--- a/frontend/components/friends/friends.tsx
+++ b/frontend/components/friends/friends.tsx
@@ -1,4 +1,4 @@
-import { getCachedUser } from "@/lib/requests/cached";
+import { getCachedUserSocial } from "@/lib/requests/cached";
 import { FriendBlock } from "./friend-block";
 import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
@@ -7,7 +7,7 @@ import { fetchFriends } from "@/lib/requests/friends";
 export async function Friends() {
   const user = await getCurrentUser();
   if (!user || !user?.email) return notFound();
-  const authUser = await getCachedUser(user.email);
+  const authUser = await getCachedUserSocial(user.email);
 
   const friends = await fetchFriends(authUser);
 

--- a/frontend/lib/requests/droplet-analytics.ts
+++ b/frontend/lib/requests/droplet-analytics.ts
@@ -17,6 +17,11 @@ export interface DropletAnalyticsData {
   totalEnrolled: number;
   completedCount: number;
   completionRate: number;
+  lastMonthEnrolled: number;
+  lastMonthCompleted: number;
+  lastMonthCompletionRate: number;
+  averageRating: number | null;
+  lastMonthAverageRating: number | null;
   lessonCompletion: { name: string; count: number }[];
   scrollDepth: LessonScrollDepth[];
 }
@@ -25,26 +30,60 @@ export async function getDropletAnalytics(
   dropletId: number,
   lessons: { id: number; name: string }[],
 ): Promise<DropletAnalyticsData> {
-  const [totalRes, completedRes] = await Promise.all([
-    fetchEnrollmentMetadata({
-      filters: { droplet: { id: { $eq: dropletId } } },
-      pagination: { pageSize: 1, page: 1 },
-    }),
-    fetchEnrollmentMetadata({
-      filters: {
-        droplet: { id: { $eq: dropletId } },
-        isComplete: { $eq: true },
-      },
-      pagination: { pageSize: 1, page: 1 },
-    }),
-  ]);
+  const now = new Date();
+  const endOfLastMonth = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    0,
+    23,
+    59,
+    59,
+    999,
+  ).toISOString();
+
+  const [totalRes, completedRes, lastMonthTotalRes, lastMonthCompletedRes] =
+    await Promise.all([
+      fetchEnrollmentMetadata({
+        filters: { droplet: { id: { $eq: dropletId } } },
+        pagination: { pageSize: 1, page: 1 },
+      }),
+      fetchEnrollmentMetadata({
+        filters: {
+          droplet: { id: { $eq: dropletId } },
+          isComplete: { $eq: true },
+        },
+        pagination: { pageSize: 1, page: 1 },
+      }),
+      fetchEnrollmentMetadata({
+        filters: {
+          droplet: { id: { $eq: dropletId } },
+          createdAt: { $lte: endOfLastMonth },
+        },
+        pagination: { pageSize: 1, page: 1 },
+      }),
+      fetchEnrollmentMetadata({
+        filters: {
+          droplet: { id: { $eq: dropletId } },
+          isComplete: { $eq: true },
+          createdAt: { $lte: endOfLastMonth },
+        },
+        pagination: { pageSize: 1, page: 1 },
+      }),
+    ]);
 
   const totalEnrolled = totalRes?.meta?.pagination?.total ?? 0;
   const completedCount = completedRes?.meta?.pagination?.total ?? 0;
+  const lastMonthEnrolled = lastMonthTotalRes?.meta?.pagination?.total ?? 0;
+  const lastMonthCompleted =
+    lastMonthCompletedRes?.meta?.pagination?.total ?? 0;
   const completionRate =
     totalEnrolled === 0
       ? 0
       : Math.round((completedCount / totalEnrolled) * 10000) / 100;
+  const lastMonthCompletionRate =
+    lastMonthEnrolled === 0
+      ? 0
+      : Math.round((lastMonthCompleted / lastMonthEnrolled) * 10000) / 100;
 
   // Build per-lesson view counts by fetching all enrollments with viewedLessons
   // populated and counting client-side. Filtering by viewedLessons relation ID
@@ -54,38 +93,102 @@ export async function getDropletAnalytics(
     lessons.map((l) => [l.id, 0]),
   );
 
-  if (lessons.length > 0 && totalEnrolled > 0) {
-    const pageSize = 250;
-    let page = 1;
-    while (true) {
-      const res = await fetchEnrollmentMetadata({
-        filters: { droplet: { id: { $eq: dropletId } } },
-        pagination: { pageSize, page },
-        populate: { viewedLessons: { fields: ["id"] } },
-        fields: ["id"],
-      });
+  async function fetchAllEnrollments() {
+    let ratingSum = 0;
+    let ratingCount = 0;
+    if (totalEnrolled > 0) {
+      const pageSize = 250;
+      let page = 1;
+      while (true) {
+        const res = await fetchEnrollmentMetadata({
+          filters: { droplet: { id: { $eq: dropletId } } },
+          pagination: { pageSize, page },
+          populate:
+            lessons.length > 0
+              ? { viewedLessons: { fields: ["id"] } }
+              : undefined,
+          fields: ["id", "rating"],
+        });
 
-      // res.data comes back as raw Strapi objects (flattenResponse: false)
-      const raw = (res.data ?? []) as unknown as {
-        id: number;
-        attributes: { viewedLessons: { data: { id: number }[] } };
-      }[];
+        // res.data comes back as raw Strapi objects (flattenResponse: false)
+        const raw = (res.data ?? []) as unknown as {
+          id: number;
+          attributes: {
+            rating?: number | null;
+            viewedLessons: { data: { id: number }[] };
+          };
+        }[];
 
-      for (const enrollment of raw) {
-        for (const lesson of enrollment.attributes?.viewedLessons?.data ?? []) {
-          if (lessonViewCounts.has(lesson.id)) {
-            lessonViewCounts.set(
-              lesson.id,
-              (lessonViewCounts.get(lesson.id) ?? 0) + 1,
-            );
+        for (const enrollment of raw) {
+          const rating = enrollment.attributes?.rating;
+          if (rating != null && rating !== 0) {
+            ratingSum += rating;
+            ratingCount++;
+          }
+          if (lessons.length > 0) {
+            for (const lesson of enrollment.attributes?.viewedLessons?.data ??
+              []) {
+              if (lessonViewCounts.has(lesson.id)) {
+                lessonViewCounts.set(
+                  lesson.id,
+                  (lessonViewCounts.get(lesson.id) ?? 0) + 1,
+                );
+              }
+            }
           }
         }
-      }
 
-      if (raw.length < pageSize) break;
-      page++;
+        if (raw.length < pageSize) break;
+        page++;
+      }
     }
+    return ratingCount === 0
+      ? null
+      : Math.round((ratingSum / ratingCount) * 10) / 10;
   }
+
+  async function fetchLastMonthRating() {
+    let lastMonthRatingSum = 0;
+    let lastMonthRatingCount = 0;
+    if (lastMonthEnrolled > 0) {
+      const pageSize = 250;
+      let page = 1;
+      while (true) {
+        const res = await fetchEnrollmentMetadata({
+          filters: {
+            droplet: { id: { $eq: dropletId } },
+            createdAt: { $lte: endOfLastMonth },
+          },
+          pagination: { pageSize, page },
+          fields: ["id", "rating"],
+        });
+
+        const raw = (res.data ?? []) as unknown as {
+          id: number;
+          attributes: { rating?: number | null };
+        }[];
+
+        for (const enrollment of raw) {
+          const rating = enrollment.attributes?.rating;
+          if (rating != null && rating !== 0) {
+            lastMonthRatingSum += rating;
+            lastMonthRatingCount++;
+          }
+        }
+
+        if (raw.length < pageSize) break;
+        page++;
+      }
+    }
+    return lastMonthRatingCount === 0
+      ? null
+      : Math.round((lastMonthRatingSum / lastMonthRatingCount) * 10) / 10;
+  }
+
+  const [averageRating, lastMonthAverageRating] = await Promise.all([
+    fetchAllEnrollments(),
+    fetchLastMonthRating(),
+  ]);
 
   const lessonCompletion = lessons.map((lesson) => ({
     name: lesson.name,
@@ -117,6 +220,11 @@ export async function getDropletAnalytics(
     totalEnrolled,
     completedCount,
     completionRate,
+    lastMonthEnrolled,
+    lastMonthCompleted,
+    lastMonthCompletionRate,
+    averageRating,
+    lastMonthAverageRating,
     lessonCompletion,
     scrollDepth,
   };

--- a/frontend/testing/requests/droplet-analytics.test.ts
+++ b/frontend/testing/requests/droplet-analytics.test.ts
@@ -1,0 +1,143 @@
+import { getDropletAnalytics } from "../../lib/requests/droplet-analytics";
+
+jest.mock("../../lib/requests/enrollment", () => ({
+  fetchEnrollmentMetadata: jest.fn(),
+}));
+
+const { fetchEnrollmentMetadata } = require("../../lib/requests/enrollment");
+
+// Helper to build a raw enrollment object with optional rating
+function makeRawEnrollment(
+  id: number,
+  rating?: number | null,
+  viewedLessonIds: number[] = [],
+) {
+  return {
+    id,
+    attributes: {
+      rating: rating ?? null,
+      viewedLessons: { data: viewedLessonIds.map((lid) => ({ id: lid })) },
+    },
+  };
+}
+
+// Standard pagination metadata
+function makeMeta(total: number) {
+  return { pagination: { page: 1, pageCount: 1, pageSize: 1, total } };
+}
+
+describe("getDropletAnalytics — averageRating", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns averageRating=-1 and lastMonthAverageRating=-1 when no ratings exist", async () => {
+    // The first four calls are the count-only metadata calls
+    fetchEnrollmentMetadata
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(2) }) // total
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(1) }) // completed
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(1) }) // lastMonth total
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) }) // lastMonth completed
+      // paginated loop for lesson views + rating (totalEnrolled=2 so loop runs)
+      .mockResolvedValueOnce({
+        data: [makeRawEnrollment(1, null), makeRawEnrollment(2, null)],
+        meta: makeMeta(2),
+      })
+      // paginated loop for lastMonth rating (lastMonthEnrolled=1 so loop runs)
+      .mockResolvedValueOnce({
+        data: [makeRawEnrollment(1, null)],
+        meta: makeMeta(1),
+      });
+
+    const result = await getDropletAnalytics(10, []);
+
+    expect(result.averageRating).toBe(-1);
+    expect(result.lastMonthAverageRating).toBe(-1);
+  });
+
+  it("computes averageRating from valid ratings, ignoring null/0", async () => {
+    // totalEnrolled=3, completedCount=1, lastMonthEnrolled=1, lastMonthCompleted=0
+    fetchEnrollmentMetadata
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(3) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(1) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(1) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
+      // main loop: 3 enrollments — ratings 4, null, 2  → avg = (4+2)/2 = 3.0
+      .mockResolvedValueOnce({
+        data: [
+          makeRawEnrollment(1, 4),
+          makeRawEnrollment(2, null),
+          makeRawEnrollment(3, 2),
+        ],
+        meta: makeMeta(3),
+      })
+      // lastMonth loop: 1 enrollment — rating 5 → avg = 5.0
+      .mockResolvedValueOnce({
+        data: [makeRawEnrollment(1, 5)],
+        meta: makeMeta(1),
+      });
+
+    const result = await getDropletAnalytics(10, []);
+
+    expect(result.averageRating).toBe(3);
+    expect(result.lastMonthAverageRating).toBe(5);
+  });
+
+  it("rounds averageRating to 1 decimal place", async () => {
+    fetchEnrollmentMetadata
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(3) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
+      // main loop: ratings 4, 3, 5 → avg = 4.0
+      .mockResolvedValueOnce({
+        data: [
+          makeRawEnrollment(1, 4),
+          makeRawEnrollment(2, 3),
+          makeRawEnrollment(3, 5),
+        ],
+        meta: makeMeta(3),
+      })
+      // lastMonth loop: no enrollments
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) });
+
+    const result = await getDropletAnalytics(10, []);
+
+    // (4+3+5)/3 = 4.0
+    expect(result.averageRating).toBe(4);
+    expect(result.lastMonthAverageRating).toBe(-1);
+  });
+
+  it("skips zero-value ratings (treats 0 as no rating)", async () => {
+    fetchEnrollmentMetadata
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(2) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
+      // ratings: 0 and 4 → only 4 counts → avg = 4.0
+      .mockResolvedValueOnce({
+        data: [makeRawEnrollment(1, 0), makeRawEnrollment(2, 4)],
+        meta: makeMeta(2),
+      })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) });
+
+    const result = await getDropletAnalytics(10, []);
+
+    expect(result.averageRating).toBe(4);
+  });
+
+  it("does not run the main paginated loop when totalEnrolled is 0", async () => {
+    fetchEnrollmentMetadata
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
+      .mockResolvedValueOnce({ data: [], meta: makeMeta(0) });
+
+    const result = await getDropletAnalytics(10, []);
+
+    expect(result.averageRating).toBe(-1);
+    expect(result.lastMonthAverageRating).toBe(-1);
+    // Only the 4 count calls should have been made (no paginated loops)
+    expect(fetchEnrollmentMetadata).toHaveBeenCalledTimes(4);
+  });
+});

--- a/frontend/testing/requests/droplet-analytics.test.ts
+++ b/frontend/testing/requests/droplet-analytics.test.ts
@@ -4,7 +4,9 @@ jest.mock("../../lib/requests/enrollment", () => ({
   fetchEnrollmentMetadata: jest.fn(),
 }));
 
-const { fetchEnrollmentMetadata } = require("../../lib/requests/enrollment");
+const { fetchEnrollmentMetadata } = jest.requireMock(
+  "../../lib/requests/enrollment",
+);
 
 // Helper to build a raw enrollment object with optional rating
 function makeRawEnrollment(
@@ -31,7 +33,7 @@ describe("getDropletAnalytics — averageRating", () => {
     jest.resetAllMocks();
   });
 
-  it("returns averageRating=-1 and lastMonthAverageRating=-1 when no ratings exist", async () => {
+  it("returns averageRating=null and lastMonthAverageRating=null when no ratings exist", async () => {
     // The first four calls are the count-only metadata calls
     fetchEnrollmentMetadata
       .mockResolvedValueOnce({ data: [], meta: makeMeta(2) }) // total
@@ -51,8 +53,8 @@ describe("getDropletAnalytics — averageRating", () => {
 
     const result = await getDropletAnalytics(10, []);
 
-    expect(result.averageRating).toBe(-1);
-    expect(result.lastMonthAverageRating).toBe(-1);
+    expect(result.averageRating).toBeNull();
+    expect(result.lastMonthAverageRating).toBeNull();
   });
 
   it("computes averageRating from valid ratings, ignoring null/0", async () => {
@@ -105,7 +107,7 @@ describe("getDropletAnalytics — averageRating", () => {
 
     // (4+3+5)/3 = 4.0
     expect(result.averageRating).toBe(4);
-    expect(result.lastMonthAverageRating).toBe(-1);
+    expect(result.lastMonthAverageRating).toBeNull();
   });
 
   it("skips zero-value ratings (treats 0 as no rating)", async () => {
@@ -126,7 +128,7 @@ describe("getDropletAnalytics — averageRating", () => {
     expect(result.averageRating).toBe(4);
   });
 
-  it("does not run the main paginated loop when totalEnrolled is 0", async () => {
+  it("does not run the main paginated loop when totalEnrolled is 0 and returns null ratings", async () => {
     fetchEnrollmentMetadata
       .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
       .mockResolvedValueOnce({ data: [], meta: makeMeta(0) })
@@ -135,8 +137,8 @@ describe("getDropletAnalytics — averageRating", () => {
 
     const result = await getDropletAnalytics(10, []);
 
-    expect(result.averageRating).toBe(-1);
-    expect(result.lastMonthAverageRating).toBe(-1);
+    expect(result.averageRating).toBeNull();
+    expect(result.lastMonthAverageRating).toBeNull();
     // Only the 4 count calls should have been made (no paginated loops)
     expect(fetchEnrollmentMetadata).toHaveBeenCalledTimes(4);
   });

--- a/frontend/tests/components/admin/droplet-analytics-modal.test.tsx
+++ b/frontend/tests/components/admin/droplet-analytics-modal.test.tsx
@@ -26,12 +26,12 @@ const mockDroplet = {
   lessons: [],
 };
 
-describe("DropletAnalyticsModal — Avg Rating stat card", () => {
+describe("DropletAnalyticsModal — Average Rating stat card", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("renders the Avg Rating card with value and last month when ratings exist", async () => {
+  it("renders the Average Rating card with value and last month when ratings exist", async () => {
     mockGetDropletAnalytics.mockResolvedValue(baseAnalytics);
 
     render(
@@ -43,18 +43,18 @@ describe("DropletAnalyticsModal — Avg Rating stat card", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Avg Rating")).toBeInTheDocument();
+      expect(screen.getByText("Average Rating")).toBeInTheDocument();
     });
 
     expect(screen.getByText("4.2 / 5")).toBeInTheDocument();
     expect(screen.getByText(/Last month:.*3\.8 \/ 5/)).toBeInTheDocument();
   });
 
-  it("shows N/A when averageRating is -1 (no ratings)", async () => {
+  it("shows N/A when averageRating is null (no ratings)", async () => {
     mockGetDropletAnalytics.mockResolvedValue({
       ...baseAnalytics,
-      averageRating: -1,
-      lastMonthAverageRating: -1,
+      averageRating: null,
+      lastMonthAverageRating: null,
     });
 
     render(
@@ -66,7 +66,7 @@ describe("DropletAnalyticsModal — Avg Rating stat card", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Avg Rating")).toBeInTheDocument();
+      expect(screen.getByText("Average Rating")).toBeInTheDocument();
     });
 
     // The value should be N/A (not a rating string)
@@ -91,6 +91,6 @@ describe("DropletAnalyticsModal — Avg Rating stat card", () => {
 
     expect(screen.getByText("Completed")).toBeInTheDocument();
     expect(screen.getByText("Completion Rate")).toBeInTheDocument();
-    expect(screen.getByText("Avg Rating")).toBeInTheDocument();
+    expect(screen.getByText("Average Rating")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/admin/droplet-analytics-modal.test.tsx
+++ b/frontend/tests/components/admin/droplet-analytics-modal.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { DropletAnalyticsModal } from "@/components/admin/droplets/droplet-analytics-modal";
+import { getDropletAnalytics } from "@/lib/requests/droplet-analytics";
+
+jest.mock("@/lib/requests/droplet-analytics");
+
+const mockGetDropletAnalytics = getDropletAnalytics as jest.Mock;
+
+const baseAnalytics = {
+  totalEnrolled: 100,
+  completedCount: 60,
+  completionRate: 60.0,
+  lastMonthEnrolled: 80,
+  lastMonthCompleted: 40,
+  lastMonthCompletionRate: 50.0,
+  averageRating: 4.2,
+  lastMonthAverageRating: 3.8,
+  lessonCompletion: [],
+  scrollDepth: [],
+};
+
+const mockDroplet = {
+  id: 1,
+  name: "Test Droplet",
+  slug: "test-droplet",
+  lessons: [],
+};
+
+describe("DropletAnalyticsModal — Avg Rating stat card", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the Avg Rating card with value and last month when ratings exist", async () => {
+    mockGetDropletAnalytics.mockResolvedValue(baseAnalytics);
+
+    render(
+      <DropletAnalyticsModal
+        droplet={mockDroplet}
+        open={true}
+        onOpenChange={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Avg Rating")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("4.2 / 5")).toBeInTheDocument();
+    expect(screen.getByText(/Last month:.*3\.8 \/ 5/)).toBeInTheDocument();
+  });
+
+  it("shows N/A when averageRating is -1 (no ratings)", async () => {
+    mockGetDropletAnalytics.mockResolvedValue({
+      ...baseAnalytics,
+      averageRating: -1,
+      lastMonthAverageRating: -1,
+    });
+
+    render(
+      <DropletAnalyticsModal
+        droplet={mockDroplet}
+        open={true}
+        onOpenChange={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Avg Rating")).toBeInTheDocument();
+    });
+
+    // The value should be N/A (not a rating string)
+    const ratingCards = screen.getAllByText("N/A");
+    expect(ratingCards.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders all four stat card titles", async () => {
+    mockGetDropletAnalytics.mockResolvedValue(baseAnalytics);
+
+    render(
+      <DropletAnalyticsModal
+        droplet={mockDroplet}
+        open={true}
+        onOpenChange={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Total Enrolled")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.getByText("Completion Rate")).toBeInTheDocument();
+    expect(screen.getByText("Avg Rating")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/friends/friends.test.tsx
+++ b/frontend/tests/components/friends/friends.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Friends } from "@/components/friends/friends";
 import { getCurrentUser } from "@/lib/auth/session";
-import { getCachedUser } from "@/lib/requests/cached";
+import { getCachedUserSocial } from "@/lib/requests/cached";
 import { fetchFriends } from "@/lib/requests/friends";
 import { notFound } from "next/navigation";
 
@@ -14,7 +14,7 @@ jest.mock("next/navigation", () => ({
 }));
 
 jest.mock("@/lib/requests/cached", () => ({
-  getCachedUser: jest.fn(),
+  getCachedUserSocial: jest.fn(),
 }));
 
 jest.mock("@/lib/requests/friends", () => ({
@@ -45,7 +45,7 @@ describe("Friends", () => {
       },
     ];
 
-    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthUser);
+    (getCachedUserSocial as jest.Mock).mockResolvedValue(mockAuthUser);
     (fetchFriends as jest.Mock).mockResolvedValue(mockFriends);
 
     const { container } = await render(await Friends());
@@ -69,7 +69,7 @@ describe("Friends", () => {
       email: "test@example.com",
     };
 
-    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthUser);
+    (getCachedUserSocial as jest.Mock).mockResolvedValue(mockAuthUser);
     (fetchFriends as jest.Mock).mockResolvedValue([]);
 
     await render(await Friends());
@@ -82,7 +82,7 @@ describe("Friends", () => {
       email: "test@example.com",
     };
 
-    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthUser);
+    (getCachedUserSocial as jest.Mock).mockResolvedValue(mockAuthUser);
     (fetchFriends as jest.Mock).mockResolvedValue([]);
 
     await render(await Friends());


### PR DESCRIPTION
## Description

  A series of UI and analytics improvements to the admin dashboard and droplet analytics modal:

  Admin Dashboard
  - Added sliding pill animation to timeframe selector (7d/30d/90d) and request tab selectors
  - Fixed x-axis spacing and date interval display on avg session duration and active users charts
  - Removed refresh button (data revalidates on page load via Next.js caching)
  - Standardized search bar width to max-w-[818px] across all admin pages
  - Added spacing between page titles and search bars

  Admin Tables
  - Made user names in the users table link to their profile page
  - Added Radix tooltips to all action icons across users, reports, droplets, groups, and playlists tables
  - Replaced "Visit Page" text button in reports table with external link icon
  - Fixed trash icon hover color (stays red, background turns grey)
  - Standardized outline style on all action buttons

  Modals
  - Added X close button to all 6 admin modals (droplet analytics, create user, edit user ×2, activity timeline ×2)
  - Custom scrollbar on modals: thin, no track, fades in on hover
  - Scrollbar clipped to rounded modal corners

  Droplet Analytics Modal
  - Redesigned stat cards with last month comparison values and trend percentage (up/down)
  - Added 4th stat card: Average Rating
  - Stat cards now fit in a single row
  - Added sliding pill animation to lesson tab selector in scroll depth chart
  - Directional slide animation when switching between lessons
  - Two data-fetch loops now run in parallel (performance improvement)
  - Fixed averageRating type from magic -1 sentinel to number | null
  - Added error handling on analytics fetch

  Profile Pages
  - System admins can now view private user profiles

  Friends Page
  - Fixed crash caused by missing blocked/was_blocked relation population (getCachedUser → getCachedUserSocial)
  - Fixed double API call in FriendSuggestions component
  - Fixed default tab showing no selection on load ("droplets" → "friends")

## Motivation and Context

Addresses ODY-373 (PostHog admin dashboard integration) and resolves several pre-existing bugs discovered during the UI pass. The friends page crash was a silent server-side error blocking users from accessing the settings page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can view private profiles when authorized.
  * Droplet analytics now show last-month metrics and trend indicators.

* **Improvements**
  * Slide-in animations and sliding indicators for tabs/timeframe selectors.
  * Wider search bars across admin pages.
  * Added close buttons and improved scrollbar styling in dialogs.
  * Chart spacing and axis/tick rendering refined.
  * Modal layout and presentation enhancements; tooltips improved.

* **Bug Fixes**
  * Removed redundant friend-suggestions fetch.

* **Tests**
  * Added tests covering droplet analytics and modal rating UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->