### PR TITLE
Presentation Shell Slide Overflow 

### DIFF
--- a/frontend/components/presentation/presentation-shell.tsx
+++ b/frontend/components/presentation/presentation-shell.tsx
@@ -47,6 +47,10 @@ export function PresentationShell({
 
   useEffect(() => {
     setMounted(true);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
   }, []);
 
   // ── Build slide deck: intro + lessons + end (memoized) ──
@@ -223,7 +227,7 @@ export function PresentationShell({
       : 0;
 
   return (
-    <div className="fixed inset-0 z-[100] bg-white text-slate-900 select-none dark:bg-[#191919] dark:text-white">
+    <div className="fixed inset-0 z-[100] overflow-hidden bg-white text-slate-900 select-none dark:bg-[#191919] dark:text-white">
       {/* ── Odyssey logo (top-right) ── */}
       <div className="fixed top-5 right-6 z-[102]">
         <Logo width={160} height={50} />
@@ -487,7 +491,7 @@ export function PresentationShell({
               // Default layout
               return (
                 <div className="w-full max-w-4xl text-left">
-                  <div className="space-y-4">
+                  <div className="max-h-[85vh] space-y-4 overflow-hidden [&_img]:max-h-[40vh] [&_img]:w-auto [&_img]:object-contain [&_pre]:max-h-[55vh] [&_pre]:overflow-y-auto">
                     {allBlocks.map((block, idx) => (
                       <PresentationBlockRenderer
                         key={`${currentSlideKey}-${idx}`}


### PR DESCRIPTION

## Description
- Added a **Slide Break** block type to the V1 (classic) editor, so authors can insert presentation slide markers without needing to upgrade to the BlockNote v2 editor
- The **Present** button in the draft sidebar is now **greyed out with a tooltip** ("No presentation blocks in sight") when no lessons contain slide break markers — previously it only checked whether lessons existed at all
- Extracted shared constants (`SLIDE_BREAK_MARKER`, `SLIDE_BREAK_TYPE`, `dashedLineStyle`) into `lib/blocknote/slide-break.ts` and replaced hardcoded strings across 5 files
- 
## Motivation and Context

V1 droplets had no way to use presentation mode because slide breaks were only available in the BlockNote v2 editor. Authors working with legacy V1 content couldn't present without migrating their entire lesson. This change makes presentation mode available regardless of editor version.


## Checklist:


- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unwanted scrolling behavior when presenter view is active.
  * Improved slide content display with optimized spacing and overflow handling for images and code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->