### PR TITLE
Admin Re-design Final Changes

### DIFF
--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -11,7 +11,7 @@
       "url": "https://khouryodyssey.org"
     },
     "license": null,
-    "x-generation-date": "2026-03-30T20:47:42.562Z"
+    "x-generation-date": "2026-04-01T19:39:38.579Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -14266,7 +14266,8 @@
             "required": [
               "name",
               "format",
-              "fileUrl"
+              "fileUrl",
+              "droplet"
             ],
             "type": "object",
             "properties": {
@@ -14361,7 +14362,8 @@
         "required": [
           "name",
           "format",
-          "fileUrl"
+          "fileUrl",
+          "droplet"
         ],
         "properties": {
           "name": {

--- a/docs/superpowers/plans/2026-03-31-presentation-mode-fixes.md
+++ b/docs/superpowers/plans/2026-03-31-presentation-mode-fixes.md
@@ -1,0 +1,1242 @@
+# Presentation Mode Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix disappearing content in presentation mode, add overflow warnings in the editor, and add an AI auto-format button.
+
+**Architecture:** Replace fragile HTML-comment layout markers with typed properties on generic blocks. Add a hidden measurement div in the editor that detects slide overflow. Add a Server Action that calls Haiku to auto-insert slide breaks and image layouts.
+
+**Tech Stack:** Next.js 15, BlockNote, Tailwind v3.4, Anthropic SDK (claude-3-haiku-20240307)
+
+---
+
+## File Map
+
+| File                                                            | Action | Responsibility                                                            |
+| --------------------------------------------------------------- | ------ | ------------------------------------------------------------------------- |
+| `frontend/types/index.d.ts`                                     | Modify | Add `slideLayout`, `slideLayoutImageUrl` to generic block variant         |
+| `frontend/lib/blocknote/convert-blocks.ts`                      | Modify | Emit `slideLayout` property instead of `<!--LAYOUT:-->` comments          |
+| `frontend/components/presentation/utils.ts`                     | Modify | Read `slideLayout` property, remove comment parsing, keep blocks in array |
+| `frontend/components/presentation/presentation-shell.tsx`       | Modify | Fix flex math, image-only slides, overflow-y-auto                         |
+| `frontend/components/ui/blocknote/blocks/slide-break-block.tsx` | Modify | Accept overflow prop, show warning variant                                |
+| `frontend/components/draft/lesson/blocknote-editor-client.tsx`  | Modify | Add overflow detection context provider                                   |
+| `frontend/hooks/useSlideOverflowDetection.ts`                   | Create | Hidden measurement hook                                                   |
+| `frontend/lib/actions/auto-format-slides.ts`                    | Create | Server Action for Haiku auto-format                                       |
+| `frontend/components/draft/sidebar.tsx`                         | Modify | Add Auto-Format Slides button                                             |
+
+---
+
+### Task 1: Add `slideLayout` properties to the Block type
+
+**Files:**
+
+- Modify: `frontend/types/index.d.ts:135-142`
+
+- [ ] **Step 1: Add optional properties to the generic block variant**
+
+In `frontend/types/index.d.ts`, update the `droplets.generic` variant of the `Block` type:
+
+```ts
+  | {
+      __component: "droplets.generic";
+      content: string;
+      id?: number;
+      sourceBlockIds?: number[];
+      _clientId?: string;
+      slideLayout?: "image-left" | "image-right" | "full-image";
+      slideLayoutImageUrl?: string;
+    }
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+Expected: No new errors (existing errors are OK, no errors referencing `slideLayout`)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/types/index.d.ts
+git commit -m "feat(types): add slideLayout properties to generic block type"
+```
+
+---
+
+### Task 2: Emit `slideLayout` property in block conversion
+
+**Files:**
+
+- Modify: `frontend/lib/blocknote/convert-blocks.ts:379-399`
+- Test: `frontend/tests/lib/blocknote/convert-blocks.test.ts` (create if needed)
+
+- [ ] **Step 1: Write a failing test for image layout conversion**
+
+Check if a test file exists at `frontend/tests/lib/blocknote/convert-blocks.test.ts`. If not, create it. Add tests:
+
+```ts
+import { convertBlockNoteToV1Blocks } from "@/lib/blocknote/convert-blocks";
+
+describe("convertBlockNoteToV1Blocks - image layout", () => {
+  it("emits slideLayout property for image-right layout", () => {
+    const blocks = [
+      {
+        id: "test-img-1",
+        type: "image",
+        props: {
+          url: "https://cdn.example.com/photo.jpg",
+          name: "Test photo",
+          layout: "image-right",
+        },
+        content: undefined,
+        children: [],
+      },
+    ];
+
+    const result = convertBlockNoteToV1Blocks(blocks as any);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].__component).toBe("droplets.generic");
+
+    const generic = result[0] as any;
+    expect(generic.slideLayout).toBe("image-right");
+    expect(generic.slideLayoutImageUrl).toBe(
+      "https://cdn.example.com/photo.jpg",
+    );
+    // Content should be a clean <img> tag with no <!--LAYOUT:--> comment
+    expect(generic.content).toContain("<img");
+    expect(generic.content).not.toContain("<!--LAYOUT:");
+  });
+
+  it("emits slideLayout property for image-left layout", () => {
+    const blocks = [
+      {
+        id: "test-img-2",
+        type: "image",
+        props: {
+          url: "https://cdn.example.com/left.jpg",
+          name: "Left photo",
+          layout: "image-left",
+        },
+        content: undefined,
+        children: [],
+      },
+    ];
+
+    const result = convertBlockNoteToV1Blocks(blocks as any);
+    const generic = result[0] as any;
+    expect(generic.slideLayout).toBe("image-left");
+    expect(generic.slideLayoutImageUrl).toBe(
+      "https://cdn.example.com/left.jpg",
+    );
+  });
+
+  it("emits slideLayout property for full-image layout", () => {
+    const blocks = [
+      {
+        id: "test-img-3",
+        type: "image",
+        props: {
+          url: "https://cdn.example.com/full.jpg",
+          name: "Full photo",
+          layout: "full-image",
+        },
+        content: undefined,
+        children: [],
+      },
+    ];
+
+    const result = convertBlockNoteToV1Blocks(blocks as any);
+    const generic = result[0] as any;
+    expect(generic.slideLayout).toBe("full-image");
+  });
+
+  it("does NOT emit slideLayout for default layout images", () => {
+    const blocks = [
+      {
+        id: "test-img-4",
+        type: "image",
+        props: {
+          url: "https://cdn.example.com/default.jpg",
+          name: "Default photo",
+          layout: "default",
+        },
+        content: undefined,
+        children: [],
+      },
+    ];
+
+    const result = convertBlockNoteToV1Blocks(blocks as any);
+    const generic = result[0] as any;
+    expect(generic.slideLayout).toBeUndefined();
+    expect(generic.slideLayoutImageUrl).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx jest --testPathPattern="convert-blocks" --verbose 2>&1 | tail -20`
+Expected: FAIL — `slideLayout` is undefined because images still emit `<!--LAYOUT:-->` comments
+
+- [ ] **Step 3: Update the image case in convert-blocks.ts**
+
+In `frontend/lib/blocknote/convert-blocks.ts`, replace the `case "image":` block (lines 379-399) with:
+
+```ts
+    case "image": {
+      const url = (blockAny.props?.url as string) || "";
+      const alt = (blockAny.props?.name as string) || "";
+      const layout = (blockAny.props?.layout as string) || "default";
+      const imgTag = `<img src="${escapeHtml(url)}" alt="${escapeHtml(alt)}" class="rounded-md" />`;
+
+      if (layout !== "default" && url) {
+        return {
+          __component: "droplets.generic" as const,
+          id: blockId,
+          content: imgTag,
+          slideLayout: layout as "image-left" | "image-right" | "full-image",
+          slideLayoutImageUrl: url,
+        };
+      }
+      return {
+        __component: "droplets.generic" as const,
+        id: blockId,
+        content: imgTag,
+      };
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx jest --testPathPattern="convert-blocks" --verbose 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/lib/blocknote/convert-blocks.ts frontend/tests/lib/blocknote/convert-blocks.test.ts
+git commit -m "feat(convert-blocks): emit slideLayout property instead of HTML comments"
+```
+
+---
+
+### Task 3: Update slide splitting to use `slideLayout` property
+
+**Files:**
+
+- Modify: `frontend/components/presentation/utils.ts`
+
+- [ ] **Step 1: Write failing tests for the new slide splitting behavior**
+
+Create `frontend/tests/components/presentation/utils.test.ts`:
+
+```ts
+import { splitBlocksIntoSlides } from "@/components/presentation/utils";
+import { SLIDE_BREAK_MARKER } from "@/lib/blocknote/slide-break";
+import type { Lesson } from "@/types";
+
+function makeLessonV1(blocks: any[]): Lesson {
+  return {
+    id: 1,
+    name: "Test Lesson",
+    slug: "test-lesson",
+    type: "lesson",
+    blocks,
+    blocksVersion: "v1",
+    orderIndex: 0,
+  } as Lesson;
+}
+
+describe("splitBlocksIntoSlides", () => {
+  it("creates a slide for an image-right block with no sibling text", () => {
+    const lesson = makeLessonV1([
+      { __component: "droplets.generic", id: 1, content: SLIDE_BREAK_MARKER },
+      {
+        __component: "droplets.generic",
+        id: 2,
+        content: '<img src="https://example.com/img.jpg" alt="test" />',
+        slideLayout: "image-right",
+        slideLayoutImageUrl: "https://example.com/img.jpg",
+      },
+      { __component: "droplets.generic", id: 3, content: SLIDE_BREAK_MARKER },
+    ]);
+
+    const slides = splitBlocksIntoSlides(lesson, 0);
+    // Should have: lesson title card + the image slide
+    expect(slides.length).toBeGreaterThanOrEqual(2);
+
+    const imageSlide = slides.find((s) => s.layout === "image-right");
+    expect(imageSlide).toBeDefined();
+    expect(imageSlide!.layoutImageUrl).toBe("https://example.com/img.jpg");
+    expect(imageSlide!.blocks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("creates a slide with image-left layout and keeps text blocks", () => {
+    const lesson = makeLessonV1([
+      { __component: "droplets.generic", id: 1, content: SLIDE_BREAK_MARKER },
+      { __component: "droplets.generic", id: 2, content: "<p>Some text</p>" },
+      {
+        __component: "droplets.generic",
+        id: 3,
+        content: '<img src="https://example.com/left.jpg" alt="" />',
+        slideLayout: "image-left",
+        slideLayoutImageUrl: "https://example.com/left.jpg",
+      },
+      { __component: "droplets.generic", id: 4, content: SLIDE_BREAK_MARKER },
+    ]);
+
+    const slides = splitBlocksIntoSlides(lesson, 0);
+    const imageSlide = slides.find((s) => s.layout === "image-left");
+    expect(imageSlide).toBeDefined();
+    expect(imageSlide!.layoutImageUrl).toBe("https://example.com/left.jpg");
+    // Should have both the text block AND the image block
+    expect(imageSlide!.blocks.length).toBe(2);
+  });
+
+  it("does NOT parse <!--LAYOUT:--> comments as layout markers", () => {
+    // Legacy format — should be treated as a regular generic block, not a layout
+    const lesson = makeLessonV1([
+      { __component: "droplets.generic", id: 1, content: SLIDE_BREAK_MARKER },
+      {
+        __component: "droplets.generic",
+        id: 2,
+        content:
+          '<!--LAYOUT:IMAGE_RIGHT:https://example.com/old.jpg--><img src="https://example.com/old.jpg" />',
+      },
+      { __component: "droplets.generic", id: 3, content: SLIDE_BREAK_MARKER },
+    ]);
+
+    const slides = splitBlocksIntoSlides(lesson, 0);
+    // The old comment block should just be a regular block in a default-layout slide
+    const contentSlides = slides.filter(
+      (s) =>
+        s.lessonIndex === 0 &&
+        s.blocks.length > 0 &&
+        !s.blocks[0].content.includes("text-center"),
+    );
+    expect(contentSlides.length).toBe(1);
+    expect(contentSlides[0].layout).toBe("default");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx jest --testPathPattern="presentation/utils" --verbose 2>&1 | tail -30`
+Expected: FAIL — current code still parses HTML comments and discards layout blocks
+
+- [ ] **Step 3: Update utils.ts to use slideLayout property**
+
+Replace the contents of `frontend/components/presentation/utils.ts`:
+
+```ts
+/**
+ * Presentation mode slide-splitting utilities.
+ *
+ * Splits on <!--SLIDE_BREAK--> markers. Image blocks with a `slideLayout`
+ * property control slide layout (image-left, image-right, full-image).
+ */
+import { Block, Lesson } from "@/types";
+import { convertBlockNoteToV1Blocks } from "@/lib/blocknote/convert-blocks";
+import { SLIDE_BREAK_MARKER } from "@/lib/blocknote/slide-break";
+
+export type SlideLayout =
+  | "default"
+  | "image-left"
+  | "image-right"
+  | "full-image";
+
+export type Slide = {
+  blocks: Block[];
+  title?: string;
+  lessonName: string;
+  lessonIndex: number;
+  layout: SlideLayout;
+  layoutImageUrl?: string;
+};
+
+// ── Helpers ──
+
+function isEmptySpacing(block: Block): boolean {
+  if (block.__component !== "droplets.generic") return false;
+  return block.content.includes("empty-paragraph-spacing");
+}
+
+function isSlideBreak(block: Block): boolean {
+  return (
+    block.__component === "droplets.generic" &&
+    block.content === SLIDE_BREAK_MARKER
+  );
+}
+
+function hasSlideLayout(block: Block): block is Extract<
+  Block,
+  { __component: "droplets.generic" }
+> & {
+  slideLayout: SlideLayout;
+  slideLayoutImageUrl: string;
+} {
+  return (
+    block.__component === "droplets.generic" &&
+    "slideLayout" in block &&
+    block.slideLayout !== undefined
+  );
+}
+
+function extractHeadingTitle(block: Block): string | undefined {
+  if (block.__component !== "droplets.generic") return undefined;
+  const match = block.content.match(/<h[1-3][^>]*>(.*?)<\/h[1-3]>/i);
+  if (!match) return undefined;
+  return match[1].replace(/<[^>]+>/g, "").trim() || undefined;
+}
+
+// ── Main ──
+
+export function splitBlocksIntoSlides(
+  lesson: Lesson,
+  lessonIndex: number,
+): Slide[] {
+  const rawBlocks: Block[] =
+    lesson.blocksVersion === "v2" && lesson.blocksV2
+      ? convertBlockNoteToV1Blocks(lesson.blocksV2)
+      : lesson.blocks ?? [];
+
+  const cleanBlocks = rawBlocks.filter(
+    (b) => !isEmptySpacing(b) && !isSlideBreak(b),
+  );
+  if (cleanBlocks.length === 0) return [];
+
+  const hasSlideBreaks = rawBlocks.some(isSlideBreak);
+  if (!hasSlideBreaks) return [];
+
+  const slides: Slide[] = [];
+
+  // Lesson title card
+  slides.push({
+    blocks: [
+      {
+        __component: "droplets.generic" as const,
+        id: -(lessonIndex + 1) * 1000,
+        content: `<h1 class="text-center">${lesson.name}</h1>`,
+      },
+    ],
+    title: lesson.name,
+    lessonName: lesson.name,
+    lessonIndex,
+    layout: "default",
+  });
+
+  return splitByMarkers(rawBlocks, lesson, lessonIndex, slides);
+}
+
+function splitByMarkers(
+  rawBlocks: Block[],
+  lesson: Lesson,
+  lessonIndex: number,
+  slides: Slide[],
+): Slide[] {
+  let current: Block[] = [];
+  let heading: string | undefined;
+  let currentLayout: SlideLayout = "default";
+  let currentLayoutImageUrl: string | undefined;
+
+  function flush() {
+    if (current.length > 0) {
+      slides.push({
+        blocks: current,
+        title: heading,
+        lessonName: lesson.name,
+        lessonIndex,
+        layout: currentLayout,
+        layoutImageUrl: currentLayoutImageUrl,
+      });
+      current = [];
+      heading = undefined;
+      currentLayout = "default";
+      currentLayoutImageUrl = undefined;
+    }
+  }
+
+  for (const block of rawBlocks) {
+    if (isEmptySpacing(block)) continue;
+
+    if (isSlideBreak(block)) {
+      flush();
+      continue;
+    }
+
+    // Read layout from typed property — block stays in the array
+    if (hasSlideLayout(block)) {
+      currentLayout = block.slideLayout;
+      currentLayoutImageUrl = block.slideLayoutImageUrl;
+    }
+
+    const h = extractHeadingTitle(block);
+    if (h) heading = h;
+
+    current.push(block);
+  }
+
+  flush();
+  return slides;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx jest --testPathPattern="presentation/utils" --verbose 2>&1 | tail -30`
+Expected: PASS
+
+- [ ] **Step 5: Run existing tests to check for regressions**
+
+Run: `cd frontend && npx jest --verbose 2>&1 | tail -30`
+Expected: All existing tests still pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/components/presentation/utils.ts frontend/tests/components/presentation/utils.test.ts
+git commit -m "feat(presentation): use slideLayout property instead of HTML comment parsing"
+```
+
+---
+
+### Task 4: Fix presentation shell rendering
+
+**Files:**
+
+- Modify: `frontend/components/presentation/presentation-shell.tsx:436-503`
+
+- [ ] **Step 1: Fix image-left/right layout rendering**
+
+In `frontend/components/presentation/presentation-shell.tsx`, replace the image-left/right layout block (lines 436-477) with:
+
+```tsx
+if ((layout === "image-left" || layout === "image-right") && layoutImageUrl) {
+  // Filter out the image-layout block from text content
+  const textBlocks = allBlocks.filter(
+    (b) => !(b.__component === "droplets.generic" && "slideLayout" in b),
+  );
+
+  const imgSide = (
+    <div className="flex min-w-0 basis-1/2 items-center justify-center rounded-2xl bg-slate-100 p-4 dark:bg-slate-800/60">
+      <img
+        src={layoutImageUrl}
+        alt=""
+        className="max-h-[60vh] w-full rounded-xl object-cover shadow-md"
+      />
+    </div>
+  );
+
+  // If no text blocks, render image centered at larger size
+  if (textBlocks.length === 0) {
+    return (
+      <div className="flex w-full items-center justify-center">
+        <img
+          src={layoutImageUrl}
+          alt=""
+          className="max-h-[75vh] w-auto rounded-lg object-contain"
+        />
+      </div>
+    );
+  }
+
+  const textSide = (
+    <div className="flex max-h-[60vh] min-w-0 basis-1/2 flex-col justify-center space-y-5 overflow-y-auto px-2">
+      {textBlocks.map((block, idx) => (
+        <PresentationBlockRenderer
+          key={`${currentSlideKey}-${idx}`}
+          block={block}
+        />
+      ))}
+    </div>
+  );
+
+  return (
+    <div
+      className="flex w-full max-w-5xl items-stretch gap-6 text-left"
+      style={{ minHeight: "60vh" }}
+    >
+      {layout === "image-left" ? (
+        <>
+          {imgSide}
+          {textSide}
+        </>
+      ) : (
+        <>
+          {textSide}
+          {imgSide}
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Fix default layout overflow**
+
+In the same file, replace the default layout block (lines 492-503) with:
+
+```tsx
+// Default layout
+return (
+  <div className="w-full max-w-4xl text-left">
+    <div className="max-h-[85vh] space-y-4 overflow-y-auto [&_img]:max-h-[40vh] [&_img]:w-auto [&_img]:object-contain [&_pre]:max-h-[55vh] [&_pre]:overflow-y-auto">
+      {allBlocks.map((block, idx) => (
+        <PresentationBlockRenderer
+          key={`${currentSlideKey}-${idx}`}
+          block={block}
+        />
+      ))}
+    </div>
+  </div>
+);
+```
+
+The only change: `overflow-hidden` to `overflow-y-auto`.
+
+- [ ] **Step 3: Verify the app builds**
+
+Run: `cd frontend && npx next build 2>&1 | tail -20`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/components/presentation/presentation-shell.tsx
+git commit -m "fix(presentation): fix image layout flex math, overflow-y-auto, image-only slides"
+```
+
+---
+
+### Task 5: Create the overflow detection hook
+
+**Files:**
+
+- Create: `frontend/hooks/useSlideOverflowDetection.ts`
+
+- [ ] **Step 1: Create the hook**
+
+Create `frontend/hooks/useSlideOverflowDetection.ts`:
+
+```ts
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { convertBlockNoteToV1Blocks } from "@/lib/blocknote/convert-blocks";
+import { SLIDE_BREAK_TYPE } from "@/lib/blocknote/slide-break";
+import type { CustomBlockNoteBlock } from "@/types";
+import DOMPurify from "isomorphic-dompurify";
+
+/**
+ * Groups BlockNote blocks into slide chunks (split by slide-break blocks).
+ * Returns the index of each slide-break block that has overflow in the preceding chunk.
+ */
+export function useSlideOverflowDetection(
+  blocks: CustomBlockNoteBlock[] | undefined,
+): Set<string> {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [overflowingBreaks, setOverflowingBreaks] = useState<Set<string>>(
+    new Set(),
+  );
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Create the hidden measurement div on mount
+  useEffect(() => {
+    const div = document.createElement("div");
+    div.style.cssText = [
+      "position: fixed",
+      "top: -9999px",
+      "left: -9999px",
+      "width: 896px", // max-w-4xl = 56rem = 896px
+      "opacity: 0",
+      "pointer-events: none",
+      "overflow: hidden",
+    ].join(";");
+    div.className =
+      "prose prose-xl prose-sky prose-headings:font-bold prose-p:leading-relaxed max-w-none";
+    document.body.appendChild(div);
+    containerRef.current = div;
+
+    return () => {
+      document.body.removeChild(div);
+      containerRef.current = null;
+    };
+  }, []);
+
+  const measure = useCallback(() => {
+    if (!containerRef.current || !blocks || blocks.length === 0) {
+      setOverflowingBreaks(new Set());
+      return;
+    }
+
+    const viewportHeight = window.innerHeight;
+    const defaultBudget = viewportHeight * 0.85;
+    const imageBudget = viewportHeight * 0.6;
+
+    // Split blocks into chunks by slide-break
+    const chunks: { blocks: CustomBlockNoteBlock[]; breakId: string | null }[] =
+      [];
+    let currentChunk: CustomBlockNoteBlock[] = [];
+
+    for (const block of blocks) {
+      if (block.type === SLIDE_BREAK_TYPE) {
+        chunks.push({ blocks: currentChunk, breakId: block.id });
+        currentChunk = [];
+      } else {
+        currentChunk.push(block);
+      }
+    }
+    // Last chunk after the final slide break (no break ID to flag)
+    // We don't flag this one since there's no slide break after it
+
+    const overflows = new Set<string>();
+    const container = containerRef.current;
+
+    for (const chunk of chunks) {
+      if (!chunk.breakId || chunk.blocks.length === 0) continue;
+
+      // Convert to v1 blocks, then to HTML
+      const v1Blocks = convertBlockNoteToV1Blocks(
+        chunk.blocks as CustomBlockNoteBlock[],
+      );
+
+      // Check if any block has a slideLayout (affects budget)
+      const hasImageLayout = v1Blocks.some(
+        (b) => b.__component === "droplets.generic" && "slideLayout" in b,
+      );
+      const budget = hasImageLayout ? imageBudget : defaultBudget;
+
+      // Render to HTML
+      const html = v1Blocks
+        .map((b) => {
+          if (b.__component === "droplets.generic") return b.content;
+          if (b.__component === "droplets.callout")
+            return "<div style='height:80px'></div>";
+          if (b.__component === "droplets.code-block")
+            return `<pre style="max-height:55vh;overflow:hidden">${b.code}</pre>`;
+          if (b.__component === "droplets.video")
+            return "<div style='aspect-ratio:16/9;height:360px'></div>";
+          return "<div style='height:60px'></div>"; // quizzes, sandpack, etc.
+        })
+        .join("");
+
+      container.innerHTML = DOMPurify.sanitize(html, {
+        ADD_TAGS: ["math", "semantics", "mrow", "mi", "mo", "mn"],
+        ADD_ATTR: ["class", "style"],
+      });
+
+      if (container.scrollHeight > budget) {
+        overflows.add(chunk.breakId);
+      }
+    }
+
+    container.innerHTML = "";
+    setOverflowingBreaks(overflows);
+  }, [blocks]);
+
+  // Debounced measurement on content change
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(measure, 500);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [measure]);
+
+  // Re-measure on window resize
+  useEffect(() => {
+    const handleResize = () => measure();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [measure]);
+
+  return overflowingBreaks;
+}
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | grep "useSlideOverflowDetection" | head -5`
+Expected: No errors referencing this file (or no output)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/hooks/useSlideOverflowDetection.ts
+git commit -m "feat(editor): add useSlideOverflowDetection hook for measuring slide overflow"
+```
+
+---
+
+### Task 6: Wire overflow detection into the editor and slide break block
+
+**Files:**
+
+- Modify: `frontend/components/draft/lesson/blocknote-editor-client.tsx`
+- Modify: `frontend/components/ui/blocknote/blocks/slide-break-block.tsx`
+
+- [ ] **Step 1: Create an overflow context**
+
+Add a React context to share overflow state. At the top of `frontend/components/draft/lesson/blocknote-editor-client.tsx`, add:
+
+```ts
+import { createContext, useContext } from "react";
+import { useSlideOverflowDetection } from "@/hooks/useSlideOverflowDetection";
+
+const SlideOverflowContext = createContext<Set<string>>(new Set());
+export const useSlideOverflow = () => useContext(SlideOverflowContext);
+```
+
+- [ ] **Step 2: Wrap the editor with the overflow context provider**
+
+In the `BlockNoteEditorClient` component, add the hook call after `isReady`:
+
+```ts
+const overflowingBreaks = useSlideOverflowDetection(
+  isReady ? (editor.document as unknown as CustomBlockNoteBlock[]) : undefined,
+);
+```
+
+Add `CustomBlockNoteBlock` to the imports from `@/types`.
+
+Wrap the return JSX (the `<div className="blocknote-no-link ...">` block) with:
+
+```tsx
+return (
+  <SlideOverflowContext.Provider value={overflowingBreaks}>
+    <div className="blocknote-no-link w-full rounded-lg border border-slate-200 dark:border-slate-700">
+      {/* ... existing BlockNoteView ... */}
+    </div>
+  </SlideOverflowContext.Provider>
+);
+```
+
+- [ ] **Step 3: Update the slide break block to show overflow warning**
+
+Read the current `frontend/components/ui/blocknote/blocks/slide-break-block.tsx` first, then modify the render function to check overflow context. The slide break block needs to read `useSlideOverflow()` and check if its block ID is in the overflow set.
+
+In the slide break block's render component, add:
+
+```tsx
+import { useSlideOverflow } from "@/components/draft/lesson/blocknote-editor-client";
+
+// Inside the render function:
+const overflowingBreaks = useSlideOverflow();
+const isOverflowing = overflowingBreaks.has(props.block.id);
+```
+
+Then conditionally render the warning below the existing slide break line:
+
+```tsx
+{
+  isOverflowing && (
+    <div className="mt-1 flex items-center justify-center gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        className="h-3.5 w-3.5"
+      >
+        <path
+          fillRule="evenodd"
+          d="M6.701 2.25c.577-1 2.02-1 2.598 0l5.196 9a1.5 1.5 0 0 1-1.299 2.25H2.804a1.5 1.5 0 0 1-1.3-2.25l5.197-9ZM8 5a.75.75 0 0 1 .75.75v2.5a.75.75 0 0 1-1.5 0v-2.5A.75.75 0 0 1 8 5Zm0 6.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+          clipRule="evenodd"
+        />
+      </svg>
+      Slide content may overflow in presentation mode
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Verify the app builds**
+
+Run: `cd frontend && npx next build 2>&1 | tail -20`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/draft/lesson/blocknote-editor-client.tsx frontend/components/ui/blocknote/blocks/slide-break-block.tsx
+git commit -m "feat(editor): wire overflow detection into editor and slide break blocks"
+```
+
+---
+
+### Task 7: Create the auto-format Server Action
+
+**Files:**
+
+- Create: `frontend/lib/actions/auto-format-slides.ts`
+
+- [ ] **Step 1: Create the Server Action file**
+
+Create `frontend/lib/actions/auto-format-slides.ts`:
+
+````ts
+"use server";
+
+import Anthropic from "@anthropic-ai/sdk";
+
+type AutoFormatOperation =
+  | { type: "insert-slide-break"; afterBlockIndex: number }
+  | {
+      type: "set-image-layout";
+      blockIndex: number;
+      layout: "image-left" | "image-right" | "full-image";
+    };
+
+type BlockSummary = {
+  index: number;
+  type: string;
+  textPreview: string;
+  hasImage: boolean;
+  imageUrl?: string;
+};
+
+export async function autoFormatSlides(
+  blockSummaries: BlockSummary[],
+): Promise<{ operations: AutoFormatOperation[] } | { error: string }> {
+  const anthropic = new Anthropic({
+    apiKey: process.env.ANTHROPIC_API_KEY || "",
+  });
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return { error: "Anthropic API key not configured" };
+  }
+
+  const blockList = blockSummaries
+    .map((b) => {
+      let desc = `[${b.index}] ${b.type}`;
+      if (b.textPreview) desc += `: "${b.textPreview}"`;
+      if (b.hasImage) desc += ` (image: ${b.imageUrl ?? "unknown"})`;
+      return desc;
+    })
+    .join("\n");
+
+  try {
+    const msg = await anthropic.messages.create({
+      model: "claude-3-haiku-20240307",
+      max_tokens: 2048,
+      messages: [
+        {
+          role: "user",
+          content: `You are formatting lesson content for a slide presentation. Given the block list below, decide:
+
+1. Where to insert slide breaks to create well-sized slides. Each slide should have roughly 3-8 blocks of content. Break at natural content boundaries (before headings, between topics, before/after images).
+2. For any image blocks, what presentation layout to use:
+   - "image-left": image on left, text on right (use when text follows the image)
+   - "image-right": image on right, text on left (use when text precedes the image)
+   - "full-image": image fills the whole slide (use for standalone images with no adjacent text)
+
+Rules:
+- Do NOT insert a slide break before the very first block.
+- Do NOT insert a slide break after the very last block.
+- If slide breaks already exist (type: "slide-break"), work around them — do not duplicate.
+- Keep text-heavy slides to ~25 lines or fewer.
+- Keep image+text slides to ~15 lines of text.
+
+Respond with ONLY a JSON array of operations. No explanation, no markdown fences.
+
+Operation types:
+{"type":"insert-slide-break","afterBlockIndex":N}
+{"type":"set-image-layout","blockIndex":N,"layout":"image-left"|"image-right"|"full-image"}
+
+Block list:
+${blockList}`,
+        },
+      ],
+    });
+
+    const text = msg.content[0].type === "text" ? msg.content[0].text : "";
+
+    // Parse the JSON response — strip markdown fences if Haiku wraps them
+    const cleaned = text
+      .replace(/```json?\n?/g, "")
+      .replace(/```\n?/g, "")
+      .trim();
+    const operations: AutoFormatOperation[] = JSON.parse(cleaned);
+
+    // Validate operations
+    const valid = operations.filter((op) => {
+      if (op.type === "insert-slide-break") {
+        return (
+          typeof op.afterBlockIndex === "number" &&
+          op.afterBlockIndex >= 0 &&
+          op.afterBlockIndex < blockSummaries.length
+        );
+      }
+      if (op.type === "set-image-layout") {
+        return (
+          typeof op.blockIndex === "number" &&
+          op.blockIndex >= 0 &&
+          op.blockIndex < blockSummaries.length &&
+          ["image-left", "image-right", "full-image"].includes(op.layout)
+        );
+      }
+      return false;
+    });
+
+    return { operations: valid };
+  } catch (err) {
+    console.error("Auto-format slides failed:", err);
+
+    if (err instanceof Anthropic.APIError) {
+      if (err.status === 429)
+        return { error: "Rate limited — try again in a moment." };
+      if (err.status === 529)
+        return { error: "Service overloaded — try again later." };
+    }
+
+    return { error: "Failed to auto-format slides. Please try again." };
+  }
+}
+````
+
+- [ ] **Step 2: Verify no type errors**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | grep "auto-format" | head -5`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/lib/actions/auto-format-slides.ts
+git commit -m "feat(actions): add autoFormatSlides Server Action using Haiku"
+```
+
+---
+
+### Task 8: Add the Auto-Format button to the sidebar
+
+**Files:**
+
+- Modify: `frontend/components/draft/sidebar.tsx`
+
+- [ ] **Step 1: Read the current sidebar file**
+
+Read `frontend/components/draft/sidebar.tsx` fully to understand the imports, state, and where the Present button is.
+
+- [ ] **Step 2: Add the Auto-Format button**
+
+Add the import at the top of the file:
+
+```ts
+import { autoFormatSlides } from "@/lib/actions/auto-format-slides";
+import { Wand2, Loader2 } from "lucide-react";
+```
+
+Add state for the auto-format operation inside the component (near other state declarations):
+
+```ts
+const [isAutoFormatting, setIsAutoFormatting] = useState(false);
+```
+
+Add the handler function inside the component:
+
+```ts
+const handleAutoFormat = async () => {
+  setIsAutoFormatting(true);
+  try {
+    // Build block summaries from current lessons
+    const allBlocks: {
+      index: number;
+      type: string;
+      textPreview: string;
+      hasImage: boolean;
+      imageUrl?: string;
+    }[] = [];
+    let globalIndex = 0;
+
+    for (const lesson of lessons) {
+      const blocks = lesson.blocksV2 ?? [];
+      for (const block of blocks) {
+        const b = block as any;
+        const textContent =
+          b.content
+            ?.map((c: any) => c.text ?? "")
+            .join("")
+            .slice(0, 100) ?? "";
+
+        allBlocks.push({
+          index: globalIndex,
+          type: b.type ?? "unknown",
+          textPreview: textContent,
+          hasImage: b.type === "image",
+          imageUrl: b.props?.url,
+        });
+        globalIndex++;
+      }
+    }
+
+    const result = await autoFormatSlides(allBlocks);
+
+    if ("error" in result) {
+      toast.error(result.error);
+      return;
+    }
+
+    // Apply operations to the editor
+    // The parent page needs to handle applying these operations to the BlockNote editor.
+    // For now, dispatch a custom event that the editor can listen to.
+    window.dispatchEvent(
+      new CustomEvent("auto-format-slides", {
+        detail: { operations: result.operations },
+      }),
+    );
+
+    toast.success(
+      `Auto-formatted: ${result.operations.filter((o) => o.type === "insert-slide-break").length} slide breaks inserted`,
+    );
+  } catch (err) {
+    console.error("Auto-format error:", err);
+    toast.error("Failed to auto-format slides");
+  } finally {
+    setIsAutoFormatting(false);
+  }
+};
+```
+
+Add the button in the sidebar, right before the Present button (inside the `<div className="flex w-full flex-col gap-2 pb-2">` block, after the Preview link):
+
+```tsx
+<button
+  onClick={handleAutoFormat}
+  disabled={isAutoFormatting}
+  className="flex items-center justify-center gap-2 rounded-full bg-amber-400 px-6 py-2 text-center text-black transition hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-amber-600 dark:text-white dark:hover:bg-amber-700"
+>
+  {isAutoFormatting ? (
+    <>
+      <Loader2 className="h-4 w-4 animate-spin" />
+      Formatting...
+    </>
+  ) : (
+    <>
+      <Wand2 className="h-4 w-4" />
+      Auto-Format Slides
+    </>
+  )}
+</button>
+```
+
+- [ ] **Step 3: Verify the app builds**
+
+Run: `cd frontend && npx next build 2>&1 | tail -20`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/components/draft/sidebar.tsx
+git commit -m "feat(sidebar): add Auto-Format Slides button using Haiku AI"
+```
+
+---
+
+### Task 9: Wire auto-format operations into the BlockNote editor
+
+**Files:**
+
+- Modify: `frontend/components/draft/lesson/blocknote-editor-client.tsx`
+
+- [ ] **Step 1: Add a listener for auto-format events**
+
+In the `BlockNoteEditorClient` component, add a `useEffect` that listens for the `auto-format-slides` custom event and applies operations to the editor:
+
+```ts
+// Listen for auto-format operations from the sidebar
+useEffect(() => {
+  if (!isReady) return;
+
+  const handleAutoFormat = (e: Event) => {
+    const { operations } = (e as CustomEvent).detail;
+    if (!operations || !Array.isArray(operations)) return;
+
+    // Sort insert operations in reverse order so indices stay valid
+    const insertOps = operations
+      .filter((op: any) => op.type === "insert-slide-break")
+      .sort((a: any, b: any) => b.afterBlockIndex - a.afterBlockIndex);
+
+    const layoutOps = operations.filter(
+      (op: any) => op.type === "set-image-layout",
+    );
+
+    // Apply layout changes first (doesn't shift indices)
+    for (const op of layoutOps) {
+      const block = editor.document[op.blockIndex];
+      if (block && block.type === "image") {
+        editor.updateBlock(block, {
+          props: { layout: op.layout } as any,
+        });
+      }
+    }
+
+    // Insert slide breaks in reverse order
+    for (const op of insertOps) {
+      const afterBlock = editor.document[op.afterBlockIndex];
+      if (afterBlock) {
+        editor.insertBlocks(
+          [{ type: "slide-break" as any }],
+          afterBlock,
+          "after",
+        );
+      }
+    }
+  };
+
+  window.addEventListener("auto-format-slides", handleAutoFormat);
+  return () =>
+    window.removeEventListener("auto-format-slides", handleAutoFormat);
+}, [editor, isReady]);
+```
+
+- [ ] **Step 2: Verify the app builds**
+
+Run: `cd frontend && npx next build 2>&1 | tail -20`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/draft/lesson/blocknote-editor-client.tsx
+git commit -m "feat(editor): handle auto-format slide operations from sidebar"
+```
+
+---
+
+### Task 10: End-to-end verification
+
+- [ ] **Step 1: Run all tests**
+
+Run: `cd frontend && npx jest --verbose 2>&1 | tail -30`
+Expected: All tests pass
+
+- [ ] **Step 2: Run the build**
+
+Run: `cd frontend && npx next build 2>&1 | tail -20`
+Expected: Build succeeds
+
+- [ ] **Step 3: Run linting**
+
+Run: `cd frontend && npx next lint 2>&1 | tail -20`
+Expected: No new lint errors
+
+- [ ] **Step 4: Manual smoke test checklist**
+
+Start the dev server (`npm run dev`) and verify:
+
+1. Create a droplet with a lesson containing text + image (set to image-right layout) + slide breaks
+2. Verify the overflow warning appears when a slide has too much content
+3. Verify presentation mode shows the image-right layout correctly with text visible
+4. Verify an image-right slide with NO text renders the image full-width (not half-empty)
+5. Verify `overflow-y-auto` allows scrolling on overfull default-layout slides
+6. Click "Auto-Format Slides" and verify slide breaks are inserted
+7. Verify the overflow warnings update after auto-format
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: presentation mode fixes — overflow warnings, image layouts, auto-format"
+```

--- a/docs/superpowers/specs/2026-03-31-presentation-mode-fixes-design.md
+++ b/docs/superpowers/specs/2026-03-31-presentation-mode-fixes-design.md
@@ -1,0 +1,159 @@
+# Presentation Mode: Overflow Warnings, Image Layout Fixes, and AI Auto-Format
+
+**Date:** 2026-03-31
+**Status:** Draft
+**Related ticket:** ODY-386
+
+## Problem
+
+Presentation mode has three categories of issues that make slide creation unreliable:
+
+1. **Disappearing content** — Image blocks with layout settings (image-right, image-left) are discarded during slide splitting if no adjacent text blocks exist. The slide vanishes entirely.
+2. **Silent clipping** — The default slide layout uses `overflow-hidden` with a `max-h-[85vh]` cap. Content that exceeds this is silently cut off with no scroll or indicator.
+3. **No authoring feedback** — There is no way for an author to know if their content will fit on a slide until they enter presentation mode and notice something missing.
+
+## Decisions Made
+
+- **Author-side prevention** over runtime scaling or scrolling. The editor warns authors when content overflows rather than auto-shrinking or scrolling at presentation time.
+- **Pixel-precise measurement** over heuristic estimation. A hidden renderer measures actual content height.
+- **Inline overflow warning** in the editor between slide breaks (not sidebar-only).
+- **Replace HTML comment layout markers** with a `slideLayout` property on existing generic blocks. No new block type.
+- **AI auto-format** via Haiku to insert slide breaks and image layouts in one click.
+
+## Design
+
+### 1. Fix Image Layout System
+
+**Current (broken):** `convert-blocks.ts` encodes image layout as an HTML comment prefix: `<!--LAYOUT:IMAGE_RIGHT:url--><img ... />`. During slide splitting in `utils.ts`, `isLayoutMarker()` matches this block, extracts the layout/URL, and discards the block entirely via `continue`. If no other blocks exist between the slide breaks, `flush()` skips creating the slide because `current.length === 0`.
+
+**New approach:** Add `slideLayout` and `slideLayoutImageUrl` as optional properties on the generic block object.
+
+#### convert-blocks.ts changes
+
+For image blocks with non-default layout, emit:
+
+```ts
+{
+  __component: "droplets.generic",
+  id: blockId,
+  content: imgTag,              // clean <img> tag, no comment prefix
+  slideLayout: "image-right",   // new property
+  slideLayoutImageUrl: url,     // new property
+}
+```
+
+#### utils.ts changes
+
+- Remove `isLayoutMarker()`, `getLayout()`, `getLayoutImageUrl()` functions.
+- In `splitByMarkers()`, check for `block.slideLayout` instead of parsing HTML comments.
+- When a block has `slideLayout`, set the slide's layout and image URL from it, but **keep the block in the `current` array** (do not `continue`).
+- The block stays in the slide, so `current.length > 0` is always true when an image-layout block exists.
+
+#### presentation-shell.tsx changes
+
+For image-left/right slides:
+
+- The image-layout block is in `allBlocks`. Filter it out when rendering the text side (it's already rendered as the image side via `slide.layoutImageUrl`).
+- If no text blocks remain after filtering, render the image centered at a larger size instead of an empty half-split.
+- Fix flex math: replace `w-1/2 shrink-0` + `w-1/2` + `gap-10` (totals >100%) with `basis-1/2 min-w-0` on both sides.
+
+#### Type changes
+
+Add optional `slideLayout` and `slideLayoutImageUrl` to the `droplets.generic` variant of the `Block` type. These properties are only read by the presentation pipeline — the regular lesson renderer ignores them.
+
+### 2. Overflow Warning in the Editor
+
+#### Hidden measurement container
+
+A zero-opacity, pointer-events-none `<div>` rendered inside the editor page. Styled to match presentation mode's exact CSS constraints:
+
+- Same `max-w-4xl` width
+- Same `prose-xl` typography
+- Same padding/margins as the slide viewport
+
+This div is never visible to the author.
+
+#### Measurement flow
+
+1. When editor content changes (debounced ~500ms after last keystroke/block change):
+   - Walk the BlockNote document and identify groups of blocks between slide break blocks.
+   - For each group, convert to HTML using the same `convertBlockNoteToV1Blocks` pipeline.
+   - Inject the HTML into the hidden measurement div.
+   - Compare `scrollHeight` vs the viewport budget:
+     - Default layout: `85vh` equivalent (computed from `window.innerHeight * 0.85`)
+     - Image-left/right layout: `60vh` equivalent
+   - Record which slide groups overflow.
+2. Re-measure on `window.resize` (debounced).
+
+#### Overflow indicator
+
+When a slide group overflows, display a warning bar above the corresponding slide break in the editor:
+
+- Styled as a variant of the existing slide break line (amber/red tinted)
+- Text: "Slide content may overflow in presentation mode"
+- Non-interactive — purely informational
+
+#### Implementation location
+
+The measurement logic lives in a custom hook (`useSlideOverflowDetection`) used by the BlockNote editor client component. The overflow state is a `Set<number>` of slide-break block indices that have overflow. The slide break block component reads this state (via context or prop) to conditionally show the warning.
+
+### 3. Presentation Shell Cleanup
+
+Bug fixes applied alongside the architectural changes:
+
+1. **`overflow-hidden` to `overflow-y-auto`** on the default layout container (`presentation-shell.tsx:494`). Safety net so content scrolls rather than being silently clipped.
+2. **Fix flex math on image-left/right** — `basis-1/2 min-w-0` on both sides, smaller gap.
+3. **Image-only slides** — When an image-layout slide has no text blocks after filtering, render the image centered with optional caption instead of a half-empty split layout.
+4. **Remove all HTML comment parsing** — Delete `isLayoutMarker`, `getLayout`, `getLayoutImageUrl` from `utils.ts`.
+
+### 4. AI Auto-Format Button
+
+A one-click button that uses Claude Haiku to automatically insert slide breaks and set image layouts on a lesson's content.
+
+#### Button placement
+
+In the editor sidebar, near the existing "Present" button. Label: "Auto-Format Slides" (or similar).
+
+#### Flow
+
+1. **On click** — Serialize the lesson's BlockNote content to a text/block summary.
+2. **Send to Haiku** — API call with a system prompt instructing Haiku to:
+   - Analyze the content structure (headings, paragraphs, images, code blocks, quizzes).
+   - Decide where to insert slide breaks at logical content boundaries.
+   - Set appropriate image layouts (image-left, image-right, full-image) for any images based on surrounding content.
+   - Keep each slide's content within the viewport budget (~25 lines of text for default, ~18 for image layouts).
+3. **Haiku returns** — A structured response: a list of operations (insert slide break after block N, set image M to layout X).
+4. **Apply to editor** — Execute the operations as BlockNote transactions. Slide breaks are inserted, image layout props are updated.
+5. **Author reviews** — The slide breaks and image layouts appear in the editor. The overflow warnings immediately validate whether each slide fits. The author can adjust before presenting.
+
+#### Constraints
+
+- **Non-destructive** — Only inserts slide breaks and changes image layout props. Never modifies, reorders, or deletes content.
+- **Idempotent-ish** — If slide breaks already exist, Haiku should work with/around them rather than duplicating.
+- **Fallback** — If the API call fails, show a toast error. The editor state is unchanged.
+
+#### API integration
+
+Uses the existing Anthropic SDK. The API call is made from a Server Action to keep the API key server-side. The editor calls the Server Action and applies the returned operations client-side.
+
+## Out of Scope
+
+- **No auto-scaling / fit-to-slide** — Authors fix overflow themselves (manually or via AI auto-format)
+- **No touch/swipe navigation** — Separate feature
+- **No presenter notes or slide grid overview** — Separate features
+- **No changes to the regular lesson renderer** — Only the presentation pipeline is affected
+- **No changes to the BlockNote schema definition** — `slideLayout` rides on the existing generic block as an extra property, not a new block spec
+
+## Files Affected
+
+| File                                                               | Change                                                                         |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `frontend/types/index.ts` (or wherever Block is defined)           | Add optional `slideLayout`, `slideLayoutImageUrl` to generic block             |
+| `frontend/lib/blocknote/convert-blocks.ts`                         | Emit `slideLayout` property instead of `<!--LAYOUT:...-->` comment             |
+| `frontend/components/presentation/utils.ts`                        | Read `slideLayout` property, remove HTML comment parsing, keep blocks in array |
+| `frontend/components/presentation/presentation-shell.tsx`          | Fix flex math, handle image-only slides, `overflow-y-auto`                     |
+| `frontend/components/presentation/presentation-block-renderer.tsx` | No changes (generic blocks render the same)                                    |
+| `frontend/components/ui/blocknote/blocks/slide-break-block.tsx`    | Show overflow warning variant                                                  |
+| New: `frontend/hooks/useSlideOverflowDetection.ts`                 | Hidden measurement logic                                                       |
+| New: `frontend/lib/actions/auto-format-slides.ts`                  | Server Action for Haiku API call                                               |
+| `frontend/components/draft/sidebar.tsx`                            | Add "Auto-Format Slides" button                                                |

--- a/frontend/app/(editing)/draft/p/[slug]/page.tsx
+++ b/frontend/app/(editing)/draft/p/[slug]/page.tsx
@@ -54,11 +54,13 @@ export default async function EditPlaylistPage({ params }: Props) {
 
   if (
     !playlist ||
-    (!playlist.authors?.some((author) => author.id === authUser.id) &&
-      !isAuthorizedUserAdmin(user.roles))
+    (!isAuthorizedUserAdmin(user.roles) &&
+      !playlist.authors?.some((author) => author.id === authUser?.id))
   ) {
     return notFound();
   }
+
+  if (!authUser) return notFound();
 
   const allDroplets = await getDroplets({
     filters: {

--- a/frontend/app/(general)/admin/page.tsx
+++ b/frontend/app/(general)/admin/page.tsx
@@ -126,7 +126,7 @@ async function StatsAndPageviews() {
   return (
     <>
       {/* Desktop */}
-      <div className="hidden md:grid md:grid-cols-[524fr_578fr] md:items-start md:gap-[25px]">
+      <div className="hidden md:grid md:grid-cols-[524fr_578fr] md:items-start md:gap-5">
         <div className="grid grid-cols-2 gap-5">{statCards}</div>
         <UniquePageviewBarChart data={pageviewCountRaw} />
       </div>
@@ -193,7 +193,7 @@ export default function Page() {
         fallback={
           <>
             {/* Desktop */}
-            <div className="hidden md:grid md:grid-cols-[524fr_578fr] md:items-start md:gap-[25px]">
+            <div className="hidden md:grid md:grid-cols-[524fr_578fr] md:items-start md:gap-5">
               <div className="grid grid-cols-2 gap-5">
                 <StatCardSkeleton />
                 <StatCardSkeleton />

--- a/frontend/components/admin/charts/active-users-chart.tsx
+++ b/frontend/components/admin/charts/active-users-chart.tsx
@@ -3,7 +3,14 @@
 import { useId, useState } from "react";
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid } from "recharts";
 import { ChartContainer, ChartTooltip } from "@/components/ui/chart";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { IconTrendingUp, IconTrendingDown } from "@tabler/icons-react";
 import {
   filterByDays,
   filterByDateRange,
@@ -65,6 +72,30 @@ export function ActiveUsersChart({
     count: d.count,
   }));
 
+  const mid = Math.floor(formatted.length / 2);
+  const firstHalf = formatted.slice(0, mid);
+  const secondHalf = formatted.slice(mid);
+  const avgFirst =
+    firstHalf.length > 0
+      ? firstHalf.reduce((s, d) => s + d.count, 0) / firstHalf.length
+      : 0;
+  const avgSecond =
+    secondHalf.length > 0
+      ? secondHalf.reduce((s, d) => s + d.count, 0) / secondHalf.length
+      : 0;
+  const trendPct = avgFirst > 0 ? ((avgSecond - avgFirst) / avgFirst) * 100 : 0;
+  const trendUp = trendPct >= 0;
+
+  const periodLabel = dateRange
+    ? `from ${formatChartDate(dateRange.start)} – ${formatChartDate(dateRange.end)}`
+    : timeframe === 7
+      ? "this week"
+      : timeframe === 30
+        ? "this month"
+        : timeframe === 90
+          ? "this quarter"
+          : `in the last ${timeframe} days`;
+
   return (
     <Card className="flex h-[320px] flex-col overflow-hidden rounded-[20px] border-0 bg-[#FCFCFD] shadow-[0px_0px_4px_0px_rgba(0,0,0,0.25)] md:h-[396px] dark:bg-slate-800">
       <CardHeader className="flex-row items-start justify-between px-6 pt-5 pb-1">
@@ -79,7 +110,7 @@ export function ActiveUsersChart({
           activeDateRange={dateRange}
         />
       </CardHeader>
-      <CardContent className="min-h-0 flex-1 px-6 pb-4">
+      <CardContent className="min-h-0 flex-1 px-6 pb-2">
         {formatted.length === 0 ? (
           <div className="flex h-full items-center justify-center text-[14px] text-slate-400">
             No active user data available
@@ -126,6 +157,21 @@ export function ActiveUsersChart({
           </ChartContainer>
         )}
       </CardContent>
+      {formatted.length > 0 && (
+        <CardFooter className="flex items-center gap-2 px-6 pt-0 pb-4 text-sm">
+          {trendUp ? (
+            <IconTrendingUp className="h-4 w-4 text-[#1ea438]" />
+          ) : (
+            <IconTrendingDown className="h-4 w-4 text-[#ce3131]" />
+          )}
+          <span
+            className={`font-medium ${trendUp ? "text-[#1ea438]" : "text-[#ce3131]"}`}
+          >
+            {trendUp ? "Trending up" : "Trending down"} by{" "}
+            {Math.abs(trendPct).toFixed(1)}% {periodLabel}
+          </span>
+        </CardFooter>
+      )}
     </Card>
   );
 }

--- a/frontend/components/admin/charts/avg-session-duration-chart.tsx
+++ b/frontend/components/admin/charts/avg-session-duration-chart.tsx
@@ -5,7 +5,6 @@ import { AreaChart, Area, XAxis, YAxis, CartesianGrid } from "recharts";
 import {
   ChartContainer,
   ChartTooltip,
-  ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
 import {
@@ -27,9 +26,29 @@ import {
   type DateRange,
 } from "@/components/admin/charts/timeframe-selector";
 
+function AvgSessionTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: { value: number }[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px] shadow-sm dark:border-slate-700 dark:bg-slate-800">
+      <p className="text-slate-500 dark:text-slate-400">{label}</p>
+      <p className="font-medium text-black dark:text-white">
+        Average Duration: {payload[0].value} min
+      </p>
+    </div>
+  );
+}
+
 const chartConfig = {
   duration: {
-    label: "Avg Duration (min)",
+    label: "Average Duration (min)",
     color: "#2D7597",
   },
 } satisfies ChartConfig;
@@ -86,7 +105,7 @@ export function AvgSessionDurationChart({
     <Card className="flex h-[320px] flex-col overflow-hidden rounded-[20px] border-0 bg-[#FCFCFD] shadow-[0px_0px_4px_0px_rgba(0,0,0,0.25)] md:h-[396px] dark:bg-slate-800">
       <CardHeader className="flex-row items-start justify-between px-6 pt-5 pb-1">
         <CardTitle className="text-[20px] font-medium dark:text-white">
-          Avg Session Duration
+          Average Session Duration
         </CardTitle>
         <TimeframeSelector
           options={CHART_TIMEFRAMES}
@@ -132,13 +151,7 @@ export function AvgSessionDurationChart({
                 width={40}
                 tickFormatter={(v: number) => `${v}m`}
               />
-              <ChartTooltip
-                content={
-                  <ChartTooltipContent
-                    formatter={(value) => [`${value} min`, "Avg Duration"]}
-                  />
-                }
-              />
+              <ChartTooltip content={<AvgSessionTooltip />} />
               <Area
                 type="monotone"
                 dataKey="duration"

--- a/frontend/components/admin/charts/unique-pageview-chart.tsx
+++ b/frontend/components/admin/charts/unique-pageview-chart.tsx
@@ -58,7 +58,7 @@ function RoundedTopCursor({
   height?: number;
 }) {
   if (x == null || y == null || width == null || height == null) return null;
-  const r = 6;
+  const r = Math.min(6, width / 2);
   return (
     <path
       d={`M${x + r},${y} h${width - 2 * r} a${r},${r} 0 0 1 ${r},${r} v${height - r} h${-width} v${-(height - r)} a${r},${r} 0 0 1 ${r},${-r}z`}
@@ -108,7 +108,7 @@ export function UniquePageviewBarChart({
       ? secondHalf.reduce((s, d) => s + d.count, 0) / secondHalf.length
       : 0;
   const trendPct = avgFirst > 0 ? ((avgSecond - avgFirst) / avgFirst) * 100 : 0;
-  const trendUp = trendPct >= 0;
+  const trendUp = trendPct > 0;
 
   const periodLabel = dateRange
     ? `from ${formatChartDate(dateRange.start)} – ${formatChartDate(dateRange.end)}`

--- a/frontend/components/admin/charts/unique-pageview-chart.tsx
+++ b/frontend/components/admin/charts/unique-pageview-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { IconTrendingUp, IconTrendingDown } from "@tabler/icons-react";
 import {
   BarChart,
   Bar,
@@ -12,7 +13,6 @@ import {
 import {
   ChartContainer,
   ChartTooltip,
-  ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
 import {
@@ -25,6 +25,47 @@ import {
   TimeframeSelector,
   type DateRange,
 } from "@/components/admin/charts/timeframe-selector";
+
+function PageviewTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: { value: number }[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px] shadow-sm dark:border-slate-700 dark:bg-slate-800">
+      <p className="text-slate-500 dark:text-slate-400">{label}</p>
+      <p className="font-medium text-black dark:text-white">
+        Pageviews: {payload[0].value}
+      </p>
+    </div>
+  );
+}
+
+function RoundedTopCursor({
+  x,
+  y,
+  width,
+  height,
+}: {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+}) {
+  if (x == null || y == null || width == null || height == null) return null;
+  const r = 6;
+  return (
+    <path
+      d={`M${x + r},${y} h${width - 2 * r} a${r},${r} 0 0 1 ${r},${r} v${height - r} h${-width} v${-(height - r)} a${r},${r} 0 0 1 ${r},${-r}z`}
+      fill="rgba(0,0,0,0.1)"
+    />
+  );
+}
 
 const chartConfig = {
   count: {
@@ -55,6 +96,30 @@ export function UniquePageviewBarChart({
     count: d.count,
   }));
 
+  const mid = Math.floor(formatted.length / 2);
+  const firstHalf = formatted.slice(0, mid);
+  const secondHalf = formatted.slice(mid);
+  const avgFirst =
+    firstHalf.length > 0
+      ? firstHalf.reduce((s, d) => s + d.count, 0) / firstHalf.length
+      : 0;
+  const avgSecond =
+    secondHalf.length > 0
+      ? secondHalf.reduce((s, d) => s + d.count, 0) / secondHalf.length
+      : 0;
+  const trendPct = avgFirst > 0 ? ((avgSecond - avgFirst) / avgFirst) * 100 : 0;
+  const trendUp = trendPct >= 0;
+
+  const periodLabel = dateRange
+    ? `from ${formatChartDate(dateRange.start)} – ${formatChartDate(dateRange.end)}`
+    : timeframe === 7
+      ? "this week"
+      : timeframe === 14
+        ? "last 2 weeks"
+        : timeframe === 30
+          ? "this month"
+          : `in the last ${timeframe} days`;
+
   return (
     <div className="flex h-[280px] flex-col overflow-hidden rounded-[20px] bg-[#FCFCFD] shadow-[0px_0px_4px_0px_rgba(0,0,0,0.25)] dark:bg-slate-800">
       <div className="flex items-start justify-between px-5 pt-4 pb-2">
@@ -69,7 +134,7 @@ export function UniquePageviewBarChart({
           activeDateRange={dateRange}
         />
       </div>
-      <div className="min-h-0 flex-1 px-5 pb-4">
+      <div className="min-h-0 flex-1 px-5 pt-2 pb-0">
         {formatted.length === 0 ? (
           <div className="flex h-full items-center justify-center text-[14px] text-slate-400">
             No pageview data available
@@ -78,7 +143,7 @@ export function UniquePageviewBarChart({
           <ChartContainer config={chartConfig} className="h-full w-full">
             <BarChart
               data={formatted}
-              margin={{ top: 15, right: 10, left: 0, bottom: 5 }}
+              margin={{ top: 8, right: 10, left: 0, bottom: 0 }}
             >
               <CartesianGrid vertical={false} stroke="#e2e8f0" />
               <XAxis
@@ -97,7 +162,10 @@ export function UniquePageviewBarChart({
                 tick={{ fontSize: 12, fill: "#60646c" }}
                 width={40}
               />
-              <ChartTooltip content={<ChartTooltipContent />} />
+              <ChartTooltip
+                cursor={<RoundedTopCursor />}
+                content={<PageviewTooltip />}
+              />
               <Bar dataKey="count" fill="#2D7597" radius={[4, 4, 0, 0]}>
                 <LabelList
                   dataKey="count"
@@ -111,6 +179,21 @@ export function UniquePageviewBarChart({
           </ChartContainer>
         )}
       </div>
+      {formatted.length > 0 && (
+        <div className="flex items-center gap-2 px-5 pt-0 pb-4 text-sm">
+          {trendUp ? (
+            <IconTrendingUp className="h-4 w-4 text-[#1ea438]" />
+          ) : (
+            <IconTrendingDown className="h-4 w-4 text-[#ce3131]" />
+          )}
+          <span
+            className={`font-medium ${trendUp ? "text-[#1ea438]" : "text-[#ce3131]"}`}
+          >
+            {trendUp ? "Trending up" : "Trending down"} by{" "}
+            {Math.abs(trendPct).toFixed(1)}% {periodLabel}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/admin/droplets/droplet-analytics-modal.tsx
+++ b/frontend/components/admin/droplets/droplet-analytics-modal.tsx
@@ -95,6 +95,27 @@ function computeTrend(
   };
 }
 
+function RoundedRightCursor({
+  x,
+  y,
+  width,
+  height,
+}: {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+}) {
+  if (x == null || y == null || width == null || height == null) return null;
+  const r = 6;
+  return (
+    <path
+      d={`M${x},${y} h${width - r} a${r},${r} 0 0 1 ${r},${r} v${height - 2 * r} a${r},${r} 0 0 1 ${-r},${r} h${-(width - r)}z`}
+      fill="rgba(0,0,0,0.1)"
+    />
+  );
+}
+
 function BarInsideLabel(props: LabelProps) {
   const { x, y, width, height, value } = props as {
     x: number;
@@ -155,37 +176,48 @@ function ScrollDepthChart({
 
   return (
     <div className="mt-6 rounded-[20px] bg-[#fcfcfd] p-8 shadow dark:bg-slate-800">
-      <h4 className="text-[22px] font-bold text-black dark:text-white">
-        Scroll Depth
-      </h4>
-      <p className="mt-1 text-[16px] text-[#475569] dark:text-slate-400">
-        Showing growth/decline in users as they progress through a lesson
-      </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h4 className="text-[22px] font-bold text-black dark:text-white">
+            Scroll Depth
+          </h4>
+          <p className="mt-1 text-[16px] text-[#475569] dark:text-slate-400">
+            Showing growth/decline in users as they progress through a lesson
+          </p>
+        </div>
+        {scrollDepth[activeIndex].estimated && (
+          <span className="mt-1 shrink-0 rounded-full bg-[#2D7597] px-3 py-1 text-[13px] text-white">
+            Estimated — real tracking in progress
+          </span>
+        )}
+      </div>
 
       {/* Sliding pill tab selector */}
-      <div className="relative mt-5 inline-flex rounded-[97px] bg-[#eaecf0] p-1 dark:bg-slate-700">
-        <div
-          className="absolute rounded-[97px] bg-[#2D7597] shadow transition-all duration-200 ease-in-out"
-          style={{ left: pill.left, width: pill.width, top: 4, bottom: 4 }}
-        />
-        {scrollDepth.map((lesson, i) => (
-          <button
-            key={lesson.lessonId}
-            ref={(el) => {
-              if (el) tabRefs.current.set(i, el);
-              else tabRefs.current.delete(i);
-            }}
-            onClick={() => onTabChange(i)}
-            className={cn(
-              "relative z-10 rounded-[97px] px-4 py-1.5 text-[14px] font-medium transition-colors duration-200",
-              i === activeIndex
-                ? "text-white"
-                : "text-[#475569] hover:text-black dark:text-slate-300 dark:hover:text-white",
-            )}
-          >
-            {lesson.lessonName}
-          </button>
-        ))}
+      <div className="mt-5 max-w-full overflow-x-auto [&::-webkit-scrollbar]:hidden">
+        <div className="relative inline-flex rounded-[97px] bg-[#eaecf0] p-1 dark:bg-slate-700">
+          <div
+            className="absolute rounded-[97px] bg-[#2D7597] shadow transition-all duration-200 ease-in-out"
+            style={{ left: pill.left, width: pill.width, top: 4, bottom: 4 }}
+          />
+          {scrollDepth.map((lesson, i) => (
+            <button
+              key={lesson.lessonId}
+              ref={(el) => {
+                if (el) tabRefs.current.set(i, el);
+                else tabRefs.current.delete(i);
+              }}
+              onClick={() => onTabChange(i)}
+              className={cn(
+                "relative z-10 shrink-0 rounded-[97px] px-4 py-1.5 text-[14px] font-medium whitespace-nowrap transition-colors duration-200",
+                i === activeIndex
+                  ? "text-white"
+                  : "text-[#475569] hover:text-black dark:text-slate-300 dark:hover:text-white",
+              )}
+            >
+              {lesson.lessonName}
+            </button>
+          ))}
+        </div>
       </div>
 
       <div className={cn("mt-6 w-full overflow-x-auto", animClass)}>
@@ -201,11 +233,13 @@ function ScrollDepthChart({
             tick={{ fill: "#475569", fontSize: 14 }}
             axisLine={{ stroke: "#e2e8f0" }}
             tickLine={false}
+            padding={{ left: 24, right: 10 }}
           />
           <YAxis
             tick={{ fill: "#475569", fontSize: 14 }}
             axisLine={{ stroke: "#e2e8f0" }}
             tickLine={false}
+            width={40}
           />
           <Tooltip
             contentStyle={{
@@ -254,13 +288,13 @@ export function DropletAnalyticsModal({
           Droplet Analytics - {droplet.name}
         </DialogTitle>
 
-        <div className="flex max-h-[90vh] flex-col overflow-y-auto [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-transparent [&::-webkit-scrollbar-track]:bg-transparent [&:hover::-webkit-scrollbar-thumb]:bg-slate-300 dark:[&:hover::-webkit-scrollbar-thumb]:bg-slate-600">
+        <div className="flex max-h-[90vh] flex-col overflow-y-auto [&::-webkit-scrollbar]:hidden">
           {/* ---- Header ---- */}
           <div className="sticky top-0 z-10 rounded-t-[20px] bg-white pt-10 pr-10 pb-0 pl-14 dark:bg-slate-900">
-            <DialogClose className="absolute top-4 right-5 rounded-full p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300">
+            <DialogClose className="absolute top-7 right-7 rounded-full p-1.5 text-[#475569] transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300">
               <IconX className="h-5 w-5" />
             </DialogClose>
-            <div className="flex items-start justify-between pr-8">
+            <div className="flex items-baseline justify-between pr-8">
               <div>
                 <h2 className="text-[40px] font-semibold text-black dark:text-white">
                   Analytics
@@ -273,7 +307,7 @@ export function DropletAnalyticsModal({
                 <p className="text-[32px] font-semibold text-black dark:text-white">
                   {droplet.name}
                 </p>
-                <p className="text-[14px] text-[#94a3b8] dark:text-slate-500">
+                <p className="text-[14px] text-[#475569] dark:text-slate-400">
                   Last updated:{" "}
                   {new Date().toLocaleDateString("en-US", {
                     month: "short",
@@ -352,7 +386,7 @@ export function DropletAnalyticsModal({
                 {/* Lesson-level analytics */}
                 {analytics.lessonCompletion.length > 0 && (
                   <>
-                    <h3 className="mt-12 text-[32px] font-semibold text-black dark:text-white">
+                    <h3 className="mt-8 text-[32px] font-semibold text-black dark:text-white">
                       Lesson-level Analytics
                     </h3>
 
@@ -381,6 +415,7 @@ export function DropletAnalyticsModal({
                           <XAxis type="number" hide />
                           <YAxis type="category" dataKey="name" hide />
                           <Tooltip
+                            cursor={<RoundedRightCursor />}
                             contentStyle={{
                               borderRadius: 12,
                               border: "none",
@@ -390,8 +425,8 @@ export function DropletAnalyticsModal({
                           <Bar
                             dataKey="count"
                             fill="#2D7597"
-                            radius={[16, 16, 16, 16]}
-                            barSize={36}
+                            radius={[0, 6, 6, 0]}
+                            barSize={44}
                           >
                             <LabelList
                               dataKey="name"

--- a/frontend/components/admin/droplets/droplet-analytics-modal.tsx
+++ b/frontend/components/admin/droplets/droplet-analytics-modal.tsx
@@ -279,7 +279,7 @@ export function DropletAnalyticsModal({
       .then(setAnalytics)
       .catch(() => setAnalytics(null))
       .finally(() => setLoading(false));
-  }, [open, droplet.id]);
+  }, [open, droplet.id, droplet.lessons]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/frontend/components/admin/droplets/droplets-page-client.tsx
+++ b/frontend/components/admin/droplets/droplets-page-client.tsx
@@ -38,8 +38,10 @@ const DropletAnalyticsModal = dynamic(
 );
 
 const DROPLET_COLUMNS: AdminColumnDef[] = [
-  { label: "Title", width: "w-[45%]" },
-  { label: "Tags", width: "w-[35%]" },
+  { label: "Title", width: "w-[35%]" },
+  { label: "Type", width: "w-[10%]" },
+  { label: "Focus Area", width: "w-[12%]" },
+  { label: "Tags", width: "w-[23%]" },
   { label: "Actions", width: "w-[20%]" },
 ];
 
@@ -49,6 +51,7 @@ const TAG_TYPE_COLORS: Record<string, { bg: string; text: string }> = {
   skill: { bg: "bg-[#fae6f3]", text: "text-[#855169]" },
   knowledge: { bg: "bg-[#f9f7e6]", text: "text-[#7f6b55]" },
   professional: { bg: "bg-[#def2fd]", text: "text-[#284965]" },
+  personal: { bg: "bg-[#f0fdf4]", text: "text-[#166534]" },
   databases: { bg: "bg-[#e0f2fe]", text: "text-[#0c4a6e]" },
   interviews: { bg: "bg-[#fef3c7]", text: "text-[#92400e]" },
   cloud: { bg: "bg-[#ede9fe]", text: "text-[#5b21b6]" },
@@ -102,6 +105,15 @@ const FILTER_TYPE_OPTIONS = [
   { value: "skill", label: "Skill" },
 ] as const;
 
+const FILTER_FOCUS_AREA_OPTIONS = [
+  { value: "personal", label: "Personal" },
+  { value: "technical", label: "Technical" },
+  { value: "professional", label: "Professional" },
+] as const;
+
+const TYPE_VALUES = new Set(["knowledge", "skill"]);
+const FOCUS_AREA_VALUES = new Set(["personal", "technical", "professional"]);
+
 // ——— DropletTableRow ———
 function DropletTableRow({ droplet }: { droplet: Droplet }) {
   const [isHidden, setIsHidden] = useState(droplet.isHidden);
@@ -148,21 +160,43 @@ function DropletTableRow({ droplet }: { droplet: Droplet }) {
           </Link>
         </td>
 
+        {/* Type */}
+        <td className="h-[56px] px-6 py-[11px]">
+          <Badge
+            variant="outline"
+            className={cn(
+              "rounded-[16px] border-0 px-[9px] py-[4px] text-[14px] leading-[18px] font-medium",
+              typeColors.bg,
+              typeColors.text,
+            )}
+          >
+            {uppercaseFirstChar(droplet.type)}
+          </Badge>
+        </td>
+
+        {/* Focus Area */}
+        <td className="h-[56px] px-6 py-[11px]">
+          {droplet.focusArea &&
+            (() => {
+              const focusColors = getTagColors(droplet.focusArea);
+              return (
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    "rounded-[16px] border-0 px-[9px] py-[4px] text-[14px] leading-[18px] font-medium",
+                    focusColors.bg,
+                    focusColors.text,
+                  )}
+                >
+                  {uppercaseFirstChar(droplet.focusArea)}
+                </Badge>
+              );
+            })()}
+        </td>
+
         {/* Tags */}
         <td className="h-[56px] px-6 py-[11px]">
           <div className="flex flex-wrap gap-[5px]">
-            {/* Type badge */}
-            <Badge
-              variant="outline"
-              className={cn(
-                "rounded-[16px] border-0 px-[9px] py-[4px] text-[14px] leading-[18px] font-medium",
-                typeColors.bg,
-                typeColors.text,
-              )}
-            >
-              {uppercaseFirstChar(droplet.type)}
-            </Badge>
-            {/* Tag badges */}
             {droplet.tags?.map((tag) => {
               const colors = getTagColors(tag.name);
               return (
@@ -341,7 +375,15 @@ export function DropletsPageClient({ droplets }: { droplets: Droplet[] }) {
       }
       return sorted;
     },
-    filterFn: (d, types) => types.length === 0 || types.includes(d.type),
+    filterFn: (d, filters) => {
+      const activeTypes = filters.filter((f) => TYPE_VALUES.has(f));
+      const activeFocus = filters.filter((f) => FOCUS_AREA_VALUES.has(f));
+      const typeMatch =
+        activeTypes.length === 0 || activeTypes.includes(d.type);
+      const focusMatch =
+        activeFocus.length === 0 || activeFocus.includes(d.focusArea);
+      return typeMatch && focusMatch;
+    },
   });
 
   return (
@@ -368,8 +410,19 @@ export function DropletsPageClient({ droplets }: { droplets: Droplet[] }) {
             onReset={handleFilterReset}
             hasActiveFilters={hasActiveFilters}
           >
+            <p className="mb-1.5 text-xs font-semibold tracking-wide text-[#667085] uppercase">
+              Type
+            </p>
             <FilterCheckboxGroup
               options={FILTER_TYPE_OPTIONS}
+              selected={draftFilterTypes}
+              onToggle={toggleDraftFilterType}
+            />
+            <p className="mt-3 mb-1.5 text-xs font-semibold tracking-wide text-[#667085] uppercase">
+              Focus Area
+            </p>
+            <FilterCheckboxGroup
+              options={FILTER_FOCUS_AREA_OPTIONS}
               selected={draftFilterTypes}
               onToggle={toggleDraftFilterType}
             />

--- a/frontend/components/admin/reports/reports-page-client.tsx
+++ b/frontend/components/admin/reports/reports-page-client.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState, useTransition } from "react";
 import type { Report } from "./reports";
 import { useAdminTableFilters } from "@/hooks/use-admin-table-filters";
 import { cn } from "@/lib/utils";
-import { Badge } from "@/components/ui/badge";
 import { SearchBar } from "@/components/admin/search-bar";
 import { SortButton } from "@/components/admin/sort-button";
 import {
@@ -42,19 +41,22 @@ const SORT_GROUPS = [
   },
 ] as const;
 
-const DESC_CHAR_LIMIT = 80;
+const DESC_CHAR_LIMIT = 50;
+const PATH_CHAR_LIMIT = 40;
 
 const REPORT_COLUMNS: AdminColumnDef[] = [
   { label: "Name", width: "w-[20%]" },
-  { label: "Description", width: "w-[40%]" },
-  { label: "Path", width: "w-[18%]" },
-  { label: "Actions", width: "w-[22%]" },
+  { label: "Description", width: "w-[37%]" },
+  { label: "Path", width: "w-[28%]" },
+  { label: "Actions", width: "w-[15%]" },
 ];
 
 // ——— Report Row ———
 function ReportRow({ report }: { report: Report }) {
   const [isPending, startTransition] = useTransition();
   const [expanded, setExpanded] = useState(false);
+  const [pathExpanded, setPathExpanded] = useState(false);
+  const isPathLong = report.path && report.path.length > PATH_CHAR_LIMIT;
 
   const strippedDescription = useMemo(
     () =>
@@ -95,14 +97,14 @@ function ReportRow({ report }: { report: Report }) {
       )}
     >
       {/* Name */}
-      <td className="h-[80px] py-3 pr-6 pl-[30px]">
+      <td className="h-[56px] py-3 pr-6 pl-[30px]">
         <p className="truncate text-[16px] font-medium text-[#101828] dark:text-white">
           {report.fullName}
         </p>
       </td>
 
       {/* Description */}
-      <td className="h-[80px] px-6 py-[11px]">
+      <td className="h-[56px] px-6 py-[11px]">
         <p className="text-[16px] leading-[20px] font-medium text-[#101828] dark:text-white">
           {displayDescription}
           {isTruncated && !expanded && (
@@ -125,17 +127,34 @@ function ReportRow({ report }: { report: Report }) {
       </td>
 
       {/* Path */}
-      <td className="h-[80px] px-6 py-[11px]">
-        <Badge
-          variant="outline"
-          className="max-w-full truncate rounded-[16px] border-0 bg-[#f2f4f7] px-[9px] py-[4px] text-[14px] leading-[18px] font-medium text-[#60646c] dark:bg-slate-700 dark:text-slate-300"
-        >
-          {report.path}
-        </Badge>
+      <td className="h-[56px] px-6 py-[11px]">
+        {pathExpanded ? (
+          <p className="text-[16px] font-medium break-all text-[#101828] dark:text-white">
+            {report.path}{" "}
+            <button
+              onClick={() => setPathExpanded(false)}
+              className="text-[#2D7597] hover:underline"
+            >
+              See Less
+            </button>
+          </p>
+        ) : (
+          <div className="flex min-w-0 items-center gap-1 text-[16px] font-medium text-[#101828] dark:text-white">
+            <span className="min-w-0 truncate">{report.path}</span>
+            {isPathLong && (
+              <button
+                onClick={() => setPathExpanded(true)}
+                className="shrink-0 text-[#2D7597] hover:underline"
+              >
+                See More
+              </button>
+            )}
+          </div>
+        )}
       </td>
 
       {/* Actions */}
-      <td className="h-[80px] px-6 py-3">
+      <td className="h-[56px] px-6 py-3">
         <TooltipProvider delayDuration={300}>
           <div className="flex items-center gap-[10px]">
             <Tooltip>

--- a/frontend/components/admin/requests/requests-page-client.tsx
+++ b/frontend/components/admin/requests/requests-page-client.tsx
@@ -668,7 +668,7 @@ export function RequestsPageClient({
             }}
             onClick={() => setActiveTab(tab.key)}
             className={cn(
-              "relative z-10 mx-1 h-[37px] rounded-[35px] px-5 text-[16px] font-semibold transition-colors duration-200",
+              "relative z-10 mx-1 h-[37px] rounded-[35px] px-5 text-[16px] font-normal transition-colors duration-200",
               activeTab === tab.key
                 ? "text-white"
                 : "text-[#202630] hover:text-[#2D7597] dark:text-slate-300",

--- a/frontend/components/admin/sort-radio-group.tsx
+++ b/frontend/components/admin/sort-radio-group.tsx
@@ -20,7 +20,7 @@ export function SortRadioGroup({
     <div className="space-y-3">
       {groups.map((group) => (
         <div key={group.header}>
-          <p className="mb-1.5 text-xs font-semibold tracking-wide text-slate-400 uppercase">
+          <p className="mb-1.5 text-xs font-semibold tracking-wide text-[#667085] uppercase">
             {group.header}
           </p>
           <div className="space-y-1.5">

--- a/frontend/components/admin/users/create-user.tsx
+++ b/frontend/components/admin/users/create-user.tsx
@@ -176,9 +176,17 @@ export function CreateUser() {
 
             {/* Drag & Drop area */}
             <div
+              role="button"
+              tabIndex={0}
               onDrop={handleDrop}
               onDragOver={(e) => e.preventDefault()}
               onClick={() => fileInputRef.current?.click()}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  fileInputRef.current?.click();
+                }
+              }}
               className="mt-3 flex h-[56px] cursor-pointer items-center gap-[10px] rounded-[30px] border border-dashed border-[#efeff0] bg-[#fcfcfd] px-5 transition-colors hover:border-[#2D7597]"
             >
               <IconUpload className="h-5 w-5 text-[#667085]" />

--- a/frontend/components/admin/users/create-user.tsx
+++ b/frontend/components/admin/users/create-user.tsx
@@ -110,14 +110,14 @@ export function CreateUser() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button className="bg-[#2D7597] text-white hover:bg-[#255e78]">
-          <IconPlus className="mr-1 h-5 w-5" />
+        <Button className="gap-1 bg-[#2D7597] text-white hover:bg-[#255e78]">
+          <IconPlus className="h-5 w-5" stroke={2.25} />
           Create User
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-[1260px] overflow-hidden !rounded-[20px] border-0 p-0">
         <DialogTitle className="sr-only">Create User</DialogTitle>
-        <DialogClose className="absolute top-4 right-4 z-10 rounded-full p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300">
+        <DialogClose className="absolute top-7 right-7 z-10 rounded-full p-1.5 text-[#c1c7d0] transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300">
           <IconX className="h-5 w-5" />
         </DialogClose>
         <div className="px-14 py-10">
@@ -143,12 +143,12 @@ export function CreateUser() {
                     handleAddSingleUser();
                   }
                 }}
-                className="h-[44px] flex-1 rounded-[30px] border-2 border-[#efeff0] bg-[#fcfcfd] px-5 text-[16px] text-slate-900 outline-none placeholder:text-[#667085] focus:border-[#2D7597]"
+                className="h-[44px] flex-1 rounded-[30px] border border-[#efeff0] bg-[#fcfcfd] px-5 text-[16px] text-slate-900 outline-none placeholder:text-[#667085] focus:border-[#2D7597]"
               />
               <button
                 onClick={handleAddSingleUser}
                 disabled={singleLoading || !singleEmail.trim()}
-                className="flex h-[44px] w-[121px] items-center justify-center gap-[6px] rounded-[8px] border border-[#2D7597] bg-[#2D7597] text-[16px] font-medium text-white shadow-[0px_1px_2px_0px_rgba(16,24,40,0.05)] transition-colors hover:bg-[#255e78] disabled:opacity-50"
+                className="flex h-[44px] w-[121px] items-center justify-center gap-[6px] rounded-[8px] border border-[#2D7597] bg-[#2D7597] text-[16px] font-medium text-white shadow-[0px_1px_2px_0px_rgba(16,24,40,0.05)] transition-colors hover:bg-[#255e78] disabled:pointer-events-none disabled:opacity-50"
               >
                 <IconPlus className="h-5 w-5" />
                 {singleLoading ? "Adding..." : "Add User"}
@@ -171,7 +171,7 @@ export function CreateUser() {
               onChange={(e) => setBatchEmails(e.target.value)}
               placeholder="Enter email addresses separated by commas or new lines."
               rows={4}
-              className="mt-4 w-full rounded-[30px] border-2 border-[#efeff0] bg-[#fcfcfd] px-5 py-4 text-[16px] text-slate-900 outline-none placeholder:text-[#667085] focus:border-[#2D7597]"
+              className="mt-4 w-full rounded-[30px] border border-[#efeff0] bg-[#fcfcfd] px-5 py-4 text-[16px] text-slate-900 outline-none placeholder:text-[#667085] focus:border-[#2D7597]"
             />
 
             {/* Drag & Drop area */}
@@ -179,7 +179,7 @@ export function CreateUser() {
               onDrop={handleDrop}
               onDragOver={(e) => e.preventDefault()}
               onClick={() => fileInputRef.current?.click()}
-              className="mt-3 flex h-[56px] cursor-pointer items-center gap-[10px] rounded-[30px] border-[3px] border-dashed border-[#efeff0] bg-[#fcfcfd] px-5 transition-colors hover:border-[#2D7597]"
+              className="mt-3 flex h-[56px] cursor-pointer items-center gap-[10px] rounded-[30px] border border-dashed border-[#efeff0] bg-[#fcfcfd] px-5 transition-colors hover:border-[#2D7597]"
             >
               <IconUpload className="h-5 w-5 text-[#667085]" />
               <p className="text-[16px] text-[#667085]">
@@ -203,7 +203,7 @@ export function CreateUser() {
               <button
                 onClick={handleAddBatchUsers}
                 disabled={batchLoading || !batchEmails.trim()}
-                className="flex h-[44px] w-[127px] items-center justify-center gap-[6px] rounded-[8px] border border-[#2D7597] bg-[#2D7597] text-[16px] font-medium text-white shadow-[0px_1px_2px_0px_rgba(16,24,40,0.05)] transition-colors hover:bg-[#255e78] disabled:opacity-50"
+                className="flex h-[44px] w-[127px] items-center justify-center gap-[6px] rounded-[8px] border border-[#2D7597] bg-[#2D7597] text-[16px] font-medium text-white shadow-[0px_1px_2px_0px_rgba(16,24,40,0.05)] transition-colors hover:bg-[#255e78] disabled:pointer-events-none disabled:opacity-50"
               >
                 <IconPlus className="h-5 w-5" />
                 {batchLoading ? "Adding..." : "Add Users"}

--- a/frontend/components/draft/add-lesson.tsx
+++ b/frontend/components/draft/add-lesson.tsx
@@ -2,7 +2,12 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useFormStatus } from "react-dom";
-import { PlusIcon, CornerDownLeftIcon, LoaderIcon, Import } from "lucide-react";
+import {
+  PlusIcon,
+  CornerDownLeftIcon,
+  LoaderIcon,
+  FileInput,
+} from "lucide-react";
 import { Droplet, Lesson } from "@/types";
 import { useRouter } from "next/navigation";
 import { addLesson } from "@/lib/requests/lesson";
@@ -153,7 +158,7 @@ export function AddLesson({
           {" "}
           {/* Changed to flex container */}
           <div className="cursor-pointer p-2">
-            <Import
+            <FileInput
               role="button"
               onClick={handleImportClick}
               className="transition-colors hover:text-slate-600 dark:hover:text-slate-300"

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -202,7 +202,7 @@ export function LessonRenderer({
       if (!el) return;
       const rect = el.getBoundingClientRect();
       if (rect.height === 0) return;
-      const scrolled = window.innerHeight - rect.top;
+      const scrolled = rect.height - (rect.bottom - window.innerHeight);
       const pct = Math.min(100, Math.max(0, (scrolled / rect.height) * 100));
       for (const milestone of MILESTONES) {
         if (pct >= milestone && !firedMilestones.current.has(milestone)) {

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -15,7 +15,7 @@ import { BlocksRenderer } from "@strapi/blocks-react-renderer";
 import { ArrowDownFromLineIcon } from "lucide-react";
 import { QuizBlock } from "./quiz";
 import GenericBlockRenderer from "./generic-block-renderer";
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { LockIcon } from "lucide-react";
 import { CalloutIcon } from "@/components/ui/callout-icons";
@@ -97,6 +97,8 @@ export function LessonRenderer({
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
   const [highlights, setHighlights] = useState<Highlight[]>([]);
+  const lessonContentRef = useRef<HTMLDivElement>(null);
+  const firedMilestones = useRef<Set<number>>(new Set());
 
   // Move all hooks before any early returns
   useEffect(() => {
@@ -185,6 +187,41 @@ export function LessonRenderer({
       }
     }
   }, [authUser?.id]);
+
+  useEffect(() => {
+    firedMilestones.current = new Set();
+  }, [lesson.id]);
+
+  useEffect(() => {
+    if (!enrollmentId) return;
+
+    const MILESTONES = [25, 50, 75, 100];
+
+    function handleScroll() {
+      const el = lessonContentRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      if (rect.height === 0) return;
+      const scrolled = window.innerHeight - rect.top;
+      const pct = Math.min(100, Math.max(0, (scrolled / rect.height) * 100));
+      for (const milestone of MILESTONES) {
+        if (pct >= milestone && !firedMilestones.current.has(milestone)) {
+          firedMilestones.current.add(milestone);
+          posthog.capture("lesson_scroll_depth", {
+            percent: milestone,
+            lesson_id: lesson.id,
+            lesson_name: lesson.name,
+            droplet_id: droplet.id,
+            user_id: authUser?.id,
+          });
+        }
+      }
+    }
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [lesson.id, droplet.id, enrollmentId, authUser?.id]);
 
   if (isNotEnrolled) {
     return (
@@ -335,7 +372,10 @@ export function LessonRenderer({
   }
 
   return (
-    <div className="mx-auto w-full min-w-[300px] py-8 md:min-w-[700px]">
+    <div
+      ref={lessonContentRef}
+      className="mx-auto w-full min-w-[300px] py-8 md:min-w-[700px]"
+    >
       <div className="relative mx-auto w-full max-w-2xl xl:py-8">
         <h1 className="text-6xl font-extrabold text-balance">{lesson.name}</h1>
 

--- a/frontend/components/new/multi-select.tsx
+++ b/frontend/components/new/multi-select.tsx
@@ -58,13 +58,15 @@ export function MultiSelect({
     try {
       if (tagName) {
         const result = await createNewTag(tagName);
-        if (result.success) {
+        if (result.success && result.data) {
+          setSelected([...selected, result.data]);
           toast.success("Tag created successfully");
         } else {
           console.error("Failed to create tag", result.error);
           toast.error(`"${tagName} tag already exists"`);
         }
         setIsOpen(false);
+        setTagName("");
       }
     } catch (error) {
       console.error("Failed to create new tag: ", error);

--- a/frontend/lib/chart-utils.ts
+++ b/frontend/lib/chart-utils.ts
@@ -10,9 +10,9 @@ export interface TimeframeOption {
 
 /** Standard timeframe options used across admin charts */
 export const CHART_TIMEFRAMES: TimeframeOption[] = [
-  { label: "7 days", value: 7 },
-  { label: "30 days", value: 30 },
-  { label: "90 days", value: 90 },
+  { label: "7d", value: 7 },
+  { label: "30d", value: 30 },
+  { label: "90d", value: 90 },
 ];
 
 /** Compact timeframe options for smaller chart cards */

--- a/frontend/lib/requests/authorized-user.ts
+++ b/frontend/lib/requests/authorized-user.ts
@@ -37,7 +37,7 @@ export async function getAuthorizedUserByEmail<
     sort,
     filters: {
       ...filters,
-      email: { $eq: email },
+      email: { $eqi: email },
     },
     populate,
     fields,

--- a/frontend/lib/requests/data.ts
+++ b/frontend/lib/requests/data.ts
@@ -16,7 +16,7 @@ export async function fetchDroplets() {
     while (true) {
       const query = qs.stringify({
         sort: ["id"],
-        fields: ["id", "name", "type", "slug", "isHidden"],
+        fields: ["id", "name", "type", "slug", "isHidden", "focusArea"],
         populate: {
           lessons: { fields: ["id", "name"] },
           tags: { fields: ["id", "name"] },

--- a/frontend/lib/requests/droplet-analytics.ts
+++ b/frontend/lib/requests/droplet-analytics.ts
@@ -207,13 +207,14 @@ export async function getDropletAnalytics(
   const scrollDepth: LessonScrollDepth[] = lessons.map((lesson) => {
     const phData = posthogScrollDepth.get(lesson.id);
     if (phData && phData.size > 0) {
+      const ph25 = phData.get(25) ?? 0;
       return {
         lessonId: lesson.id,
         lessonName: lesson.name,
         estimated: false,
         points: [
-          { label: "Started", count: totalEnrolled },
-          { label: "25%", count: phData.get(25) ?? 0 },
+          { label: "Started", count: Math.max(totalEnrolled, ph25) },
+          { label: "25%", count: ph25 },
           { label: "50%", count: phData.get(50) ?? 0 },
           { label: "75%", count: phData.get(75) ?? 0 },
           { label: "100%", count: phData.get(100) ?? 0 },

--- a/frontend/lib/requests/droplet-analytics.ts
+++ b/frontend/lib/requests/droplet-analytics.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { fetchEnrollmentMetadata } from "./enrollment";
+import { fetchLessonScrollDepth } from "./posthog";
 
 export interface ScrollDepthPoint {
   label: string;
@@ -11,6 +12,7 @@ export interface LessonScrollDepth {
   lessonId: number;
   lessonName: string;
   points: ScrollDepthPoint[];
+  estimated: boolean;
 }
 
 export interface DropletAnalyticsData {
@@ -185,19 +187,40 @@ export async function getDropletAnalytics(
       : Math.round((lastMonthRatingSum / lastMonthRatingCount) * 10) / 10;
   }
 
-  const [averageRating, lastMonthAverageRating] = await Promise.all([
-    fetchAllEnrollments(),
-    fetchLastMonthRating(),
-  ]);
+  const [averageRating, lastMonthAverageRating, posthogScrollDepth] =
+    await Promise.all([
+      fetchAllEnrollments(),
+      fetchLastMonthRating(),
+      fetchLessonScrollDepth(
+        dropletId,
+        lessons.map((l) => l.id),
+      ),
+    ]);
 
   const lessonCompletion = lessons.map((lesson) => ({
     name: lesson.name,
     count: lessonViewCounts.get(lesson.id) ?? 0,
   }));
 
-  // Scroll depth: approximate per-lesson drop-off curve.
-  // Started = totalEnrolled, 25% = lesson view count, 100% = droplet completions.
+  // Scroll depth: use PostHog event counts when available, otherwise fall back
+  // to the approximate drop-off curve derived from Strapi enrollment data.
   const scrollDepth: LessonScrollDepth[] = lessons.map((lesson) => {
+    const phData = posthogScrollDepth.get(lesson.id);
+    if (phData && phData.size > 0) {
+      return {
+        lessonId: lesson.id,
+        lessonName: lesson.name,
+        estimated: false,
+        points: [
+          { label: "Started", count: totalEnrolled },
+          { label: "25%", count: phData.get(25) ?? 0 },
+          { label: "50%", count: phData.get(50) ?? 0 },
+          { label: "75%", count: phData.get(75) ?? 0 },
+          { label: "100%", count: phData.get(100) ?? 0 },
+        ],
+      };
+    }
+    // Fallback: interpolate from Strapi view/completion counts
     const viewed = lessonViewCounts.get(lesson.id) ?? 0;
     const p25 = viewed;
     const p100 = completedCount;
@@ -206,6 +229,7 @@ export async function getDropletAnalytics(
     return {
       lessonId: lesson.id,
       lessonName: lesson.name,
+      estimated: true,
       points: [
         { label: "Started", count: totalEnrolled },
         { label: "25%", count: p25 },

--- a/frontend/lib/requests/posthog.ts
+++ b/frontend/lib/requests/posthog.ts
@@ -283,7 +283,7 @@ export async function fetchLessonScrollDepth(
        FROM events
        WHERE event = 'lesson_scroll_depth'
          AND JSONExtractInt(properties, 'droplet_id') = ${dropletId}
-         AND lesson_id IN (${lessonIds.join(", ")})
+         AND JSONExtractInt(properties, 'lesson_id') IN (${lessonIds.join(", ")})
        GROUP BY lesson_id, pct`,
     );
     if (!rows) return new Map();
@@ -294,8 +294,11 @@ export async function fetchLessonScrollDepth(
       result.get(lessonId)!.set(pct, users);
     }
     return result;
-  } catch (e: any) {
-    console.error("PostHog Fetch Error (scroll depth):", e.message);
+  } catch (e: unknown) {
+    console.error(
+      "PostHog Fetch Error (scroll depth):",
+      e instanceof Error ? e.message : e,
+    );
     return new Map();
   }
 }

--- a/frontend/lib/requests/posthog.ts
+++ b/frontend/lib/requests/posthog.ts
@@ -269,6 +269,37 @@ export async function fetchWeeklyNewUsers(): Promise<
   }
 }
 
+export async function fetchLessonScrollDepth(
+  dropletId: number,
+  lessonIds: number[],
+): Promise<Map<number, Map<number, number>>> {
+  if (lessonIds.length === 0) return new Map();
+  try {
+    const rows = await runHogQLQuery(
+      `SELECT
+         JSONExtractInt(properties, 'lesson_id') AS lesson_id,
+         JSONExtractInt(properties, 'percent') AS pct,
+         count(DISTINCT distinct_id) AS users
+       FROM events
+       WHERE event = 'lesson_scroll_depth'
+         AND JSONExtractInt(properties, 'droplet_id') = ${dropletId}
+         AND lesson_id IN (${lessonIds.join(", ")})
+       GROUP BY lesson_id, pct`,
+    );
+    if (!rows) return new Map();
+
+    const result = new Map<number, Map<number, number>>();
+    for (const [lessonId, pct, users] of rows as [number, number, number][]) {
+      if (!result.has(lessonId)) result.set(lessonId, new Map());
+      result.get(lessonId)!.set(pct, users);
+    }
+    return result;
+  } catch (e: any) {
+    console.error("PostHog Fetch Error (scroll depth):", e.message);
+    return new Map();
+  }
+}
+
 export async function fetchAvgSessionDuration(): Promise<
   { date: string; duration: number }[]
 > {

--- a/frontend/testing/requests/authorized-users.test.ts
+++ b/frontend/testing/requests/authorized-users.test.ts
@@ -75,7 +75,7 @@ describe("Authorized User Tests", () => {
         urlParams: expect.objectContaining({
           filters: expect.objectContaining({
             email: {
-              $eq: testEmail,
+              $eqi: testEmail,
             },
           }),
         }),
@@ -126,7 +126,7 @@ describe("Authorized User Tests", () => {
       expect(fetchAPI).toHaveBeenCalledWith("/authorized-users", {
         urlParams: expect.objectContaining({
           filters: expect.objectContaining({
-            email: { $eq: testEmail },
+            email: { $eqi: testEmail },
             isEnabled: true,
           }),
         }),


### PR DESCRIPTION
Description:                                                                                                                                                                                                                                         
Polish pass on the admin re-design with several functional improvements across the admin dashboard, droplets table, reports table, and the lesson scroll-depth analytics pipeline.                                                                                                    
   
Admin charts:                                                                                                                              
  - Added trend indicators (trending up/down with % change) to the Active Users and Unique Pageview charts
  - Replaced generic ChartTooltipContent with custom styled tooltips on the Avg Session Duration and Unique Pageview charts                  
  - Added a rounded top/right cursor shape on bar chart hover                                                              
                                                                                                                                             
Droplets table:                                                                                                                            
  - Extracted Type and Focus Area into their own dedicated columns (previously both were inline tag badges inside the Tags column)           
  - Added Focus Area filter section to the filter panel                                                                                      
  - Added personal tag color to the color map
                                                                                                                                             
Reports table:  
  - Reduced row height from 80px to 56px for a tighter layout                                                                                
  - Replaced the truncated path Badge with an inline expandable "See More / See Less" control                                                
  - Adjusted column widths and char limits for better space usage                            
                                                                                                                                             
Droplet Analytics modal:                                                                                                                   
  - Scroll depth tab selector is now horizontally scrollable for droplets with many lessons
  - Added an "Estimated, real tracking in progress" badge when scroll depth data is approximated from Strapi rather than real PostHog events
                                                                                                                                             
Lesson scroll-depth tracking (real data):                                                                                                  
  - Added a useEffect scroll listener in LessonRenderer that fires lesson_scroll_depth PostHog events at 25 / 50 / 75 / 100% milestones      
  - Added fetchLessonScrollDepth HogQL query in posthog.ts                                                                                   
  - getDropletAnalytics now fetches real PostHog scroll data in parallel and falls back to the Strapi-derived estimate; LessonScrollDepth    
  gains an estimated boolean flag                                                                                                            
                                                                                                                                             
Multi-select fix:                                                                                                                          
  - After creating a new tag, it is now immediately added to the selected list and the input field is cleared                                
                                                                                                                                             
Motivation and Context:                                                                                                                                   
These are final tweaks for the admin dashboard re-design (ODY-376). The scroll-depth tracking closes the loop on the PostHog analytics integration, the modal previously showed estimated data; it now shows real per-user scroll milestone data where available and labels estimated data explicitly. The table layout changes improve scannability and reduce visual clutter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trend indicators/footers on analytics charts, improved cursors/tooltips, and shortened timeframe labels (7d/30d/90d)
  * Focus Area column and filters for droplets; reports table supports expandable path previews
  * PostHog-backed scroll-depth analytics with estimated fallback and UI instrumentation
  * Presentation-mode design and implementation plan added (docs)

* **Bug Fixes**
  * Draft/playlist auth now handles missing user and returns 404
  * Tag creation clears input only on success
  * Email matching made case-insensitive

* **Style**
  * Refined admin spacing, typography, form and modal styles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->