### PR TITLE
Sandbox Code Editor

### DIFF
--- a/frontend/components/draft/lesson/blocknote-editor-client.tsx
+++ b/frontend/components/draft/lesson/blocknote-editor-client.tsx
@@ -21,6 +21,7 @@ import {
   getLatexSlashMenuItems,
   getCodeSlashMenuItems,
   getSlideBreakSlashMenuItems,
+  getSandpackSlashMenuItems,
 } from "@/components/ui/blocknote/editor/slash-menu-config";
 import "@/components/ui/blocknote/editor/custom-blocknote.css";
 import type { Block } from "@blocknote/core";
@@ -256,6 +257,7 @@ export function BlockNoteEditorClient({
             const latexItems = getLatexSlashMenuItems(editor);
             const codeItems = getCodeSlashMenuItems(editor);
             const slideBreakItems = getSlideBreakSlashMenuItems(editor);
+            const sandpackItems = getSandpackSlashMenuItems(editor);
 
             const allItems = [
               ...defaultItems,
@@ -263,6 +265,7 @@ export function BlockNoteEditorClient({
               ...quizItems,
               ...latexItems,
               ...codeItems,
+              ...sandpackItems,
               ...slideBreakItems,
             ];
 

--- a/frontend/components/draft/lesson/sandpack-viewer.tsx
+++ b/frontend/components/draft/lesson/sandpack-viewer.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import dynamic from "next/dynamic";
 import { useTheme } from "next-themes";
 import { PanelLeft, Maximize2, Minimize2 } from "lucide-react";
+import {
+  SandpackProvider,
+  SandpackLayout,
+  SandpackCodeEditor,
+  SandpackPreview,
+  SandpackFileExplorer,
+} from "@codesandbox/sandpack-react";
 import {
   SandpackTemplate,
   TEMPLATE_LABELS,
@@ -14,37 +20,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-
-const SandpackProvider = dynamic(
-  () =>
-    import("@codesandbox/sandpack-react").then((mod) => mod.SandpackProvider),
-  { ssr: false },
-);
-
-const SandpackLayout = dynamic(
-  () => import("@codesandbox/sandpack-react").then((mod) => mod.SandpackLayout),
-  { ssr: false },
-);
-
-const SandpackCodeEditor = dynamic(
-  () =>
-    import("@codesandbox/sandpack-react").then((mod) => mod.SandpackCodeEditor),
-  { ssr: false },
-);
-
-const SandpackPreview = dynamic(
-  () =>
-    import("@codesandbox/sandpack-react").then((mod) => mod.SandpackPreview),
-  { ssr: false },
-);
-
-const SandpackFileExplorer = dynamic(
-  () =>
-    import("@codesandbox/sandpack-react").then(
-      (mod) => mod.SandpackFileExplorer,
-    ),
-  { ssr: false },
-);
 
 interface SandpackViewerProps {
   template: SandpackTemplate;
@@ -78,45 +53,44 @@ export function SandpackViewer({
     return () => window.removeEventListener("keydown", onKey);
   }, [isFullscreen]);
 
-  const sandpackPanel = (fullscreen: boolean) => {
-    const panelHeight =
-      fullscreen || presentationMode ? "calc(100vh - 37px)" : "560px";
-    return (
-      <SandpackProvider
-        template={template}
-        files={sandpackFiles}
-        theme={sandpackTheme}
-        options={{ recompileMode: "delayed", recompileDelay: 500 }}
-      >
-        <SandpackLayout>
-          {showFileExplorer && (
-            <SandpackFileExplorer
-              style={{
-                height: panelHeight,
-                minWidth: "160px",
-                maxWidth: "200px",
-              }}
-            />
-          )}
-          <SandpackCodeEditor
-            readOnly={!editable}
-            showLineNumbers
-            showTabs={false}
-            showInlineErrors
-            style={{ height: panelHeight, flex: 1 }}
-          />
-          {showPreview && (
-            <SandpackPreview
-              style={{ height: panelHeight, flex: 1 }}
-              showNavigator
-            />
-          )}
-        </SandpackLayout>
-      </SandpackProvider>
-    );
-  };
+  const panelHeight =
+    isFullscreen || presentationMode ? "calc(100vh - 37px)" : "560px";
 
-  const titleBar = (fullscreen: boolean) => (
+  const sandpackPanel = (
+    <SandpackProvider
+      template={template}
+      files={sandpackFiles}
+      theme={sandpackTheme}
+      options={{ recompileMode: "delayed", recompileDelay: 500 }}
+    >
+      <SandpackLayout>
+        {showFileExplorer && (
+          <SandpackFileExplorer
+            style={{
+              height: panelHeight,
+              minWidth: "160px",
+              maxWidth: "200px",
+            }}
+          />
+        )}
+        <SandpackCodeEditor
+          readOnly={!editable}
+          showLineNumbers
+          showTabs={false}
+          showInlineErrors
+          style={{ height: panelHeight, flex: 1 }}
+        />
+        {showPreview && (
+          <SandpackPreview
+            style={{ height: panelHeight, flex: 1 }}
+            showNavigator
+          />
+        )}
+      </SandpackLayout>
+    </SandpackProvider>
+  );
+
+  const titleBar = (
     <TooltipProvider delayDuration={400}>
       <div className="flex items-center justify-between border-b border-[#333] bg-[#2d2d2d] px-3 py-2">
         <div className="flex items-center gap-3">
@@ -141,19 +115,25 @@ export function SandpackViewer({
             {TEMPLATE_LABELS[template]}
           </span>
         </div>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => setIsFullscreen((v) => !v)}
-              className="rounded p-1.5 text-gray-300 transition-colors hover:bg-[#3e3e3e] hover:text-white"
-            >
-              {fullscreen ? <Minimize2 size={13} /> : <Maximize2 size={13} />}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>
-            {fullscreen ? "Exit fullscreen (Esc)" : "Enter fullscreen"}
-          </TooltipContent>
-        </Tooltip>
+        {!presentationMode && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setIsFullscreen((v) => !v)}
+                className="rounded p-1.5 text-gray-300 transition-colors hover:bg-[#3e3e3e] hover:text-white"
+              >
+                {isFullscreen ? (
+                  <Minimize2 size={13} />
+                ) : (
+                  <Maximize2 size={13} />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {isFullscreen ? "Exit fullscreen (Esc)" : "Enter fullscreen"}
+            </TooltipContent>
+          </Tooltip>
+        )}
       </div>
     </TooltipProvider>
   );
@@ -161,8 +141,8 @@ export function SandpackViewer({
   if (presentationMode) {
     return (
       <div className="fixed inset-0 z-[101] flex flex-col overflow-hidden bg-[#1e1e1e]">
-        {titleBar(false)}
-        {sandpackPanel(false)}
+        {titleBar}
+        {sandpackPanel}
       </div>
     );
   }
@@ -170,14 +150,14 @@ export function SandpackViewer({
   return (
     <>
       <div className="my-4 w-full overflow-hidden rounded-lg border border-[#333] bg-[#1e1e1e]">
-        {titleBar(false)}
-        {sandpackPanel(false)}
+        {titleBar}
+        {!isFullscreen && sandpackPanel}
       </div>
 
       {isFullscreen && (
         <div className="fixed inset-0 z-50 flex flex-col bg-[#1e1e1e]">
-          {titleBar(true)}
-          {sandpackPanel(true)}
+          {titleBar}
+          {sandpackPanel}
         </div>
       )}
     </>

--- a/frontend/components/draft/lesson/sandpack-viewer.tsx
+++ b/frontend/components/draft/lesson/sandpack-viewer.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import dynamic from "next/dynamic";
+import { useTheme } from "next-themes";
+import { PanelLeft, Maximize2, Minimize2 } from "lucide-react";
+import {
+  SandpackTemplate,
+  TEMPLATE_LABELS,
+} from "@/components/ui/blocknote/blocks/sandpack-block-content";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const SandpackProvider = dynamic(
+  () =>
+    import("@codesandbox/sandpack-react").then((mod) => mod.SandpackProvider),
+  { ssr: false },
+);
+
+const SandpackLayout = dynamic(
+  () => import("@codesandbox/sandpack-react").then((mod) => mod.SandpackLayout),
+  { ssr: false },
+);
+
+const SandpackCodeEditor = dynamic(
+  () =>
+    import("@codesandbox/sandpack-react").then((mod) => mod.SandpackCodeEditor),
+  { ssr: false },
+);
+
+const SandpackPreview = dynamic(
+  () =>
+    import("@codesandbox/sandpack-react").then((mod) => mod.SandpackPreview),
+  { ssr: false },
+);
+
+const SandpackFileExplorer = dynamic(
+  () =>
+    import("@codesandbox/sandpack-react").then(
+      (mod) => mod.SandpackFileExplorer,
+    ),
+  { ssr: false },
+);
+
+interface SandpackViewerProps {
+  template: SandpackTemplate;
+  files: Record<string, string>;
+  showPreview: boolean;
+  editable: boolean;
+  presentationMode?: boolean;
+}
+
+export function SandpackViewer({
+  template,
+  files,
+  showPreview,
+  editable,
+  presentationMode = false,
+}: SandpackViewerProps) {
+  const { resolvedTheme } = useTheme();
+  const [showFileExplorer, setShowFileExplorer] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const sandpackTheme = resolvedTheme === "dark" ? "dark" : "light";
+
+  const hasCustomFiles = Object.keys(files).length > 0;
+  const sandpackFiles = hasCustomFiles ? files : undefined;
+
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsFullscreen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isFullscreen]);
+
+  const sandpackPanel = (fullscreen: boolean) => {
+    const panelHeight =
+      fullscreen || presentationMode ? "calc(100vh - 37px)" : "560px";
+    return (
+      <SandpackProvider
+        template={template}
+        files={sandpackFiles}
+        theme={sandpackTheme}
+        options={{ recompileMode: "delayed", recompileDelay: 500 }}
+      >
+        <SandpackLayout>
+          {showFileExplorer && (
+            <SandpackFileExplorer
+              style={{
+                height: panelHeight,
+                minWidth: "160px",
+                maxWidth: "200px",
+              }}
+            />
+          )}
+          <SandpackCodeEditor
+            readOnly={!editable}
+            showLineNumbers
+            showTabs={false}
+            showInlineErrors
+            style={{ height: panelHeight, flex: 1 }}
+          />
+          {showPreview && (
+            <SandpackPreview
+              style={{ height: panelHeight, flex: 1 }}
+              showNavigator
+            />
+          )}
+        </SandpackLayout>
+      </SandpackProvider>
+    );
+  };
+
+  const titleBar = (fullscreen: boolean) => (
+    <TooltipProvider delayDuration={400}>
+      <div className="flex items-center justify-between border-b border-[#333] bg-[#2d2d2d] px-3 py-2">
+        <div className="flex items-center gap-3">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setShowFileExplorer((v) => !v)}
+                className={`rounded p-1 transition-colors ${
+                  showFileExplorer
+                    ? "bg-[#3e3e3e] text-gray-200"
+                    : "text-gray-500 hover:text-gray-300"
+                }`}
+              >
+                <PanelLeft size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {showFileExplorer ? "Hide file explorer" : "Show file explorer"}
+            </TooltipContent>
+          </Tooltip>
+          <span className="text-xs text-gray-400">
+            {TEMPLATE_LABELS[template]}
+          </span>
+        </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setIsFullscreen((v) => !v)}
+              className="rounded p-1.5 text-gray-300 transition-colors hover:bg-[#3e3e3e] hover:text-white"
+            >
+              {fullscreen ? <Minimize2 size={13} /> : <Maximize2 size={13} />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {fullscreen ? "Exit fullscreen (Esc)" : "Enter fullscreen"}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  );
+
+  if (presentationMode) {
+    return (
+      <div className="fixed inset-0 z-[101] flex flex-col overflow-hidden bg-[#1e1e1e]">
+        {titleBar(false)}
+        {sandpackPanel(false)}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="my-4 w-full overflow-hidden rounded-lg border border-[#333] bg-[#1e1e1e]">
+        {titleBar(false)}
+        {sandpackPanel(false)}
+      </div>
+
+      {isFullscreen && (
+        <div className="fixed inset-0 z-50 flex flex-col bg-[#1e1e1e]">
+          {titleBar(true)}
+          {sandpackPanel(true)}
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -5,7 +5,11 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { extractHeadings, isAuthorizedUserAdmin } from "@/lib/utils";
+import {
+  extractHeadings,
+  isAuthorizedUserAdmin,
+  parseSandpackFiles,
+} from "@/lib/utils";
 import { User, Droplet, Lesson, AuthorizedUser } from "@/types";
 import { BlocksRenderer } from "@strapi/blocks-react-renderer";
 import { ArrowDownFromLineIcon } from "lucide-react";
@@ -516,24 +520,15 @@ function LessonBlockRenderer({
         />
       );
 
-    case "droplets.sandpack-block": {
-      let sandpackFiles: Record<string, string> = {};
-      try {
-        const parsed = JSON.parse(block.files || "{}");
-        if (typeof parsed === "object" && parsed !== null)
-          sandpackFiles = parsed;
-      } catch {
-        // malformed JSON — use empty files, sandpack falls back to template defaults
-      }
+    case "droplets.sandpack-block":
       return (
         <SandpackViewer
           template={block.template}
-          files={sandpackFiles}
+          files={parseSandpackFiles(block.files)}
           showPreview={block.showPreview}
           editable={block.editable}
         />
       );
-    }
 
     default:
       return null;

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -32,6 +32,20 @@ import { markLessonAsComplete } from "@/lib/requests/lesson";
 import posthog from "posthog-js";
 import "katex/dist/katex.min.css";
 import { CodeBlockViewer } from "@/components/draft/lesson/code-block-viewer";
+import dynamic from "next/dynamic";
+
+const SandpackViewer = dynamic(
+  () =>
+    import("@/components/draft/lesson/sandpack-viewer").then(
+      (mod) => mod.SandpackViewer,
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="my-4 h-64 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-800" />
+    ),
+  },
+);
 import { convertBlockNoteToV1Blocks } from "@/lib/blocknote/convert-blocks";
 
 interface LessonRendererProps {
@@ -501,6 +515,25 @@ function LessonBlockRenderer({
           runnable={block.runnable}
         />
       );
+
+    case "droplets.sandpack-block": {
+      let sandpackFiles: Record<string, string> = {};
+      try {
+        const parsed = JSON.parse(block.files || "{}");
+        if (typeof parsed === "object" && parsed !== null)
+          sandpackFiles = parsed;
+      } catch {
+        // malformed JSON — use empty files, sandpack falls back to template defaults
+      }
+      return (
+        <SandpackViewer
+          template={block.template}
+          files={sandpackFiles}
+          showPreview={block.showPreview}
+          editable={block.editable}
+        />
+      );
+    }
 
     default:
       return null;

--- a/frontend/components/presentation/presentation-block-renderer.tsx
+++ b/frontend/components/presentation/presentation-block-renderer.tsx
@@ -18,6 +18,7 @@ import DOMPurify from "isomorphic-dompurify";
 import katex from "katex";
 import "katex/dist/katex.min.css";
 import dynamic from "next/dynamic";
+import { parseSandpackFiles } from "@/lib/utils";
 
 const SandpackViewer = dynamic(
   () =>
@@ -191,25 +192,16 @@ export function PresentationBlockRenderer({
         </div>
       );
 
-    case "droplets.sandpack-block": {
-      let sandpackFiles: Record<string, string> = {};
-      try {
-        const parsed = JSON.parse(block.files || "{}");
-        if (typeof parsed === "object" && parsed !== null)
-          sandpackFiles = parsed;
-      } catch {
-        // malformed JSON — fall back to template defaults
-      }
+    case "droplets.sandpack-block":
       return (
         <SandpackViewer
           template={block.template as "vanilla" | "react" | "react-ts"}
-          files={sandpackFiles}
+          files={parseSandpackFiles(block.files)}
           showPreview={block.showPreview}
           editable={block.editable}
           presentationMode
         />
       );
-    }
 
     default:
       return null;

--- a/frontend/components/presentation/presentation-block-renderer.tsx
+++ b/frontend/components/presentation/presentation-block-renderer.tsx
@@ -17,6 +17,15 @@ import { TableRenderer } from "@/components/droplets/lessons/table-renderer";
 import DOMPurify from "isomorphic-dompurify";
 import katex from "katex";
 import "katex/dist/katex.min.css";
+import dynamic from "next/dynamic";
+
+const SandpackViewer = dynamic(
+  () =>
+    import("@/components/draft/lesson/sandpack-viewer").then(
+      (mod) => mod.SandpackViewer,
+    ),
+  { ssr: false },
+);
 
 interface PresentationBlockRendererProps {
   block: Block;
@@ -181,6 +190,26 @@ export function PresentationBlockRenderer({
           />
         </div>
       );
+
+    case "droplets.sandpack-block": {
+      let sandpackFiles: Record<string, string> = {};
+      try {
+        const parsed = JSON.parse(block.files || "{}");
+        if (typeof parsed === "object" && parsed !== null)
+          sandpackFiles = parsed;
+      } catch {
+        // malformed JSON — fall back to template defaults
+      }
+      return (
+        <SandpackViewer
+          template={block.template as "vanilla" | "react" | "react-ts"}
+          files={sandpackFiles}
+          showPreview={block.showPreview}
+          editable={block.editable}
+          presentationMode
+        />
+      );
+    }
 
     default:
       return null;

--- a/frontend/components/ui/blocknote/blocks/sandpack-block-content.tsx
+++ b/frontend/components/ui/blocknote/blocks/sandpack-block-content.tsx
@@ -149,7 +149,6 @@ function FileChangeListener({ onFilesChange }: FileChangeListenerProps) {
       simplified[filename] = fileObj.code;
     });
     onFilesChange(simplified);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sandpack.files]);
 
   return null;

--- a/frontend/components/ui/blocknote/blocks/sandpack-block-content.tsx
+++ b/frontend/components/ui/blocknote/blocks/sandpack-block-content.tsx
@@ -1,0 +1,521 @@
+"use client";
+
+import {
+  SandpackProvider,
+  SandpackLayout,
+  SandpackCodeEditor,
+  SandpackPreview,
+  SandpackFileExplorer,
+  useSandpack,
+} from "@codesandbox/sandpack-react";
+import { useState, useEffect } from "react";
+import React from "react";
+import {
+  Edit,
+  Lock,
+  Eye,
+  EyeOff,
+  RotateCcw,
+  PanelLeft,
+  Maximize2,
+  Minimize2,
+} from "lucide-react";
+import { useTheme } from "next-themes";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export type SandpackTemplate = "vanilla" | "react" | "react-ts";
+
+export const TEMPLATE_DEFAULTS: Record<
+  SandpackTemplate,
+  Record<string, string>
+> = {
+  vanilla: {
+    "/index.html": `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Live Sandbox</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <h1>Hello, World!</h1>
+    <div id="app"></div>
+    <script src="/index.js"></script>
+  </body>
+</html>`,
+    "/index.js": `const app = document.getElementById('app');
+
+app.innerHTML = '<p>Edit this code and see the changes in real time!</p>';
+
+// Try adding more elements:
+// const btn = document.createElement('button');
+// btn.textContent = 'Click me';
+// btn.addEventListener('click', () => alert('Clicked!'));
+// app.appendChild(btn);
+`,
+    "/styles.css": `body {
+  font-family: sans-serif;
+  margin: 20px;
+  color: #333;
+}
+
+h1 {
+  color: #0070f3;
+}
+
+#app {
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px solid #eaeaea;
+  border-radius: 8px;
+}
+`,
+  },
+  react: {
+    "/App.js": `import { useState } from "react";
+
+export default function App() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div style={{ fontFamily: "sans-serif", padding: "20px" }}>
+      <h1>Hello from React!</h1>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>Increment</button>
+    </div>
+  );
+}
+`,
+    "/index.js": `import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+const root = createRoot(document.getElementById("root"));
+root.render(<App />);
+`,
+  },
+  "react-ts": {
+    "/App.tsx": `import { useState } from "react";
+
+interface CounterProps {
+  initialCount?: number;
+}
+
+export default function App({ initialCount = 0 }: CounterProps) {
+  const [count, setCount] = useState<number>(initialCount);
+
+  return (
+    <div style={{ fontFamily: "sans-serif", padding: "20px" }}>
+      <h1>Hello from React + TypeScript!</h1>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount((c) => c + 1)}>Increment</button>
+    </div>
+  );
+}
+`,
+    "/index.tsx": `import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+const root = createRoot(document.getElementById("root")!);
+root.render(<App />);
+`,
+  },
+};
+
+export const TEMPLATE_LABELS: Record<SandpackTemplate, string> = {
+  vanilla: "Vanilla JS",
+  react: "React",
+  "react-ts": "React + TypeScript",
+};
+
+interface FileChangeListenerProps {
+  onFilesChange: (files: Record<string, string>) => void;
+}
+
+function FileChangeListener({ onFilesChange }: FileChangeListenerProps) {
+  const { sandpack } = useSandpack();
+
+  useEffect(() => {
+    const files = sandpack.files;
+    const simplified: Record<string, string> = {};
+    Object.entries(files).forEach(([filename, fileObj]) => {
+      simplified[filename] = fileObj.code;
+    });
+    onFilesChange(simplified);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sandpack.files]);
+
+  return null;
+}
+
+interface SandpackBlockInnerProps {
+  template: SandpackTemplate;
+  files: Record<string, string>;
+  showPreview: boolean;
+  showFileExplorer: boolean;
+  editable: boolean;
+  isAuthorMode: boolean;
+  resolvedTheme: string | undefined;
+  onFilesChange?: (files: Record<string, string>) => void;
+  fullscreen?: boolean;
+}
+
+function SandpackBlockInner({
+  template,
+  files,
+  showPreview,
+  showFileExplorer,
+  editable,
+  isAuthorMode,
+  resolvedTheme,
+  onFilesChange,
+  fullscreen,
+}: SandpackBlockInnerProps) {
+  const sandpackTheme = resolvedTheme === "dark" ? "dark" : "light";
+  const hasCustomFiles = Object.keys(files).length > 0;
+  const sandpackFiles = hasCustomFiles ? files : undefined;
+  const panelHeight = fullscreen ? "calc(100vh - 37px)" : "560px";
+
+  return (
+    <SandpackProvider
+      template={template}
+      files={sandpackFiles}
+      theme={sandpackTheme}
+      options={{ recompileMode: "delayed", recompileDelay: 500 }}
+    >
+      {isAuthorMode && onFilesChange && (
+        <FileChangeListener onFilesChange={onFilesChange} />
+      )}
+      <SandpackLayout>
+        {showFileExplorer && (
+          <SandpackFileExplorer
+            style={{
+              height: panelHeight,
+              minWidth: "160px",
+              maxWidth: "200px",
+            }}
+          />
+        )}
+        <SandpackCodeEditor
+          readOnly={!editable && !isAuthorMode}
+          showLineNumbers
+          showTabs={false}
+          showInlineErrors
+          style={{ height: panelHeight, flex: 1 }}
+        />
+        {showPreview && (
+          <SandpackPreview
+            style={{ height: panelHeight, flex: 1 }}
+            showNavigator
+          />
+        )}
+      </SandpackLayout>
+    </SandpackProvider>
+  );
+}
+
+export interface SandpackBlockContentProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  block: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  editor: any;
+}
+
+export function SandpackBlockContent({
+  block,
+  editor,
+}: SandpackBlockContentProps) {
+  const { resolvedTheme } = useTheme();
+  const isAuthorMode = editor?.isEditable !== false;
+  const [showFileExplorer, setShowFileExplorer] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsFullscreen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isFullscreen]);
+
+  const currentTemplate = (block.props.template ||
+    "vanilla") as SandpackTemplate;
+  const currentShowPreview =
+    block.props.showPreview !== false && block.props.showPreview !== "false";
+  const currentEditable =
+    block.props.editable !== false && block.props.editable !== "false";
+
+  const parsedFiles = React.useMemo(() => {
+    try {
+      const parsed = JSON.parse(block.props.files || "{}");
+      return typeof parsed === "object" && parsed !== null ? parsed : {};
+    } catch {
+      return {};
+    }
+  }, [block.props.files]);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  const toggleShowPreview = () => {
+    if (!editor) return;
+    try {
+      editor.updateBlock(block, {
+        props: { ...block.props, showPreview: !currentShowPreview },
+      });
+    } catch (error) {
+      console.error("Error toggling preview:", error);
+    }
+  };
+
+  const toggleEditable = () => {
+    if (!editor) return;
+    try {
+      editor.updateBlock(block, {
+        props: { ...block.props, editable: !currentEditable },
+      });
+    } catch (error) {
+      console.error("Error toggling editable:", error);
+    }
+  };
+
+  const changeTemplate = (newTemplate: SandpackTemplate) => {
+    if (!editor) return;
+
+    const hasCustomFiles = Object.keys(parsedFiles).length > 0;
+    const currentDefaults = TEMPLATE_DEFAULTS[currentTemplate];
+    const isDefaultFiles =
+      !hasCustomFiles ||
+      JSON.stringify(parsedFiles) === JSON.stringify(currentDefaults);
+
+    if (!isDefaultFiles) {
+      const confirmed = window.confirm(
+        "Switching templates will reset your code. Continue?",
+      );
+      if (!confirmed) return;
+    }
+
+    try {
+      editor.updateBlock(block, {
+        props: {
+          ...block.props,
+          template: newTemplate,
+          files: JSON.stringify(TEMPLATE_DEFAULTS[newTemplate]),
+        },
+      });
+    } catch (error) {
+      console.error("Error changing template:", error);
+    }
+  };
+
+  const resetToDefaults = () => {
+    if (!editor) return;
+    const confirmed = window.confirm(
+      "Reset code to template defaults? This will discard your changes.",
+    );
+    if (!confirmed) return;
+    try {
+      editor.updateBlock(block, {
+        props: {
+          ...block.props,
+          files: JSON.stringify(TEMPLATE_DEFAULTS[currentTemplate]),
+        },
+      });
+    } catch (error) {
+      console.error("Error resetting to defaults:", error);
+    }
+  };
+
+  const handleFilesChange = (newFiles: Record<string, string>) => {
+    if (!editor) return;
+    const newFilesJson = JSON.stringify(newFiles);
+    if (newFilesJson === block.props.files) return;
+    // Defer to avoid flushSync conflict with BlockNote's editor.updateBlock
+    // (BlockNote calls flushSync internally, which crashes inside a React lifecycle).
+    const currentBlock = block;
+    const currentEditor = editor;
+    setTimeout(() => {
+      try {
+        currentEditor.updateBlock(currentBlock, {
+          props: { ...currentBlock.props, files: newFilesJson },
+        });
+      } catch {
+        // Ignore update errors during rapid typing
+      }
+    }, 0);
+  };
+
+  const editorContent = (fullscreen: boolean) => (
+    <TooltipProvider delayDuration={400}>
+      {/* IDE title bar */}
+      <div className="flex items-center justify-between border-b border-[#333] bg-[#2d2d2d] px-3 py-2">
+        <div className="flex items-center gap-3">
+          {/* File explorer toggle */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setShowFileExplorer((v) => !v)}
+                className={`rounded p-1 transition-colors ${
+                  showFileExplorer
+                    ? "bg-[#3e3e3e] text-white"
+                    : "text-white hover:bg-[#3e3e3e]"
+                }`}
+                data-testid="file-explorer-toggle"
+              >
+                <PanelLeft size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {showFileExplorer ? "Hide file explorer" : "Show file explorer"}
+            </TooltipContent>
+          </Tooltip>
+
+          {/* Template selector */}
+          {isAuthorMode ? (
+            <div
+              className="flex items-center gap-0.5"
+              data-testid="template-selector"
+            >
+              {(Object.keys(TEMPLATE_LABELS) as SandpackTemplate[]).map(
+                (tmpl) => (
+                  <Tooltip key={tmpl}>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() => changeTemplate(tmpl)}
+                        className={`rounded px-2 py-0.5 text-xs transition-colors ${
+                          currentTemplate === tmpl
+                            ? "bg-[#0078d4] text-white"
+                            : "text-white hover:bg-[#3e3e3e]"
+                        }`}
+                      >
+                        {TEMPLATE_LABELS[tmpl]}
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Switch to {TEMPLATE_LABELS[tmpl]}
+                    </TooltipContent>
+                  </Tooltip>
+                ),
+              )}
+            </div>
+          ) : (
+            <span className="text-xs text-white">
+              {TEMPLATE_LABELS[currentTemplate]}
+            </span>
+          )}
+        </div>
+
+        {/* Right controls */}
+        <div className="flex items-center gap-1">
+          {isAuthorMode && (
+            <>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={resetToDefaults}
+                    className="rounded p-1.5 text-white transition-colors hover:bg-[#3e3e3e]"
+                    data-testid="reset-button"
+                  >
+                    <RotateCcw size={13} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Reset to template defaults</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={toggleEditable}
+                    className="rounded p-1.5 text-white transition-colors hover:bg-[#3e3e3e]"
+                    data-testid="editable-toggle"
+                  >
+                    {currentEditable ? <Edit size={13} /> : <Lock size={13} />}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {currentEditable
+                    ? "Students can edit — click to lock"
+                    : "Read-only for students — click to unlock"}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={toggleShowPreview}
+                    className="rounded p-1.5 text-white transition-colors hover:bg-[#3e3e3e]"
+                    data-testid="preview-toggle"
+                  >
+                    {currentShowPreview ? (
+                      <Eye size={13} />
+                    ) : (
+                      <EyeOff size={13} />
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {currentShowPreview ? "Hide preview" : "Show preview"}
+                </TooltipContent>
+              </Tooltip>
+            </>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setIsFullscreen((v) => !v)}
+                className="rounded p-1.5 text-gray-300 transition-colors hover:bg-[#3e3e3e] hover:text-white"
+              >
+                {fullscreen ? <Minimize2 size={13} /> : <Maximize2 size={13} />}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {fullscreen ? "Exit fullscreen (Esc)" : "Enter fullscreen"}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      <SandpackBlockInner
+        template={currentTemplate}
+        files={parsedFiles}
+        showPreview={currentShowPreview}
+        showFileExplorer={showFileExplorer}
+        editable={currentEditable}
+        isAuthorMode={isAuthorMode}
+        resolvedTheme={resolvedTheme}
+        onFilesChange={isAuthorMode ? handleFilesChange : undefined}
+        fullscreen={fullscreen}
+      />
+    </TooltipProvider>
+  );
+
+  return (
+    <>
+      {/* Inline block */}
+      <div
+        className="my-4 w-full overflow-hidden rounded-lg border border-[#333] bg-[#1e1e1e]"
+        contentEditable={false}
+        onMouseDown={handleMouseDown}
+      >
+        {editorContent(false)}
+      </div>
+
+      {/* Fullscreen overlay */}
+      {isFullscreen && (
+        <div
+          className="fixed inset-0 z-50 flex flex-col bg-[#1e1e1e]"
+          onMouseDown={handleMouseDown}
+        >
+          {editorContent(true)}
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/components/ui/blocknote/blocks/sandpack-block-content.tsx
+++ b/frontend/components/ui/blocknote/blocks/sandpack-block-content.tsx
@@ -354,12 +354,10 @@ export function SandpackBlockContent({
     }, 0);
   };
 
-  const editorContent = (fullscreen: boolean) => (
+  const titleBar = (
     <TooltipProvider delayDuration={400}>
-      {/* IDE title bar */}
       <div className="flex items-center justify-between border-b border-[#333] bg-[#2d2d2d] px-3 py-2">
         <div className="flex items-center gap-3">
-          {/* File explorer toggle */}
           <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -379,7 +377,6 @@ export function SandpackBlockContent({
             </TooltipContent>
           </Tooltip>
 
-          {/* Template selector */}
           {isAuthorMode ? (
             <div
               className="flex items-center gap-0.5"
@@ -414,7 +411,6 @@ export function SandpackBlockContent({
           )}
         </div>
 
-        {/* Right controls */}
         <div className="flex items-center gap-1">
           {isAuthorMode && (
             <>
@@ -472,48 +468,54 @@ export function SandpackBlockContent({
                 onClick={() => setIsFullscreen((v) => !v)}
                 className="rounded p-1.5 text-gray-300 transition-colors hover:bg-[#3e3e3e] hover:text-white"
               >
-                {fullscreen ? <Minimize2 size={13} /> : <Maximize2 size={13} />}
+                {isFullscreen ? (
+                  <Minimize2 size={13} />
+                ) : (
+                  <Maximize2 size={13} />
+                )}
               </button>
             </TooltipTrigger>
             <TooltipContent>
-              {fullscreen ? "Exit fullscreen (Esc)" : "Enter fullscreen"}
+              {isFullscreen ? "Exit fullscreen (Esc)" : "Enter fullscreen"}
             </TooltipContent>
           </Tooltip>
         </div>
       </div>
-
-      <SandpackBlockInner
-        template={currentTemplate}
-        files={parsedFiles}
-        showPreview={currentShowPreview}
-        showFileExplorer={showFileExplorer}
-        editable={currentEditable}
-        isAuthorMode={isAuthorMode}
-        resolvedTheme={resolvedTheme}
-        onFilesChange={isAuthorMode ? handleFilesChange : undefined}
-        fullscreen={fullscreen}
-      />
     </TooltipProvider>
+  );
+
+  const sandpackInner = (
+    <SandpackBlockInner
+      template={currentTemplate}
+      files={parsedFiles}
+      showPreview={currentShowPreview}
+      showFileExplorer={showFileExplorer}
+      editable={currentEditable}
+      isAuthorMode={isAuthorMode}
+      resolvedTheme={resolvedTheme}
+      onFilesChange={isAuthorMode ? handleFilesChange : undefined}
+      fullscreen={isFullscreen}
+    />
   );
 
   return (
     <>
-      {/* Inline block */}
       <div
         className="my-4 w-full overflow-hidden rounded-lg border border-[#333] bg-[#1e1e1e]"
         contentEditable={false}
         onMouseDown={handleMouseDown}
       >
-        {editorContent(false)}
+        {titleBar}
+        {!isFullscreen && sandpackInner}
       </div>
 
-      {/* Fullscreen overlay */}
       {isFullscreen && (
         <div
           className="fixed inset-0 z-50 flex flex-col bg-[#1e1e1e]"
           onMouseDown={handleMouseDown}
         >
-          {editorContent(true)}
+          {titleBar}
+          {sandpackInner}
         </div>
       )}
     </>

--- a/frontend/components/ui/blocknote/blocks/sandpack-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/sandpack-block.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { createReactBlockSpec } from "@blocknote/react";
+import { ErrorInfo } from "react";
+import React from "react";
+import dynamic from "next/dynamic";
+
+// Dynamic import keeps @codesandbox/sandpack-react out of the synchronous
+// webpack module graph so it doesn't conflict with BlockNoteSchema.create().
+const SandpackBlockContent = dynamic(
+  () => import("./sandpack-block-content").then((m) => m.SandpackBlockContent),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="my-4 w-full overflow-hidden rounded-lg border border-gray-700 bg-gray-900 p-4">
+        <div className="animate-pulse">
+          <div className="mb-4 h-4 w-1/4 rounded bg-gray-700"></div>
+          <div className="h-64 rounded bg-gray-800"></div>
+        </div>
+      </div>
+    ),
+  },
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const SandpackBlockComponent = ({ block, editor }: any) => (
+  <SandpackBlockContent block={block} editor={editor} />
+);
+
+class SandpackBlockErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("SandpackBlock Error:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="my-4 w-full rounded-lg border border-red-700 bg-red-50 p-4 dark:bg-red-950">
+          <p className="text-sm text-red-700 dark:text-red-300">
+            Live sandbox failed to load. Try refreshing the page.
+          </p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export const SandpackBlock = createReactBlockSpec(
+  {
+    type: "sandpack-block",
+    propSchema: {
+      template: {
+        default: "vanilla",
+      },
+      files: {
+        default: "{}",
+      },
+      showPreview: {
+        default: true,
+      },
+      editable: {
+        default: true,
+      },
+    },
+    content: "none",
+  },
+  {
+    render: (props) => (
+      <SandpackBlockErrorBoundary>
+        <SandpackBlockComponent {...props} />
+      </SandpackBlockErrorBoundary>
+    ),
+  },
+);

--- a/frontend/components/ui/blocknote/editor/slash-menu-config.ts
+++ b/frontend/components/ui/blocknote/editor/slash-menu-config.ts
@@ -4,7 +4,7 @@ import { createElement } from "react";
 import type { ReactElement } from "react";
 import type { CustomBlockNoteEditor } from "@/lib/blocknote/schema";
 import type { CalloutType } from "@/lib/blocknote/types";
-import { Code } from "lucide-react";
+import { Code, AppWindow } from "lucide-react";
 import {
   TriangleAlert,
   CircleHelp,
@@ -235,6 +235,42 @@ export const getCodeSlashMenuItems = (
     aliases: ["code", "snippet", "programming", "syntax"],
     group: "Code",
     subtext: "Display code with syntax highlighting",
+  },
+];
+
+export const getSandpackSlashMenuItems = (
+  editor: CustomBlockNoteEditor,
+): DefaultReactSuggestionItem[] => [
+  {
+    title: "Live Sandbox",
+    icon: createElement(AppWindow, { className: "h-4 w-4" }),
+    onItemClick: () => {
+      editor.insertBlocks(
+        [
+          {
+            type: "sandpack-block",
+            props: {
+              template: "vanilla",
+              files: "{}",
+              showPreview: true,
+              editable: true,
+            },
+          },
+        ],
+        editor.getTextCursorPosition().block,
+        "after",
+      );
+    },
+    aliases: [
+      "sandbox",
+      "sandpack",
+      "live",
+      "playground",
+      "interactive",
+      "web",
+    ],
+    group: "Code",
+    subtext: "Interactive code sandbox with live preview",
   },
 ];
 

--- a/frontend/lib/blocknote/convert-blocks.ts
+++ b/frontend/lib/blocknote/convert-blocks.ts
@@ -511,6 +511,22 @@ function convertSingleBlock(blockAny: any, blockIndex: number): Block | null {
       };
     }
 
+    case "sandpack-block": {
+      const template = blockAny.props?.template || "vanilla";
+      const files = blockAny.props?.files || "{}";
+      const showPreview = blockAny.props?.showPreview ?? true;
+      const editable = blockAny.props?.editable ?? true;
+
+      return {
+        __component: "droplets.sandpack-block",
+        id: blockIndex,
+        template,
+        files,
+        showPreview,
+        editable,
+      };
+    }
+
     case "slide-break": {
       return {
         __component: "droplets.generic",

--- a/frontend/lib/blocknote/schema.ts
+++ b/frontend/lib/blocknote/schema.ts
@@ -18,6 +18,7 @@ import { LatexBlock } from "@/components/ui/blocknote/blocks/latex-block";
 import { ImageBlock } from "@/components/ui/blocknote/blocks/image-block";
 import { CodeBlock } from "@/components/ui/blocknote/blocks/code-block";
 import { SlideBreak } from "@/components/ui/blocknote/blocks/slide-break-block";
+import { SandpackBlock } from "@/components/ui/blocknote/blocks/sandpack-block";
 
 const blockTypesToHide = new Set([
   "quote",
@@ -141,6 +142,7 @@ export const blockNoteSchema = BlockNoteSchema.create({
     image: ImageBlock(),
     "code-block": CodeBlock(),
     "slide-break": SlideBreak(),
+    "sandpack-block": SandpackBlock(),
   },
   styleSpecs: customStyleSpecs,
 });

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -568,6 +568,17 @@ export const stripHtmlTags = (html: string) => {
     .trim();
 };
 
+export function parseSandpackFiles(
+  json: string | null | undefined,
+): Record<string, string> {
+  try {
+    const parsed = JSON.parse(json || "{}");
+    return typeof parsed === "object" && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
 // Helper function to convert BlockNote JSON to markdown
 export function convertBlockNoteToMarkdown(blocks: any[]): string {
   return blocks

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@blocknote/core": "^0.41.1",
         "@blocknote/mantine": "^0.41.1",
         "@blocknote/react": "^0.41.1",
+        "@codesandbox/sandpack-react": "^2.20.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^8.0.0",
         "@emotion/react": "^11.14.0",
@@ -2720,6 +2721,182 @@
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
+      "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@codesandbox/nodebox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@codesandbox/nodebox/-/nodebox-0.1.8.tgz",
+      "integrity": "sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==",
+      "license": "SEE LICENSE IN ./LICENSE",
+      "dependencies": {
+        "outvariant": "^1.4.0",
+        "strict-event-emitter": "^0.4.3"
+      }
+    },
+    "node_modules/@codesandbox/sandpack-client": {
+      "version": "2.19.8",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-client/-/sandpack-client-2.19.8.tgz",
+      "integrity": "sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@codesandbox/nodebox": "0.1.8",
+        "buffer": "^6.0.3",
+        "dequal": "^2.0.2",
+        "mime-db": "^1.52.0",
+        "outvariant": "1.4.0",
+        "static-browser-server": "1.0.3"
+      }
+    },
+    "node_modules/@codesandbox/sandpack-react": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-react/-/sandpack-react-2.20.0.tgz",
+      "integrity": "sha512-takd1YpW/PMQ6KPQfvseWLHWklJovGY8QYj8MtWnskGKbjOGJ6uZfyZbcJ6aCFLQMpNyjTqz9AKNbvhCOZ1TUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.4.0",
+        "@codemirror/commands": "^6.1.3",
+        "@codemirror/lang-css": "^6.0.1",
+        "@codemirror/lang-html": "^6.4.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.3.2",
+        "@codemirror/state": "^6.2.0",
+        "@codemirror/view": "^6.7.1",
+        "@codesandbox/sandpack-client": "^2.19.8",
+        "@lezer/highlight": "^1.1.3",
+        "@react-hook/intersection-observer": "^3.1.1",
+        "@stitches/core": "^1.2.6",
+        "anser": "^2.1.1",
+        "clean-set": "^1.1.2",
+        "dequal": "^2.0.2",
+        "escape-carriage": "^1.3.1",
+        "lz-string": "^1.4.4",
+        "react-devtools-inline": "4.4.0",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@codesandbox/sandpack-react/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -4442,6 +4619,63 @@
         }
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
     "node_modules/@mantine/core": {
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.6.tgz",
@@ -4491,6 +4725,12 @@
       "peerDependencies": {
         "react": ">=16.8.0"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@microsoft/microsoft-graph-client": {
       "version": "3.0.7",
@@ -5306,6 +5546,12 @@
       "engines": {
         "node": ">=12.4.0"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "license": "MIT"
     },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
@@ -7101,6 +7347,28 @@
       "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
       "license": "MIT"
     },
+    "node_modules/@react-hook/intersection-observer": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-hook/intersection-observer/-/intersection-observer-3.1.2.tgz",
+      "integrity": "sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-hook/passive-layout-effect": "^1.2.0",
+        "intersection-observer": "^0.10.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/passive-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/@react-stately/checkbox": {
       "version": "3.6.10",
       "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.6.10.tgz",
@@ -8333,6 +8601,12 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@stitches/core": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/core/-/core-1.2.8.tgz",
+      "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==",
+      "license": "MIT"
     },
     "node_modules/@strapi/blocks-react-renderer": {
       "version": "1.0.2",
@@ -10111,6 +10385,12 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/anser": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
+      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
+      "license": "MIT"
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -10616,6 +10896,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -10710,6 +11010,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -10996,6 +11320,12 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/clean-set": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/clean-set/-/clean-set-1.1.2.tgz",
+      "integrity": "sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==",
       "license": "MIT"
     },
     "node_modules/client-only": {
@@ -11400,6 +11730,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/d3-array": {
@@ -12185,6 +12528,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -12193,6 +12576,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-carriage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
+      "integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -12666,6 +13055,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -12762,6 +13166,16 @@
       "integrity": "sha512-QVtGvYTf9HvQyDjbBCwoDQPP9KMuVB56H8KalrkLsPPCQfngpVmkiIoxJ4FU/SVmlmhnbr/heOmP5VlbCTEJpg==",
       "license": "MIT"
     },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -12828,6 +13242,15 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
       }
     },
     "node_modules/extend": {
@@ -14020,6 +14443,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -14131,6 +14574,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/intersection-observer": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.10.0.tgz",
+      "integrity": "sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==",
+      "deprecated": "The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.",
+      "license": "W3C-20150513"
     },
     "node_modules/intl-messageformat": {
       "version": "10.7.16",
@@ -16335,9 +16785,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -17587,6 +18035,12 @@
         "react-dom": "^16.8 || ^17 || ^18"
       }
     },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -17997,6 +18451,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
       "license": "MIT"
     },
     "node_modules/own-keys": {
@@ -19205,6 +19665,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-devtools-inline": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-inline/-/react-devtools-inline-4.4.0.tgz",
+      "integrity": "sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-symbol": "^3"
       }
     },
     "node_modules/react-dnd": {
@@ -20582,6 +21051,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/static-browser-server": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/static-browser-server/-/static-browser-server-1.0.3.tgz",
+      "integrity": "sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.1.0",
+        "dotenv": "^16.0.3",
+        "mime-db": "^1.52.0",
+        "outvariant": "^1.3.0"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "license": "MIT"
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -20865,6 +21352,12 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
     },
     "node_modules/style-to-js": {
@@ -21413,6 +21906,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "@blocknote/core": "^0.41.1",
     "@blocknote/mantine": "^0.41.1",
     "@blocknote/react": "^0.41.1",
+    "@codesandbox/sandpack-react": "^2.20.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^8.0.0",
     "@emotion/react": "^11.14.0",

--- a/frontend/tests/components/draft/blocknote-editor-client.test.tsx
+++ b/frontend/tests/components/draft/blocknote-editor-client.test.tsx
@@ -119,7 +119,7 @@ jest.mock("@blocknote/react", () => ({
   getDefaultReactSlashMenuItems: jest.fn(() => []),
   blockTypeSelectItems: jest.fn(() => []),
   getFormattingToolbarItems: jest.fn((items) => items),
-  createReactBlockSpec: jest.fn((config, spec) => ({
+  createReactBlockSpec: jest.fn((config, spec) => () => ({
     type: config.type,
     propSchema: config.propSchema,
     ...spec,

--- a/frontend/tests/components/ui/blocknote/blocks/sandpack-block.test.tsx
+++ b/frontend/tests/components/ui/blocknote/blocks/sandpack-block.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * Tests for the sandpack block component and sandpack viewer.
+ *
+ * Sandpack requires iframes and service workers not available in JSDOM,
+ * so we mock the entire @codesandbox/sandpack-react package.
+ */
+
+// Mock next-themes
+jest.mock("next-themes", () => ({
+  useTheme: jest.fn(() => ({ resolvedTheme: "light" })),
+}));
+
+// Mock next/dynamic to return a simple passthrough
+jest.mock("next/dynamic", () => {
+  return function mockDynamic(loader: () => Promise<unknown>, _opts?: unknown) {
+    // Return a placeholder component for dynamic imports
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const React = require("react");
+    return function DynamicComponent(props: Record<string, unknown>) {
+      return React.createElement(
+        "div",
+        { "data-testid": "dynamic-component" },
+        props.children as React.ReactNode,
+      );
+    };
+  };
+});
+
+// Mock @codesandbox/sandpack-react
+jest.mock("@codesandbox/sandpack-react", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require("react");
+  return {
+    SandpackProvider: ({
+      children,
+      template,
+    }: {
+      children: React.ReactNode;
+      template?: string;
+    }) =>
+      React.createElement(
+        "div",
+        { "data-testid": "sandpack-provider", "data-template": template },
+        children,
+      ),
+    SandpackCodeEditor: ({ readOnly }: { readOnly?: boolean }) =>
+      React.createElement("div", {
+        "data-testid": "sandpack-editor",
+        "data-readonly": readOnly,
+      }),
+    SandpackPreview: () =>
+      React.createElement("div", { "data-testid": "sandpack-preview" }),
+    SandpackLayout: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        "div",
+        { "data-testid": "sandpack-layout" },
+        children,
+      ),
+    useSandpack: () => ({
+      sandpack: {
+        files: {
+          "/index.js": { code: "console.log('hello')" },
+        },
+      },
+      dispatch: jest.fn(),
+    }),
+  };
+});
+
+// Mock @blocknote/react
+// createReactBlockSpec is called with (spec, options) and should return a function
+// that, when called, returns an object with spec and render.
+jest.mock("@blocknote/react", () => ({
+  createReactBlockSpec: jest.fn(
+    (
+      spec: Record<string, unknown>,
+      options: { render: (props: unknown) => unknown },
+    ) => {
+      // Return a factory function (matching real BlockNote behavior) so that
+      // SandpackBlock() calls the factory and returns the spec object.
+      return () => ({ spec, render: options.render });
+    },
+  ),
+}));
+
+// Mock @/lib/blocknote/schema
+jest.mock("@/lib/blocknote/schema", () => ({
+  blockNoteSchema: {
+    blockSchema: {},
+    inlineContentSchema: {},
+    styleSchema: {},
+  },
+}));
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// We need to render without next/dynamic since we mocked it.
+// Import the components directly after mocks are set up.
+
+describe("SandpackViewer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders with template label in the header", async () => {
+    // Import SandpackViewer after mocks are established
+    const { SandpackViewer } = await import(
+      "@/components/draft/lesson/sandpack-viewer"
+    );
+
+    render(
+      <SandpackViewer
+        template="react"
+        files={{}}
+        showPreview={true}
+        editable={true}
+      />,
+    );
+
+    expect(screen.getByText("React")).toBeInTheDocument();
+  });
+
+  it("renders vanilla template label correctly", async () => {
+    const { SandpackViewer } = await import(
+      "@/components/draft/lesson/sandpack-viewer"
+    );
+
+    render(
+      <SandpackViewer
+        template="vanilla"
+        files={{}}
+        showPreview={true}
+        editable={true}
+      />,
+    );
+
+    expect(screen.getByText("Vanilla JS")).toBeInTheDocument();
+  });
+
+  it("renders react-ts template label correctly", async () => {
+    const { SandpackViewer } = await import(
+      "@/components/draft/lesson/sandpack-viewer"
+    );
+
+    render(
+      <SandpackViewer
+        template="react-ts"
+        files={{}}
+        showPreview={true}
+        editable={true}
+      />,
+    );
+
+    expect(screen.getByText("React + TypeScript")).toBeInTheDocument();
+  });
+});
+
+describe("SandpackBlock component (editor mode)", () => {
+  const createMockEditor = (isEditable = true) => ({
+    isEditable,
+    updateBlock: jest.fn(),
+    insertBlocks: jest.fn(),
+    getTextCursorPosition: jest.fn(() => ({
+      block: { id: "test-block" },
+    })),
+  });
+
+  const createMockBlock = (overrides = {}) => ({
+    id: "block-123",
+    type: "sandpack-block",
+    props: {
+      template: "vanilla",
+      files: "{}",
+      showPreview: true,
+      editable: true,
+      ...overrides,
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders template selector in editor mode", async () => {
+    const { SandpackBlock } = await import(
+      "@/components/ui/blocknote/blocks/sandpack-block"
+    );
+
+    const blockSpec = SandpackBlock();
+    const editor = createMockEditor(true);
+    const block = createMockBlock();
+
+    // The render function from createReactBlockSpec
+    const RenderComponent = ({
+      block: b,
+      editor: e,
+    }: {
+      block: typeof block;
+      editor: typeof editor;
+    }) => {
+      // Directly render the inner component to test it
+      // We need to get the inner SandpackBlockComponent
+      const rendered = blockSpec.render({ block: b, editor: e });
+      return rendered as React.ReactElement;
+    };
+
+    // Test the block spec was created with correct type
+    expect(blockSpec.spec?.type).toBe("sandpack-block");
+  });
+
+  it("block spec has correct prop schema", async () => {
+    const { SandpackBlock } = await import(
+      "@/components/ui/blocknote/blocks/sandpack-block"
+    );
+
+    const blockSpec = SandpackBlock();
+    const propSchema = blockSpec.spec?.propSchema;
+
+    expect(propSchema).toBeDefined();
+    expect(propSchema?.template?.default).toBe("vanilla");
+    expect(propSchema?.files?.default).toBe("{}");
+    expect(propSchema?.showPreview?.default).toBe(true);
+    expect(propSchema?.editable?.default).toBe(true);
+  });
+
+  it("block spec has content type none", async () => {
+    const { SandpackBlock } = await import(
+      "@/components/ui/blocknote/blocks/sandpack-block"
+    );
+
+    const blockSpec = SandpackBlock();
+    expect(blockSpec.spec?.content).toBe("none");
+  });
+});
+
+describe("SandpackBlockComponent rendering", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset window.confirm mock
+    jest.spyOn(window, "confirm").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Helper to import and render the inner component directly
+  // We test the rendered output by importing the file
+  it("shows template selector in author mode", async () => {
+    // Dynamically import to get a fresh module after mocks
+    const mod = await import("@/components/ui/blocknote/blocks/sandpack-block");
+
+    const editor = { isEditable: true, updateBlock: jest.fn() };
+    const block = {
+      id: "block-1",
+      type: "sandpack-block",
+      props: {
+        template: "vanilla",
+        files: "{}",
+        showPreview: true,
+        editable: true,
+      },
+    };
+
+    const blockSpec = mod.SandpackBlock();
+    const rendered = blockSpec.render({ block, editor });
+
+    // The render function should return something
+    expect(rendered).toBeDefined();
+  });
+});

--- a/frontend/tests/components/ui/blocknote/editor/slash-menu-config.test.tsx
+++ b/frontend/tests/components/ui/blocknote/editor/slash-menu-config.test.tsx
@@ -22,6 +22,7 @@ jest.mock("@/lib/blocknote/types", () => ({
 import {
   getCalloutSlashMenuItems,
   getQuizSlashMenuItems,
+  getSandpackSlashMenuItems,
 } from "@/components/ui/blocknote/editor/slash-menu-config";
 
 // Mock BlockNote editor
@@ -194,6 +195,64 @@ describe("getQuizSlashMenuItems", () => {
               expect.objectContaining({ id: "1", text: "", isCorrect: true }),
               expect.objectContaining({ id: "2", text: "", isCorrect: false }),
             ]),
+          }),
+        }),
+      ]),
+      expect.anything(),
+      "after",
+    );
+  });
+});
+
+describe("getSandpackSlashMenuItems", () => {
+  it("returns an array with one item titled 'Live Sandbox'", () => {
+    const editor = createMockEditor();
+    const items = getSandpackSlashMenuItems(editor);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("Live Sandbox");
+  });
+
+  it("has correct aliases including sandbox, live, and playground", () => {
+    const editor = createMockEditor();
+    const items = getSandpackSlashMenuItems(editor);
+    const item = items[0];
+
+    expect(item.aliases).toContain("sandbox");
+    expect(item.aliases).toContain("live");
+    expect(item.aliases).toContain("playground");
+  });
+
+  it("belongs to the Code group", () => {
+    const editor = createMockEditor();
+    const items = getSandpackSlashMenuItems(editor);
+
+    expect(items[0].group).toBe("Code");
+  });
+
+  it("has an icon defined", () => {
+    const editor = createMockEditor();
+    const items = getSandpackSlashMenuItems(editor);
+
+    expect(items[0].icon).toBeDefined();
+  });
+
+  it("calls editor.insertBlocks with sandpack-block type and correct default props on click", () => {
+    const editor = createMockEditor();
+    const items = getSandpackSlashMenuItems(editor);
+    const item = items[0];
+
+    item.onItemClick?.();
+
+    expect(editor.insertBlocks).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "sandpack-block",
+          props: expect.objectContaining({
+            template: "vanilla",
+            files: "{}",
+            showPreview: true,
+            editable: true,
           }),
         }),
       ]),

--- a/frontend/tests/lib/blocknote/schema.test.ts
+++ b/frontend/tests/lib/blocknote/schema.test.ts
@@ -55,7 +55,7 @@ jest.mock("react-syntax-highlighter/dist/esm/languages/hljs/swift", () => ({}));
 
 // Mock BlockNote before importing schema
 jest.mock("@blocknote/react", () => ({
-  createReactBlockSpec: jest.fn((config, spec) => ({
+  createReactBlockSpec: jest.fn((config, spec) => () => ({
     type: config.type,
     propSchema: config.propSchema,
     ...spec,

--- a/frontend/types/index.d.ts
+++ b/frontend/types/index.d.ts
@@ -171,6 +171,15 @@ export type Block =
       editable: boolean;
       runnable: boolean;
       _clientId?: string;
+    }
+  | {
+      __component: "droplets.sandpack-block";
+      id?: number;
+      template: string;
+      files: string;
+      showPreview: boolean;
+      editable: boolean;
+      _clientId?: string;
     };
 
 export type Lesson = {


### PR DESCRIPTION
## Description

  Adds a live, interactive code editor block to the BlockNote lesson editor
  powered by Sandpack. Authors can insert a /sandbox block and students can
  read, edit, and run code directly in the lesson.

  Editor (author) features:
  - Three templates: Vanilla JS, React, React + TypeScript — switchable via
  pill buttons in the title bar
  - Toggleable file explorer sidebar (shows all files in the sandbox)
  - Per-block controls to lock/unlock student editing and show/hide the live
  preview pane
  - Reset button to restore template defaults
  - Fullscreen mode (Maximize/Minimize toggle + Escape key)
  - Tooltips on all toolbar icons

  Student (viewer) features:
  - Read-only or editable code editor depending on author setting
  - Live preview pane (when enabled by author)
  - File explorer sidebar toggle
  - Fullscreen mode

  Presentation mode:
  - Sandpack slides render as a fixed fullscreen overlay covering the entire
  slide, giving students a full-screen coding environment per slide

  Implementation notes:
  - SandpackProvider is isolated behind dynamic({ ssr: false }) to keep it out
   of the synchronous BlockNote schema initialization graph, preventing the
  runsBefore crash
  - Template selector uses <button> elements (not <select>) — ProseMirror's
  capture-phase mousedown listener prevents native <select> dropdowns from
  opening inside BlockNote blocks
  - editor.updateBlock is deferred via setTimeout(0) to avoid the flushSync
  inside lifecycle error
  - Only one SandpackProvider mounts at a time — fullscreen unmounts the
  inline instance to prevent double memory/compilation overhead
  - parseSandpackFiles() utility extracted to lib/utils.ts and shared across
  lesson renderer and presentation renderer

## Motivation and Context

  Closes ODY-382. Instructors need a way to embed runnable, editable code
  examples directly in lessons without linking to external playgrounds. This
  keeps students in the learning flow and allows per-lesson code scaffolding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive code sandbox blocks that can be inserted into lessons via the slash menu
  * Support for Vanilla JS, React, and React + TypeScript templates with customizable files
  * Toggle live preview visibility and student editability per block
  * File explorer, template switching, and fullscreen mode with Escape key to exit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->