### PR TITLE
Feature/ody 382 add live code editor block sandpack to lesson editor

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -111,3 +111,14 @@
     --border-angle: 360deg;
   }
 }
+
+/* Fix CodeMirror text selection visibility in Sandpack's light theme.
+   The default light theme uses a near-white selection that disappears
+   against the white editor background. */
+html:not(.dark) .sp-wrapper .cm-selectionBackground,
+html:not(.dark) .sp-wrapper .cm-focused .cm-selectionBackground {
+  background: #b3d4fd !important;
+}
+html:not(.dark) .sp-wrapper .cm-editor ::selection {
+  background: #b3d4fd;
+}

--- a/frontend/components/draft/lesson/sandpack-viewer.tsx
+++ b/frontend/components/draft/lesson/sandpack-viewer.tsx
@@ -100,8 +100,8 @@ export function SandpackViewer({
                 onClick={() => setShowFileExplorer((v) => !v)}
                 className={`rounded p-1 transition-colors ${
                   showFileExplorer
-                    ? "bg-[#3e3e3e] text-gray-200"
-                    : "text-gray-500 hover:text-gray-300"
+                    ? "bg-[#3e3e3e] text-white"
+                    : "text-white hover:bg-[#3e3e3e]"
                 }`}
               >
                 <PanelLeft size={14} />
@@ -111,7 +111,7 @@ export function SandpackViewer({
               {showFileExplorer ? "Hide file explorer" : "Show file explorer"}
             </TooltipContent>
           </Tooltip>
-          <span className="text-xs text-gray-400">
+          <span className="text-xs text-white">
             {TEMPLATE_LABELS[template]}
           </span>
         </div>
@@ -120,7 +120,7 @@ export function SandpackViewer({
             <TooltipTrigger asChild>
               <button
                 onClick={() => setIsFullscreen((v) => !v)}
-                className="rounded p-1.5 text-gray-300 transition-colors hover:bg-[#3e3e3e] hover:text-white"
+                className="rounded p-1.5 text-white transition-colors hover:bg-[#3e3e3e]"
               >
                 {isFullscreen ? (
                   <Minimize2 size={13} />

--- a/frontend/components/ui/blocknote/blocks/sandpack-block-content.tsx
+++ b/frontend/components/ui/blocknote/blocks/sandpack-block-content.tsx
@@ -5,10 +5,9 @@ import {
   SandpackLayout,
   SandpackCodeEditor,
   SandpackPreview,
-  SandpackFileExplorer,
   useSandpack,
 } from "@codesandbox/sandpack-react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import React from "react";
 import {
   Edit,
@@ -19,6 +18,8 @@ import {
   PanelLeft,
   Maximize2,
   Minimize2,
+  Plus,
+  X,
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import {
@@ -135,23 +136,144 @@ export const TEMPLATE_LABELS: Record<SandpackTemplate, string> = {
   "react-ts": "React + TypeScript",
 };
 
+const MAX_FILES = 20;
+const BUBBLE_EVENTS = [
+  "keydown",
+  "keypress",
+  "keyup",
+  "input",
+  "paste",
+  "cut",
+] as const;
+const MAX_FILENAME_LENGTH = 50;
+const VALID_FILENAME_PATTERN = /^\/[a-zA-Z0-9][a-zA-Z0-9._\-/]*\.[a-zA-Z0-9]+$/;
+
+export function validateSandpackFilename(
+  filename: string,
+  existingFiles: Record<string, string>,
+): string | null {
+  if (!filename || filename.trim().length === 0) return "Filename is required";
+  if (filename.length > MAX_FILENAME_LENGTH)
+    return `Max ${MAX_FILENAME_LENGTH} characters`;
+  if (!filename.startsWith("/")) return "Must start with /";
+  if (filename.includes("..")) return "Cannot contain consecutive dots";
+  if (filename.includes("//")) return "Cannot contain consecutive slashes";
+  if (!VALID_FILENAME_PATTERN.test(filename))
+    return "Only letters, numbers, dots, hyphens, underscores, and slashes allowed";
+  if (filename in existingFiles) return "File already exists";
+  return null;
+}
+
 interface FileChangeListenerProps {
   onFilesChange: (files: Record<string, string>) => void;
 }
 
 function FileChangeListener({ onFilesChange }: FileChangeListenerProps) {
   const { sandpack } = useSandpack();
+  // Keep a ref so the effect always calls the latest callback without
+  // needing it in the dependency array (avoids re-running on every render).
+  const onFilesChangeRef = useRef(onFilesChange);
+  onFilesChangeRef.current = onFilesChange;
 
   useEffect(() => {
-    const files = sandpack.files;
     const simplified: Record<string, string> = {};
-    Object.entries(files).forEach(([filename, fileObj]) => {
+    Object.entries(sandpack.files).forEach(([filename, fileObj]) => {
       simplified[filename] = fileObj.code;
     });
-    onFilesChange(simplified);
+    onFilesChangeRef.current(simplified);
   }, [sandpack.files]);
 
   return null;
+}
+
+// Null-rendering component inside SandpackProvider that exposes sandpack.addFile
+// via a ref so the title bar (outside the provider) can trigger file creation.
+interface SandpackFileCommandsProps {
+  addFileCommandRef: React.MutableRefObject<
+    ((filename: string) => void) | null
+  >;
+}
+
+function SandpackFileCommands({
+  addFileCommandRef,
+}: SandpackFileCommandsProps) {
+  const { sandpack } = useSandpack();
+  addFileCommandRef.current = (filename: string) => {
+    sandpack.addFile(filename, "");
+    sandpack.setActiveFile(filename);
+  };
+  return null;
+}
+
+interface CustomFileExplorerProps {
+  height: string;
+  isAuthorMode: boolean;
+}
+
+function CustomFileExplorer({ height, isAuthorMode }: CustomFileExplorerProps) {
+  const { sandpack } = useSandpack();
+  const filePaths = Object.keys(sandpack.files).sort();
+  const fileCount = filePaths.length;
+
+  const handleDelete = (path: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    const confirmed = window.confirm(`Delete ${path}?`);
+    if (!confirmed) return;
+    sandpack.deleteFile(path);
+  };
+
+  return (
+    <div
+      style={{ height, minWidth: "160px", maxWidth: "200px" }}
+      role="listbox"
+      aria-label="Files"
+      className="overflow-y-auto border-r border-[#333] bg-[#1e1e1e]"
+    >
+      {filePaths.map((path) => {
+        const isActive = sandpack.activeFile === path;
+        const displayPath = path.slice(1); // strip leading slash
+        return (
+          <div
+            key={path}
+            role="option"
+            aria-selected={isActive}
+            tabIndex={0}
+            onClick={() => sandpack.setActiveFile(path)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                sandpack.setActiveFile(path);
+              }
+            }}
+            className={`group flex cursor-pointer items-center justify-between px-3 py-1.5 text-xs focus:ring-1 focus:ring-[#0078d4] focus:outline-none ${
+              isActive
+                ? "bg-[#2d2d2d] text-white"
+                : "text-gray-400 hover:bg-[#252525] hover:text-white"
+            }`}
+          >
+            <span className="truncate" title={path}>
+              {displayPath}
+            </span>
+            {isAuthorMode && (
+              <button
+                onClick={(e) => handleDelete(path, e)}
+                disabled={fileCount <= 1}
+                className="ml-1 shrink-0 rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-[#555] focus:opacity-100 disabled:cursor-not-allowed disabled:opacity-20"
+                title={
+                  fileCount <= 1
+                    ? "Cannot delete the last file"
+                    : `Delete ${path}`
+                }
+                data-testid={`delete-file-button-${path}`}
+              >
+                <X size={10} />
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 interface SandpackBlockInnerProps {
@@ -163,6 +285,9 @@ interface SandpackBlockInnerProps {
   isAuthorMode: boolean;
   resolvedTheme: string | undefined;
   onFilesChange?: (files: Record<string, string>) => void;
+  addFileCommandRef?: React.MutableRefObject<
+    ((filename: string) => void) | null
+  >;
   fullscreen?: boolean;
 }
 
@@ -175,6 +300,7 @@ function SandpackBlockInner({
   isAuthorMode,
   resolvedTheme,
   onFilesChange,
+  addFileCommandRef,
   fullscreen,
 }: SandpackBlockInnerProps) {
   const sandpackTheme = resolvedTheme === "dark" ? "dark" : "light";
@@ -192,14 +318,14 @@ function SandpackBlockInner({
       {isAuthorMode && onFilesChange && (
         <FileChangeListener onFilesChange={onFilesChange} />
       )}
+      {isAuthorMode && addFileCommandRef && (
+        <SandpackFileCommands addFileCommandRef={addFileCommandRef} />
+      )}
       <SandpackLayout>
         {showFileExplorer && (
-          <SandpackFileExplorer
-            style={{
-              height: panelHeight,
-              minWidth: "160px",
-              maxWidth: "200px",
-            }}
+          <CustomFileExplorer
+            height={panelHeight}
+            isAuthorMode={isAuthorMode}
           />
         )}
         <SandpackCodeEditor
@@ -235,6 +361,15 @@ export function SandpackBlockContent({
   const isAuthorMode = editor?.isEditable !== false;
   const [showFileExplorer, setShowFileExplorer] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [addFileOpen, setAddFileOpen] = useState(false);
+  const [newFilename, setNewFilename] = useState("/");
+  const [addFileError, setAddFileError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const fullscreenRef = useRef<HTMLDivElement>(null);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const addFileInputRef = useRef<HTMLInputElement>(null);
+  const addFilePopoverRef = useRef<HTMLDivElement>(null);
+  const addFileCommandRef = useRef<((filename: string) => void) | null>(null);
 
   useEffect(() => {
     if (!isFullscreen) return;
@@ -244,6 +379,76 @@ export function SandpackBlockContent({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [isFullscreen]);
+
+  // Clear debounce timer on unmount to avoid firing updateBlock on a dead editor.
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, []);
+
+  // Stop keyboard/input/paste events from bubbling out to ProseMirror.
+  // ProseMirror registers native DOM listeners that fire before React synthetic
+  // events, so we must intercept at the native level to prevent keystrokes
+  // typed inside CodeMirror from leaking into the lesson editor.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const stop = (e: Event) => e.stopPropagation();
+    BUBBLE_EVENTS.forEach((evt) => el.addEventListener(evt, stop));
+    return () =>
+      BUBBLE_EVENTS.forEach((evt) => el.removeEventListener(evt, stop));
+  }, []);
+
+  // Same event isolation for the fullscreen overlay — uses a ref+effect so
+  // listeners are properly cleaned up each time the overlay mounts/unmounts.
+  useEffect(() => {
+    const el = fullscreenRef.current;
+    if (!isFullscreen || !el) return;
+    const stop = (e: Event) => e.stopPropagation();
+    BUBBLE_EVENTS.forEach((evt) => el.addEventListener(evt, stop));
+    return () =>
+      BUBBLE_EVENTS.forEach((evt) => el.removeEventListener(evt, stop));
+  }, [isFullscreen]);
+
+  const closeAddFilePopover = () => {
+    setAddFileOpen(false);
+    setNewFilename("/");
+    setAddFileError(null);
+  };
+
+  useEffect(() => {
+    if (!addFileOpen) return;
+    addFileInputRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeAddFilePopover();
+    };
+    const onMouseDown = (e: MouseEvent) => {
+      if (
+        addFilePopoverRef.current &&
+        !addFilePopoverRef.current.contains(e.target as Node)
+      ) {
+        closeAddFilePopover();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onMouseDown);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onMouseDown);
+    };
+  }, [addFileOpen]);
+
+  const handleAddFileCreate = () => {
+    const validationError = validateSandpackFilename(newFilename, parsedFiles);
+    if (validationError) {
+      setAddFileError(validationError);
+      return;
+    }
+    addFileCommandRef.current?.(newFilename);
+    setShowFileExplorer(true);
+    closeAddFilePopover();
+  };
 
   const currentTemplate = (block.props.template ||
     "vanilla") as SandpackTemplate;
@@ -260,6 +465,7 @@ export function SandpackBlockContent({
       return {};
     }
   }, [block.props.files]);
+  const fileCount = Object.keys(parsedFiles).length;
 
   const handleMouseDown = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -338,19 +544,24 @@ export function SandpackBlockContent({
     if (!editor) return;
     const newFilesJson = JSON.stringify(newFiles);
     if (newFilesJson === block.props.files) return;
-    // Defer to avoid flushSync conflict with BlockNote's editor.updateBlock
-    // (BlockNote calls flushSync internally, which crashes inside a React lifecycle).
+
+    // Debounce saves: cancel the previous pending update and schedule a new one.
+    // Firing updateBlock on every keystroke queues rapid ProseMirror transactions
+    // that can step on each other and produce "Position X out of range" errors.
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+
     const currentBlock = block;
     const currentEditor = editor;
-    setTimeout(() => {
+    saveTimerRef.current = setTimeout(() => {
+      saveTimerRef.current = null;
       try {
         currentEditor.updateBlock(currentBlock, {
           props: { ...currentBlock.props, files: newFilesJson },
         });
       } catch {
-        // Ignore update errors during rapid typing
+        // Ignore stale-reference errors if the block was removed
       }
-    }, 0);
+    }, 600);
   };
 
   const titleBar = (
@@ -375,6 +586,82 @@ export function SandpackBlockContent({
               {showFileExplorer ? "Hide file explorer" : "Show file explorer"}
             </TooltipContent>
           </Tooltip>
+
+          {isAuthorMode && (
+            <div className="relative">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => {
+                      if (fileCount < MAX_FILES) {
+                        setAddFileOpen((v) => !v);
+                        setNewFilename("/");
+                        setAddFileError(null);
+                      }
+                    }}
+                    disabled={fileCount >= MAX_FILES}
+                    className="rounded p-1 text-white transition-colors hover:bg-[#3e3e3e] disabled:cursor-not-allowed disabled:opacity-40"
+                    data-testid="add-file-button"
+                  >
+                    <Plus size={13} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {fileCount >= MAX_FILES
+                    ? `Maximum ${MAX_FILES} files reached`
+                    : "Add file"}
+                </TooltipContent>
+              </Tooltip>
+
+              {addFileOpen && (
+                <div
+                  ref={addFilePopoverRef}
+                  role="dialog"
+                  aria-label="Add new file"
+                  className="absolute top-full left-0 z-50 mt-1 w-64 rounded border border-[#555] bg-[#2d2d2d] p-3 shadow-lg"
+                >
+                  <input
+                    ref={addFileInputRef}
+                    type="text"
+                    aria-label="New filename"
+                    value={newFilename}
+                    onChange={(e) => {
+                      setNewFilename(e.target.value);
+                      setAddFileError(null);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleAddFileCreate();
+                    }}
+                    placeholder="/filename.js"
+                    className="w-full rounded border border-[#555] bg-[#1e1e1e] px-2 py-1 text-sm text-white outline-none focus:border-[#0078d4]"
+                    data-testid="new-filename-input"
+                  />
+                  {addFileError && (
+                    <p
+                      className="mt-1 text-xs text-red-400"
+                      data-testid="filename-error"
+                    >
+                      {addFileError}
+                    </p>
+                  )}
+                  <div className="mt-2 flex gap-2">
+                    <button
+                      onClick={handleAddFileCreate}
+                      className="rounded bg-[#0078d4] px-2 py-1 text-xs text-white hover:bg-[#106ebe]"
+                    >
+                      Create
+                    </button>
+                    <button
+                      onClick={closeAddFilePopover}
+                      className="rounded px-2 py-1 text-xs text-white hover:bg-[#3e3e3e]"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
 
           {isAuthorMode ? (
             <div
@@ -493,6 +780,7 @@ export function SandpackBlockContent({
       isAuthorMode={isAuthorMode}
       resolvedTheme={resolvedTheme}
       onFilesChange={isAuthorMode ? handleFilesChange : undefined}
+      addFileCommandRef={isAuthorMode ? addFileCommandRef : undefined}
       fullscreen={isFullscreen}
     />
   );
@@ -500,6 +788,7 @@ export function SandpackBlockContent({
   return (
     <>
       <div
+        ref={containerRef}
         className="my-4 w-full overflow-hidden rounded-lg border border-[#333] bg-[#1e1e1e]"
         contentEditable={false}
         onMouseDown={handleMouseDown}
@@ -510,6 +799,7 @@ export function SandpackBlockContent({
 
       {isFullscreen && (
         <div
+          ref={fullscreenRef}
           className="fixed inset-0 z-50 flex flex-col bg-[#1e1e1e]"
           onMouseDown={handleMouseDown}
         >

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -52,14 +52,14 @@ const nextConfig = {
             value: `
               default-src 'self';
               script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us-assets.i.posthog.com https://cdn.jsdelivr.net;
-              connect-src 'self' https://app.posthog.com https://*.posthog.com https://strapi.odyssey.khoury.northeastern.edu https://emkc.org;
+              connect-src 'self' https://app.posthog.com https://*.posthog.com https://strapi.odyssey.khoury.northeastern.edu https://emkc.org https://*.codesandbox.io;
               style-src 'self' 'unsafe-inline';
               img-src 'self' data: https: blob:;
               font-src 'self' data:;
               media-src 'self' https: blob:;
               worker-src 'self' blob:;
-              child-src 'self' https://www.youtube.com https://player.vimeo.com;
-              frame-src 'self' https://www.youtube.com https://player.vimeo.com;
+              child-src 'self' https://www.youtube.com https://player.vimeo.com https://*.codesandbox.io;
+              frame-src 'self' https://www.youtube.com https://player.vimeo.com https://*.codesandbox.io;
             `
               .replace(/\s{2,}/g, " ")
               .trim(),

--- a/frontend/tests/components/ui/blocknote/blocks/sandpack-block.test.tsx
+++ b/frontend/tests/components/ui/blocknote/blocks/sandpack-block.test.tsx
@@ -56,11 +56,18 @@ jest.mock("@codesandbox/sandpack-react", () => {
         { "data-testid": "sandpack-layout" },
         children,
       ),
+    SandpackFileExplorer: () =>
+      React.createElement("div", { "data-testid": "sandpack-file-explorer" }),
     useSandpack: () => ({
       sandpack: {
         files: {
           "/index.js": { code: "console.log('hello')" },
+          "/styles.css": { code: "body {}" },
         },
+        activeFile: "/index.js",
+        addFile: jest.fn(),
+        deleteFile: jest.fn(),
+        setActiveFile: jest.fn(),
       },
       dispatch: jest.fn(),
     }),
@@ -268,5 +275,236 @@ describe("SandpackBlockComponent rendering", () => {
 
     // The render function should return something
     expect(rendered).toBeDefined();
+  });
+});
+
+describe("validateSandpackFilename", () => {
+  let validateSandpackFilename: (
+    filename: string,
+    existingFiles: Record<string, string>,
+  ) => string | null;
+
+  beforeAll(async () => {
+    const mod = await import(
+      "@/components/ui/blocknote/blocks/sandpack-block-content"
+    );
+    validateSandpackFilename = mod.validateSandpackFilename;
+  });
+
+  const empty: Record<string, string> = {};
+
+  it("returns null for valid /app.js", () => {
+    expect(validateSandpackFilename("/app.js", empty)).toBeNull();
+  });
+
+  it("returns null for valid /src/utils.ts", () => {
+    expect(validateSandpackFilename("/src/utils.ts", empty)).toBeNull();
+  });
+
+  it("returns null for valid /styles/main.css", () => {
+    expect(validateSandpackFilename("/styles/main.css", empty)).toBeNull();
+  });
+
+  it("returns null for valid /src/components/Button.tsx", () => {
+    expect(
+      validateSandpackFilename("/src/components/Button.tsx", empty),
+    ).toBeNull();
+  });
+
+  it("returns error for empty string", () => {
+    expect(validateSandpackFilename("", empty)).toBe("Filename is required");
+  });
+
+  it("returns error for whitespace-only string", () => {
+    expect(validateSandpackFilename("   ", empty)).toBe("Filename is required");
+  });
+
+  it("returns error when missing leading slash", () => {
+    expect(validateSandpackFilename("app.js", empty)).toBe("Must start with /");
+  });
+
+  it("returns error when name exceeds 50 characters", () => {
+    const long = "/" + "a".repeat(48) + ".js"; // 52 chars total
+    expect(validateSandpackFilename(long, empty)).toBe("Max 50 characters");
+  });
+
+  it("returns error for special chars (spaces)", () => {
+    expect(validateSandpackFilename("/my file.js", empty)).toBe(
+      "Only letters, numbers, dots, hyphens, underscores, and slashes allowed",
+    );
+  });
+
+  it("returns error for special chars (<)", () => {
+    expect(validateSandpackFilename("/file<name>.js", empty)).toBe(
+      "Only letters, numbers, dots, hyphens, underscores, and slashes allowed",
+    );
+  });
+
+  it("returns error for consecutive dots (/foo..bar.js)", () => {
+    expect(validateSandpackFilename("/foo..bar.js", empty)).toBe(
+      "Cannot contain consecutive dots",
+    );
+  });
+
+  it("returns error for consecutive slashes (/foo//bar.js)", () => {
+    expect(validateSandpackFilename("/foo//bar.js", empty)).toBe(
+      "Cannot contain consecutive slashes",
+    );
+  });
+
+  it("returns error when file already exists", () => {
+    expect(
+      validateSandpackFilename("/app.js", { "/app.js": "console.log('hi')" }),
+    ).toBe("File already exists");
+  });
+
+  it("returns error for no file extension (/README)", () => {
+    expect(validateSandpackFilename("/README", empty)).toBe(
+      "Only letters, numbers, dots, hyphens, underscores, and slashes allowed",
+    );
+  });
+});
+
+describe("FileActions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(window, "confirm").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const createMockBlock = (overrides = {}) => ({
+    id: "block-123",
+    type: "sandpack-block",
+    props: {
+      template: "vanilla",
+      files: "{}",
+      showPreview: true,
+      editable: true,
+      ...overrides,
+    },
+  });
+
+  it("renders add file button in author mode (isEditable=true)", async () => {
+    const { SandpackBlockContent } = await import(
+      "@/components/ui/blocknote/blocks/sandpack-block-content"
+    );
+
+    const editor = { isEditable: true, updateBlock: jest.fn() };
+    const block = createMockBlock();
+
+    render(<SandpackBlockContent block={block} editor={editor} />);
+
+    expect(screen.getByTestId("add-file-button")).toBeInTheDocument();
+  });
+
+  it("does not render add file button when not in author mode (isEditable=false)", async () => {
+    const { SandpackBlockContent } = await import(
+      "@/components/ui/blocknote/blocks/sandpack-block-content"
+    );
+
+    const editor = { isEditable: false, updateBlock: jest.fn() };
+    const block = createMockBlock();
+
+    render(<SandpackBlockContent block={block} editor={editor} />);
+
+    expect(screen.queryByTestId("add-file-button")).not.toBeInTheDocument();
+  });
+
+  it("clicking add file button shows popover with input", async () => {
+    const { SandpackBlockContent } = await import(
+      "@/components/ui/blocknote/blocks/sandpack-block-content"
+    );
+
+    const editor = { isEditable: true, updateBlock: jest.fn() };
+    const block = createMockBlock();
+
+    render(<SandpackBlockContent block={block} editor={editor} />);
+
+    const addButton = screen.getByTestId("add-file-button");
+    fireEvent.click(addButton);
+
+    expect(screen.getByTestId("new-filename-input")).toBeInTheDocument();
+  });
+
+  it("submitting an invalid filename shows an error message", async () => {
+    const { SandpackBlockContent } = await import(
+      "@/components/ui/blocknote/blocks/sandpack-block-content"
+    );
+
+    const editor = { isEditable: true, updateBlock: jest.fn() };
+    const block = createMockBlock();
+
+    render(<SandpackBlockContent block={block} editor={editor} />);
+
+    fireEvent.click(screen.getByTestId("add-file-button"));
+
+    const input = screen.getByTestId("new-filename-input");
+    // Clear the default "/" value and type an invalid filename
+    fireEvent.change(input, { target: { value: "no-leading-slash.js" } });
+
+    fireEvent.click(screen.getByText("Create"));
+
+    expect(screen.getByTestId("filename-error")).toBeInTheDocument();
+    expect(screen.getByTestId("filename-error")).toHaveTextContent(
+      "Must start with /",
+    );
+  });
+
+  it("delete file button is disabled when only one file exists", async () => {
+    // Override useSandpack for this test to return only one file
+    const sandpackMock = require("@codesandbox/sandpack-react");
+    const originalUseSandpack = sandpackMock.useSandpack;
+    sandpackMock.useSandpack = () => ({
+      sandpack: {
+        files: {
+          "/index.js": { code: "console.log('hello')" },
+        },
+        activeFile: "/index.js",
+        addFile: jest.fn(),
+        deleteFile: jest.fn(),
+        setActiveFile: jest.fn(),
+      },
+      dispatch: jest.fn(),
+    });
+
+    const { SandpackBlockContent } = await import(
+      "@/components/ui/blocknote/blocks/sandpack-block-content"
+    );
+
+    const editor = { isEditable: true, updateBlock: jest.fn() };
+    const block = createMockBlock();
+
+    render(<SandpackBlockContent block={block} editor={editor} />);
+
+    // Open the file explorer to reveal the per-file delete buttons
+    fireEvent.click(screen.getByTestId("file-explorer-toggle"));
+
+    const deleteButton = screen.getByTestId("delete-file-button-/index.js");
+    expect(deleteButton).toBeDisabled();
+
+    // Restore
+    sandpackMock.useSandpack = originalUseSandpack;
+  });
+
+  it("delete file button calls window.confirm on click", async () => {
+    const { SandpackBlockContent } = await import(
+      "@/components/ui/blocknote/blocks/sandpack-block-content"
+    );
+
+    const editor = { isEditable: true, updateBlock: jest.fn() };
+    const block = createMockBlock();
+
+    render(<SandpackBlockContent block={block} editor={editor} />);
+
+    // Open the file explorer to reveal the per-file delete buttons
+    fireEvent.click(screen.getByTestId("file-explorer-toggle"));
+
+    const deleteButton = screen.getByTestId("delete-file-button-/index.js");
+    fireEvent.click(deleteButton);
+
+    expect(window.confirm).toHaveBeenCalledWith("Delete /index.js?");
   });
 });


### PR DESCRIPTION
## Description

Adds an interactive live code sandbox block to the BlockNote lesson editor, powered by [Sandpack](https://sandpack.codesandbox.io/). Authors can embed runnable code environments directly in lessons, with full file management. Students see a read-only or editable sandbox depending on author settings.

**Author-facing features:**
- Three starter templates: Vanilla JS, React, React + TypeScript
- Add files via `+` button in the title bar (with inline popover, validation, and auto-focus)
- Delete files via per-file `×` button in the file explorer (disabled on last file, confirm dialog)
- Custom file explorer showing full paths with keyboard navigation
- Toggle: student editable vs. read-only
- Toggle: show/hide preview panel
- Toggle: show/hide file explorer
- Reset to template defaults
- Fullscreen mode (Esc to exit)

**Student-facing:** `SandpackViewer` renders the sandbox in read or editable mode, with presentation mode support (fills the slide overlay).

**File management safety:**
- Filename validation: must start with `/`, extension required, allowlist regex, no `..`/`//`, max 50 chars, no duplicates
- Max 20 files per block (soft cap)
- Cannot delete the last file
- Confirm dialog before deletion

## Motivation and Context

Lesson authors currently have no way to embed interactive code examples. Students can read static code blocks but cannot run or experiment with code. This closes the gap by giving authors a full in-browser IDE with live preview, scoped to a single block in the lesson editor.

## Screenshots (if appropriate):

<!-- Add screenshots of the editor block and student view -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.