### PR TITLE
Improvement/ody 373 posthog admin dashboard integration

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -222,12 +222,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
           # Create annotated tag with details
-          git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION
-
-Bump type: $BUMP_TYPE
-Source branch: $BRANCH
-Target branch: ${{ github.ref_name }}
-Commit: ${{ github.sha }}"
+          TAG_MSG=$(printf "Release %s\n\nBump type: %s\nSource branch: %s\nTarget branch: %s\nCommit: %s" \
+            "$NEW_VERSION" "$BUMP_TYPE" "$BRANCH" "${{ github.ref_name }}" "${{ github.sha }}")
+          git tag -a "$NEW_VERSION" -m "$TAG_MSG"
           
           git push origin "$NEW_VERSION"
           echo "✓ Created and pushed tag: $NEW_VERSION"


### PR DESCRIPTION
Description

  - Added Average Rating stat card to the droplet analytics modal, bringing the total to four cards displayed in a single row
  - Replaced sentinel value -1 with number | null for unrated droplets throughout the analytics data contract (interface, request function, component, tests)
  - Added sliding pill animation to the scroll depth lesson tab selector
  - Added X close button to all admin modals (droplets, users, create user)
  - Applied a thin hover-only scrollbar to modals; moved scrollable overflow to an inner wrapper so the scrollbar respects the modal's rounded corners
  - Removed the admin dashboard refresh button
  - Fixed three bugs on the friends settings page: switched to getCachedUserSocial (populates blocked), removed a duplicate fetchSuggestionsById call in JSX, and corrected the
  default active tab to "friends"
  - Fixed a YAML syntax error in .github/workflows/versioning.yml — the multi-line git tag -m argument broke out of the YAML block scalar indentation; replaced with a
  printf-built variable

  Motivation and Context

  The analytics modal needed a rating signal alongside enrollment and completion metrics. The null contract is safer than a magic number. The friends page was broken due to the
  wrong cached-user variant being called. The CI versioning workflow was failing with an invalid YAML error on every push to production/develop.