### PR TITLE
feat(presentation): larger text, confetti, two-column layout, column-break block

### DIFF
--- a/frontend/components/draft/lesson/blocknote-editor-client.tsx
+++ b/frontend/components/draft/lesson/blocknote-editor-client.tsx
@@ -27,6 +27,7 @@ import {
   getLatexSlashMenuItems,
   getCodeSlashMenuItems,
   getSlideBreakSlashMenuItems,
+  getColumnBreakSlashMenuItems,
   getNotebookCodeSlashMenuItems,
   getSandpackSlashMenuItems,
 } from "@/components/ui/blocknote/editor/slash-menu-config";
@@ -358,6 +359,7 @@ export function BlockNoteEditorClient({
               const latexItems = getLatexSlashMenuItems(editor);
               const codeItems = getCodeSlashMenuItems(editor);
               const slideBreakItems = getSlideBreakSlashMenuItems(editor);
+              const columnBreakItems = getColumnBreakSlashMenuItems(editor);
               const notebookCodeItems = getNotebookCodeSlashMenuItems(editor);
               const sandpackItems = getSandpackSlashMenuItems(editor);
 
@@ -369,6 +371,7 @@ export function BlockNoteEditorClient({
                 ...codeItems,
                 ...sandpackItems,
                 ...slideBreakItems,
+                ...columnBreakItems,
                 ...notebookCodeItems,
               ];
 

--- a/frontend/components/presentation/presentation-shell.tsx
+++ b/frontend/components/presentation/presentation-shell.tsx
@@ -8,6 +8,7 @@
 import { useSlideNavigation } from "./use-slide-navigation";
 import { PresentationBlockRenderer } from "./presentation-block-renderer";
 import type { Slide } from "./utils";
+import { isColumnBreak } from "./utils";
 import { useRouter } from "next/navigation";
 import { useEffect, useCallback, useState, useMemo } from "react";
 import { cn } from "@/lib/utils";
@@ -18,6 +19,13 @@ import {
   BookTextIcon,
 } from "lucide-react";
 import { Logo } from "@/components/header/logo";
+import dynamic from "next/dynamic";
+
+const Confetti = dynamic(
+  () =>
+    import("@/app/(droplets)/d/[slug]/recap/confetti").then((m) => m.Confetti),
+  { ssr: false },
+);
 
 interface PresentationShellProps {
   dropletName: string;
@@ -165,8 +173,6 @@ export function PresentationShell({
     };
   }, [
     dropletName,
-    dropletDescription,
-    dropletTags,
     dropletOverview,
     dropletObjectives,
     dropletAuthors,
@@ -191,7 +197,7 @@ export function PresentationShell({
   if (!mounted) {
     return (
       <div className="fixed inset-0 z-[100] flex items-center justify-center bg-white text-slate-900 dark:bg-[#191919] dark:text-white">
-        <h1 className="text-5xl font-bold tracking-tight">{dropletName}</h1>
+        <h1 className="text-6xl font-bold tracking-tight">{dropletName}</h1>
       </div>
     );
   }
@@ -234,7 +240,7 @@ export function PresentationShell({
       </div>
 
       {/* ── Slide viewport ── */}
-      <div className="flex h-full w-full items-center justify-center overflow-hidden px-16 py-12">
+      <div className="flex h-full w-full items-center justify-center overflow-hidden px-20 py-16">
         <div
           key={currentSlideKey}
           className="flex w-full max-w-5xl flex-col items-center justify-center text-center"
@@ -242,16 +248,17 @@ export function PresentationShell({
           {isEndSlide ? (
             /* ── End slide ── */
             <div className="flex flex-col items-center gap-6">
-              <h1 className="text-5xl font-bold tracking-tight sm:text-6xl">
+              <Confetti />
+              <h1 className="text-6xl font-bold tracking-tight sm:text-7xl">
                 Thank You
               </h1>
-              <p className="text-xl text-slate-500 dark:text-slate-400">
+              <p className="text-2xl text-slate-500 dark:text-slate-400">
                 {dropletName}
               </p>
-              <div className="mt-4 h-0.5 w-16 rounded-full bg-sky-400/40" />
+              <div className="mt-4 h-0.5 w-24 rounded-full bg-sky-400/40" />
               <button
                 onClick={exit}
-                className="mt-6 rounded-md bg-sky-600 px-6 py-2.5 text-sm font-medium text-white transition hover:bg-sky-500"
+                className="mt-8 rounded-md bg-sky-600 px-8 py-3 text-base font-medium text-white transition hover:bg-sky-500"
               >
                 Exit Presentation
               </button>
@@ -264,7 +271,7 @@ export function PresentationShell({
                   {dropletTags.map((tag) => (
                     <span
                       key={tag}
-                      className="rounded-full border border-slate-300 px-3 py-1 text-sm text-slate-500 dark:border-slate-600 dark:text-slate-400"
+                      className="rounded-full border border-slate-300 px-4 py-1.5 text-base text-slate-500 dark:border-slate-600 dark:text-slate-400"
                     >
                       {tag}
                     </span>
@@ -272,26 +279,26 @@ export function PresentationShell({
                 </div>
               )}
 
-              <h1 className="text-5xl font-bold tracking-tight sm:text-6xl md:text-7xl">
+              <h1 className="text-6xl font-bold tracking-tight sm:text-7xl md:text-8xl">
                 {dropletName}
               </h1>
 
               {dropletDescription && (
-                <p className="max-w-2xl text-lg leading-relaxed text-slate-500 sm:text-xl dark:text-slate-400">
+                <p className="max-w-2xl text-xl leading-relaxed text-slate-500 sm:text-2xl dark:text-slate-400">
                   {dropletDescription}
                 </p>
               )}
 
-              <p className="mt-8 text-sm text-slate-400 dark:text-slate-500">
+              <p className="mt-8 text-base text-slate-400 dark:text-slate-500">
                 Press{" "}
-                <kbd className="rounded border border-slate-300 px-1.5 py-0.5 font-mono text-xs text-slate-500 dark:border-slate-600 dark:text-slate-400">
+                <kbd className="rounded border border-slate-300 px-1.5 py-0.5 font-mono text-sm text-slate-500 dark:border-slate-600 dark:text-slate-400">
                   →
                 </kbd>{" "}
                 to start{" "}
                 <span className="mx-1 text-slate-300 dark:text-slate-600">
                   ·
                 </span>{" "}
-                <kbd className="rounded border border-slate-300 px-1.5 py-0.5 font-mono text-xs text-slate-500 dark:border-slate-600 dark:text-slate-400">
+                <kbd className="rounded border border-slate-300 px-1.5 py-0.5 font-mono text-sm text-slate-500 dark:border-slate-600 dark:text-slate-400">
                   Esc
                 </kbd>{" "}
                 to exit
@@ -324,8 +331,8 @@ export function PresentationShell({
                   /* ignore */
                 }
                 return (
-                  <div className="flex flex-col items-center gap-6">
-                    <h2 className="text-3xl font-bold">Learning Objectives</h2>
+                  <div className="flex flex-col items-center gap-8">
+                    <h2 className="text-4xl font-bold">Learning Objectives</h2>
                     <div className="flex w-full max-w-3xl flex-col gap-3">
                       {objs.map((obj, i) => (
                         <div
@@ -333,7 +340,7 @@ export function PresentationShell({
                           className="flex items-start gap-3 rounded-lg border border-slate-200 bg-slate-100 px-5 py-3 text-left dark:border-slate-700 dark:bg-slate-800/50"
                         >
                           <GoalIcon className="mt-0.5 h-5 w-5 shrink-0 text-sky-500" />
-                          <p className="text-base leading-relaxed text-slate-700 dark:text-slate-200">
+                          <p className="text-lg leading-relaxed text-slate-700 dark:text-slate-200">
                             {obj}
                           </p>
                         </div>
@@ -353,9 +360,9 @@ export function PresentationShell({
                   /* ignore */
                 }
                 return (
-                  <div className="flex flex-col items-center gap-6">
-                    <h2 className="text-3xl font-bold">What&rsquo;s Inside</h2>
-                    <p className="text-slate-500 dark:text-slate-400">
+                  <div className="flex flex-col items-center gap-8">
+                    <h2 className="text-4xl font-bold">What&rsquo;s Inside</h2>
+                    <p className="text-lg text-slate-500 dark:text-slate-400">
                       This Droplet contains the following lessons:
                     </p>
                     <div className="flex w-full max-w-2xl flex-col divide-y divide-slate-200 rounded-lg border border-slate-200 bg-slate-100/50 dark:divide-slate-700 dark:border-slate-700 dark:bg-slate-800/50">
@@ -365,7 +372,7 @@ export function PresentationShell({
                           className="flex items-center gap-3 px-5 py-3"
                         >
                           <BookTextIcon className="h-4 w-4 shrink-0 text-slate-400 dark:text-slate-500" />
-                          <span className="text-base text-slate-700 dark:text-slate-200">
+                          <span className="text-lg text-slate-700 dark:text-slate-200">
                             {name}
                           </span>
                         </div>
@@ -385,9 +392,9 @@ export function PresentationShell({
                   /* ignore */
                 }
                 return (
-                  <div className="flex flex-col items-center gap-6">
-                    <h2 className="text-3xl font-bold">About the Authors</h2>
-                    <p className="text-slate-500 dark:text-slate-400">
+                  <div className="flex flex-col items-center gap-8">
+                    <h2 className="text-4xl font-bold">About the Authors</h2>
+                    <p className="text-lg text-slate-500 dark:text-slate-400">
                       This Droplet was written by:
                     </p>
                     <div className="flex flex-wrap justify-center gap-4">
@@ -398,10 +405,10 @@ export function PresentationShell({
                             key={i}
                             className="flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-100/50 px-5 py-3 dark:border-slate-700 dark:bg-slate-800/50"
                           >
-                            <div className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-sky-300 text-sm font-semibold text-sky-600 dark:border-sky-500 dark:text-sky-400">
+                            <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-sky-300 text-base font-semibold text-sky-600 dark:border-sky-500 dark:text-sky-400">
                               {initials}
                             </div>
-                            <span className="text-base text-slate-700 dark:text-slate-200">
+                            <span className="text-lg text-slate-700 dark:text-slate-200">
                               {author.firstName} {author.lastName}
                             </span>
                           </div>
@@ -418,10 +425,10 @@ export function PresentationShell({
                   .trim();
                 return (
                   <div className="flex flex-col items-center gap-4">
-                    <p className="text-sm font-medium tracking-widest text-sky-500/70 uppercase">
+                    <p className="text-base font-medium tracking-widest text-sky-500/70 uppercase">
                       Lesson
                     </p>
-                    <h1 className="text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
+                    <h1 className="text-5xl font-bold tracking-tight sm:text-6xl md:text-7xl">
                       {titleText}
                     </h1>
                     <div className="mt-2 h-0.5 w-16 rounded-full bg-sky-400/40" />
@@ -511,6 +518,52 @@ export function PresentationShell({
                 );
               }
 
+              // Two-column layout
+              if (layout === "two-columns") {
+                // Single pass: split content blocks at the first column-break
+                const leftBlocks: typeof allBlocks = [];
+                const rightBlocks: typeof allBlocks = [];
+                let foundBreak = false;
+                for (const b of allBlocks) {
+                  if (!foundBreak && isColumnBreak(b)) {
+                    foundBreak = true;
+                    continue;
+                  }
+                  if (isColumnBreak(b)) continue;
+                  (foundBreak ? rightBlocks : leftBlocks).push(b);
+                }
+                // Fallback: no column-break found, split at midpoint
+                if (!foundBreak && leftBlocks.length > 1) {
+                  const mid = Math.ceil(leftBlocks.length / 2);
+                  rightBlocks.push(...leftBlocks.splice(mid));
+                }
+
+                if (leftBlocks.length > 0 && rightBlocks.length > 0) {
+                  const columnClass =
+                    "flex max-h-[85vh] min-w-0 basis-1/2 flex-col space-y-4 overflow-y-auto [&_img]:max-h-[40vh] [&_img]:w-auto [&_img]:object-contain [&_pre]:max-h-[55vh] [&_pre]:overflow-y-auto";
+                  return (
+                    <div className="flex w-full max-w-5xl items-start gap-8 text-left">
+                      <div className={columnClass}>
+                        {leftBlocks.map((block, idx) => (
+                          <PresentationBlockRenderer
+                            key={`${currentSlideKey}-left-${idx}`}
+                            block={block}
+                          />
+                        ))}
+                      </div>
+                      <div className={columnClass}>
+                        {rightBlocks.map((block, idx) => (
+                          <PresentationBlockRenderer
+                            key={`${currentSlideKey}-right-${idx}`}
+                            block={block}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  );
+                }
+              }
+
               // Default layout
               return (
                 <div className="w-full max-w-4xl text-left">
@@ -526,7 +579,7 @@ export function PresentationShell({
               );
             })()
           ) : (
-            <p className="text-xl text-slate-400 dark:text-slate-500">
+            <p className="text-2xl text-slate-400 dark:text-slate-500">
               Empty slide
             </p>
           )}
@@ -540,7 +593,7 @@ export function PresentationShell({
           className="fixed top-1/2 left-3 z-[102] -translate-y-1/2 p-2 text-slate-300 transition hover:text-slate-500 dark:text-slate-600 dark:hover:text-slate-300"
           aria-label="Previous slide"
         >
-          <ChevronLeftIcon className="h-10 w-10" strokeWidth={1.5} />
+          <ChevronLeftIcon className="h-12 w-12" strokeWidth={1.5} />
         </button>
       )}
       {nav.canGoNext && (
@@ -549,12 +602,12 @@ export function PresentationShell({
           className="fixed top-1/2 right-3 z-[102] -translate-y-1/2 p-2 text-slate-300 transition hover:text-slate-500 dark:text-slate-600 dark:hover:text-slate-300"
           aria-label="Next slide"
         >
-          <ChevronRightIcon className="h-10 w-10" strokeWidth={1.5} />
+          <ChevronRightIcon className="h-12 w-12" strokeWidth={1.5} />
         </button>
       )}
 
       {/* ── Slide number (bottom-right) ── */}
-      <div className="fixed right-4 bottom-3 z-[102] text-xs text-slate-400 tabular-nums dark:text-slate-500">
+      <div className="fixed right-4 bottom-3 z-[102] text-sm text-slate-400 tabular-nums dark:text-slate-500">
         {nav.globalSlideNumber} / {nav.totalGlobalSlides}
       </div>
 
@@ -563,7 +616,7 @@ export function PresentationShell({
         !isEndSlide &&
         currentSlide &&
         currentSlide.lessonIndex >= 0 && (
-          <div className="fixed bottom-3 left-4 z-[102] max-w-[40%] truncate text-xs text-slate-400 dark:text-slate-600">
+          <div className="fixed bottom-3 left-4 z-[102] max-w-[40%] truncate text-sm text-slate-400 dark:text-slate-600">
             Lesson {currentSlide.lessonIndex + 1}: {currentSlide.lessonName}
           </div>
         )}
@@ -578,7 +631,7 @@ export function PresentationShell({
 
       {/* ── Lesson dots ── */}
       {titleSlideArray.length > 2 && (
-        <div className="fixed inset-x-0 bottom-4 z-[102] flex justify-center">
+        <div className="fixed inset-x-0 bottom-5 z-[102] flex justify-center">
           <div className="flex items-center gap-1">
             {titleSlideArray.map((_, idx) => (
               <button

--- a/frontend/components/presentation/utils.ts
+++ b/frontend/components/presentation/utils.ts
@@ -7,12 +7,14 @@
 import { Block, Lesson } from "@/types";
 import { convertBlockNoteToV1Blocks } from "@/lib/blocknote/convert-blocks";
 import { SLIDE_BREAK_MARKER } from "@/lib/blocknote/slide-break";
+import { COLUMN_BREAK_MARKER } from "@/lib/blocknote/column-break";
 
 export type SlideLayout =
   | "default"
   | "image-left"
   | "image-right"
-  | "full-image";
+  | "full-image"
+  | "two-columns";
 
 export type Slide = {
   blocks: Block[];
@@ -34,6 +36,13 @@ function isSlideBreak(block: Block): boolean {
   return (
     block.__component === "droplets.generic" &&
     block.content === SLIDE_BREAK_MARKER
+  );
+}
+
+export function isColumnBreak(block: Block): boolean {
+  return (
+    block.__component === "droplets.generic" &&
+    block.content === COLUMN_BREAK_MARKER
   );
 }
 
@@ -95,7 +104,7 @@ export function splitBlocksIntoSlides(
       : lesson.blocks ?? [];
 
   const cleanBlocks = rawBlocks.filter(
-    (b) => !isEmptySpacing(b) && !isSlideBreak(b),
+    (b) => !isEmptySpacing(b) && !isSlideBreak(b) && !isColumnBreak(b),
   );
   if (cleanBlocks.length === 0) return [];
 
@@ -132,6 +141,8 @@ function splitByMarkers(
   let heading: string | undefined;
   let currentLayout: SlideLayout = "default";
   let currentLayoutImageUrl: string | undefined;
+  // Layout requested by the slide-break block for the NEXT slide
+  let pendingLayout: SlideLayout | undefined;
 
   function flush() {
     if (current.length > 0) {
@@ -145,8 +156,14 @@ function splitByMarkers(
       });
       current = [];
       heading = undefined;
-      currentLayout = "default";
+      currentLayout = pendingLayout ?? "default";
       currentLayoutImageUrl = undefined;
+      pendingLayout = undefined;
+    } else if (pendingLayout !== undefined) {
+      // No blocks accumulated yet, but a pending layout was set by a slide break.
+      // Apply it now so the upcoming blocks inherit this layout.
+      currentLayout = pendingLayout;
+      pendingLayout = undefined;
     }
   }
 
@@ -154,11 +171,18 @@ function splitByMarkers(
     if (isEmptySpacing(block)) continue;
 
     if (isSlideBreak(block)) {
+      // Read the nextSlideLayout from the slide-break block
+      const layout =
+        block.__component === "droplets.generic" && "nextSlideLayout" in block
+          ? (block.nextSlideLayout as SlideLayout | undefined)
+          : undefined;
+      pendingLayout = layout && layout !== "default" ? layout : undefined;
       flush();
       continue;
     }
 
-    // Read layout from typed property or legacy comment — block stays in the array
+    // Read layout from typed property or legacy comment — image layout takes
+    // precedence over the slide-break's nextSlideLayout
     const parsedLayout = getSlideLayout(block);
     if (parsedLayout) {
       currentLayout = parsedLayout.layout;

--- a/frontend/components/ui/blocknote/blocks/column-break-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/column-break-block.tsx
@@ -1,0 +1,36 @@
+import { createReactBlockSpec } from "@blocknote/react";
+import { Columns2 } from "lucide-react";
+import { COLUMN_BREAK_TYPE } from "@/lib/blocknote/column-break";
+
+/**
+ * Column Break block for BlockNote.
+ * A subtle visual marker that indicates where content should split into
+ * left and right columns in presentation mode two-column slides.
+ *
+ * Intentionally minimal compared to SlideBreak — no interactivity,
+ * no gradient backgrounds, no toggle buttons. Just a thin dotted line
+ * with a small muted label.
+ */
+export const ColumnBreak = createReactBlockSpec(
+  {
+    type: COLUMN_BREAK_TYPE,
+    propSchema: {},
+    content: "none",
+  },
+  {
+    render: () => {
+      return (
+        <div className="pointer-events-none my-1 w-full select-none">
+          <div className="flex items-center gap-2">
+            <div className="flex-1 border-t border-dotted border-slate-300 dark:border-slate-600" />
+            <div className="flex items-center gap-1 text-[10px] font-medium tracking-wider text-slate-400 uppercase dark:text-slate-500">
+              <Columns2 className="h-2.5 w-2.5" />
+              Column Break
+            </div>
+            <div className="flex-1 border-t border-dotted border-slate-300 dark:border-slate-600" />
+          </div>
+        </div>
+      );
+    },
+  },
+);

--- a/frontend/components/ui/blocknote/blocks/slide-break-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/slide-break-block.tsx
@@ -1,24 +1,42 @@
 import { createReactBlockSpec } from "@blocknote/react";
-import { SeparatorHorizontal } from "lucide-react";
+import { Columns2Icon, SeparatorHorizontal } from "lucide-react";
 import { dashedLineStyle, SLIDE_BREAK_TYPE } from "@/lib/blocknote/slide-break";
 import { useSlideOverflow } from "@/components/draft/lesson/blocknote-editor-client";
+import { cn } from "@/lib/utils";
 
 /**
  * Slide Break block for BlockNote.
  * A visual divider that marks where a new presentation slide begins.
  * In the editor, it renders as a dashed line with a "Slide Break" label.
  * In presentation mode, the splitter uses these markers to create new slides.
+ *
+ * The optional `nextSlideLayout` prop controls the layout of the slide that
+ * follows this break. Set to "two-columns" to split content into two columns.
  */
 export const SlideBreak = createReactBlockSpec(
   {
     type: SLIDE_BREAK_TYPE,
-    propSchema: {},
+    propSchema: {
+      nextSlideLayout: {
+        default: "default" as const,
+        values: ["default", "two-columns"] as const,
+      },
+    },
     content: "none",
   },
   {
     render: (props) => {
       const overflowingBreaks = useSlideOverflow();
       const isOverflowing = overflowingBreaks.has(props.block.id);
+      const isTwoColumns = props.block.props.nextSlideLayout === "two-columns";
+
+      function toggleLayout() {
+        props.editor.updateBlock(props.block, {
+          props: {
+            nextSlideLayout: isTwoColumns ? "default" : "two-columns",
+          },
+        });
+      }
 
       return (
         <div className="pointer-events-none my-2 w-full select-none">
@@ -27,6 +45,26 @@ export const SlideBreak = createReactBlockSpec(
           <div className="flex items-center justify-center gap-2 py-0.5 text-xs font-semibold tracking-widest text-sky-400 uppercase dark:text-sky-500">
             <SeparatorHorizontal className="h-3 w-3" />
             Slide Break
+          </div>
+          <div className="pointer-events-auto flex items-center justify-center py-1">
+            <button
+              type="button"
+              onClick={toggleLayout}
+              className={cn(
+                "flex items-center gap-1.5 rounded px-2 py-0.5 text-xs font-medium transition-colors",
+                isTwoColumns
+                  ? "bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300"
+                  : "text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-400",
+              )}
+              title={
+                isTwoColumns
+                  ? "Next slide: two columns (click to revert)"
+                  : "Set next slide to two-column layout"
+              }
+            >
+              <Columns2Icon className="h-3 w-3" />
+              {isTwoColumns ? "Two Columns" : "Single Column"}
+            </button>
           </div>
           <div className="h-3 w-full bg-gradient-to-t from-sky-50/40 to-transparent dark:from-sky-950/20" />
           <div style={dashedLineStyle} />

--- a/frontend/components/ui/blocknote/editor/slash-menu-config.ts
+++ b/frontend/components/ui/blocknote/editor/slash-menu-config.ts
@@ -4,7 +4,7 @@ import { createElement } from "react";
 import type { ReactElement } from "react";
 import type { CustomBlockNoteEditor } from "@/lib/blocknote/schema";
 import type { CalloutType } from "@/lib/blocknote/types";
-import { Code, Play, AppWindow } from "lucide-react";
+import { Code, Play, AppWindow, Columns2 } from "lucide-react";
 import {
   TriangleAlert,
   CircleHelp,
@@ -318,5 +318,24 @@ export const getSlideBreakSlashMenuItems = (
     aliases: ["slide", "break", "presentation", "page break", "divider"],
     group: "Presentation",
     subtext: "Start a new presentation slide",
+  },
+];
+
+export const getColumnBreakSlashMenuItems = (
+  editor: CustomBlockNoteEditor,
+): DefaultReactSuggestionItem[] => [
+  {
+    title: "Column Break",
+    icon: createElement(Columns2, { className: "h-4 w-4" }),
+    onItemClick: () => {
+      editor.insertBlocks(
+        [{ type: "column-break" }],
+        editor.getTextCursorPosition().block,
+        "after",
+      );
+    },
+    aliases: ["column", "col break", "split column", "column break"],
+    group: "Presentation",
+    subtext: "Split content between left and right columns",
   },
 ];

--- a/frontend/lib/blocknote/column-break.ts
+++ b/frontend/lib/blocknote/column-break.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared constants for the column break feature.
+ * Used by the block component, convert-blocks, utils, and presentation-shell.
+ */
+
+export const COLUMN_BREAK_MARKER = "<!--COLUMN_BREAK-->";
+
+export const COLUMN_BREAK_TYPE = "column-break" as const;

--- a/frontend/lib/blocknote/convert-blocks.ts
+++ b/frontend/lib/blocknote/convert-blocks.ts
@@ -6,6 +6,7 @@
 import katex from "katex";
 import { Block, CustomBlockNoteBlock } from "@/types";
 import { SLIDE_BREAK_MARKER } from "@/lib/blocknote/slide-break";
+import { COLUMN_BREAK_MARKER } from "@/lib/blocknote/column-break";
 
 type BlockNoteTextStyles = {
   bold?: boolean;
@@ -550,10 +551,23 @@ function convertSingleBlock(blockAny: any, blockIndex: number): Block | null {
     }
 
     case "slide-break": {
+      const nextSlideLayout = blockAny.props?.nextSlideLayout;
+      return {
+        __component: "droplets.generic" as const,
+        id: blockId,
+        content: SLIDE_BREAK_MARKER,
+        ...(nextSlideLayout &&
+          nextSlideLayout !== "default" && {
+            nextSlideLayout: nextSlideLayout as "default" | "two-columns",
+          }),
+      };
+    }
+
+    case "column-break": {
       return {
         __component: "droplets.generic",
         id: blockId,
-        content: SLIDE_BREAK_MARKER,
+        content: COLUMN_BREAK_MARKER,
       };
     }
 

--- a/frontend/lib/blocknote/schema.ts
+++ b/frontend/lib/blocknote/schema.ts
@@ -18,6 +18,7 @@ import { LatexBlock } from "@/components/ui/blocknote/blocks/latex-block";
 import { ImageBlock } from "@/components/ui/blocknote/blocks/image-block";
 import { CodeBlock } from "@/components/ui/blocknote/blocks/code-block";
 import { SlideBreak } from "@/components/ui/blocknote/blocks/slide-break-block";
+import { ColumnBreak } from "@/components/ui/blocknote/blocks/column-break-block";
 import { NotebookCodeBlock } from "@/components/ui/blocknote/blocks/notebook-code-block";
 import { SandpackBlock } from "@/components/ui/blocknote/blocks/sandpack-block";
 
@@ -143,6 +144,7 @@ export const blockNoteSchema = BlockNoteSchema.create({
     image: ImageBlock(),
     "code-block": CodeBlock(),
     "slide-break": SlideBreak(),
+    "column-break": ColumnBreak(),
     "notebook-code": NotebookCodeBlock(),
     "sandpack-block": SandpackBlock(),
   },

--- a/frontend/tests/components/presentation/utils.test.ts
+++ b/frontend/tests/components/presentation/utils.test.ts
@@ -1,6 +1,10 @@
-import { splitBlocksIntoSlides } from "@/components/presentation/utils";
+import {
+  splitBlocksIntoSlides,
+  isColumnBreak,
+} from "@/components/presentation/utils";
 import { SLIDE_BREAK_MARKER } from "@/lib/blocknote/slide-break";
-import type { Lesson } from "@/types";
+import { COLUMN_BREAK_MARKER } from "@/lib/blocknote/column-break";
+import { Lesson } from "@/types";
 
 function makeLessonV1(blocks: any[]): Lesson {
   return {
@@ -77,5 +81,197 @@ describe("splitBlocksIntoSlides", () => {
     expect(imageSlide).toBeDefined();
     expect(imageSlide!.layoutImageUrl).toBe("https://example.com/old.jpg");
     expect(imageSlide!.blocks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("creates a two-column slide when slide break has nextSlideLayout: two-columns", () => {
+    const lesson = makeLessonV1([
+      {
+        __component: "droplets.generic",
+        id: 1,
+        content: SLIDE_BREAK_MARKER,
+        nextSlideLayout: "two-columns",
+      },
+      {
+        __component: "droplets.generic",
+        id: 2,
+        content: "<p>Left content</p>",
+      },
+      {
+        __component: "droplets.generic",
+        id: 3,
+        content: "<p>Right content</p>",
+      },
+      { __component: "droplets.generic", id: 4, content: SLIDE_BREAK_MARKER },
+    ]);
+
+    const slides = splitBlocksIntoSlides(lesson, 0);
+    const twoColSlide = slides.find((s) => s.layout === "two-columns");
+    expect(twoColSlide).toBeDefined();
+    expect(twoColSlide!.blocks.length).toBe(2);
+  });
+
+  it("produces default layout when slide break has no nextSlideLayout", () => {
+    const lesson = makeLessonV1([
+      { __component: "droplets.generic", id: 1, content: SLIDE_BREAK_MARKER },
+      {
+        __component: "droplets.generic",
+        id: 2,
+        content: "<p>Some content</p>",
+      },
+      { __component: "droplets.generic", id: 3, content: SLIDE_BREAK_MARKER },
+    ]);
+
+    const slides = splitBlocksIntoSlides(lesson, 0);
+    // Skip the lesson title card (index 0)
+    const contentSlide = slides[1];
+    expect(contentSlide).toBeDefined();
+    expect(contentSlide!.layout).toBe("default");
+  });
+
+  it("image layout takes precedence over nextSlideLayout from slide break", () => {
+    const lesson = makeLessonV1([
+      {
+        __component: "droplets.generic",
+        id: 1,
+        content: SLIDE_BREAK_MARKER,
+        nextSlideLayout: "two-columns",
+      },
+      {
+        __component: "droplets.generic",
+        id: 2,
+        content: '<img src="https://example.com/img.jpg" alt="" />',
+        slideLayout: "image-right",
+        slideLayoutImageUrl: "https://example.com/img.jpg",
+      },
+      { __component: "droplets.generic", id: 3, content: SLIDE_BREAK_MARKER },
+    ]);
+
+    const slides = splitBlocksIntoSlides(lesson, 0);
+    // The image layout should win over the two-columns from the slide break
+    const imageSlide = slides.find((s) => s.layout === "image-right");
+    expect(imageSlide).toBeDefined();
+    expect(imageSlide!.layoutImageUrl).toBe("https://example.com/img.jpg");
+  });
+});
+
+describe("isColumnBreak", () => {
+  it("returns true for a droplets.generic block with COLUMN_BREAK_MARKER content", () => {
+    const block = {
+      __component: "droplets.generic" as const,
+      id: 1,
+      content: COLUMN_BREAK_MARKER,
+    };
+    expect(isColumnBreak(block)).toBe(true);
+  });
+
+  it("returns false for a slide-break block", () => {
+    const block = {
+      __component: "droplets.generic" as const,
+      id: 1,
+      content: SLIDE_BREAK_MARKER,
+    };
+    expect(isColumnBreak(block)).toBe(false);
+  });
+
+  it("returns false for a non-generic block component", () => {
+    const block = {
+      __component: "droplets.text" as any,
+      id: 1,
+      content: COLUMN_BREAK_MARKER,
+    };
+    expect(isColumnBreak(block)).toBe(false);
+  });
+});
+
+describe("splitBlocksIntoSlides — column-break behavior", () => {
+  it("column-break block passes through into the slide's blocks array (not a slide boundary)", () => {
+    const lesson = makeLessonV1([
+      {
+        __component: "droplets.generic",
+        id: 1,
+        content: SLIDE_BREAK_MARKER,
+        nextSlideLayout: "two-columns",
+      },
+      { __component: "droplets.generic", id: 2, content: "<p>Left</p>" },
+      { __component: "droplets.generic", id: 3, content: COLUMN_BREAK_MARKER },
+      { __component: "droplets.generic", id: 4, content: "<p>Right</p>" },
+      { __component: "droplets.generic", id: 5, content: SLIDE_BREAK_MARKER },
+    ]);
+
+    const slides = splitBlocksIntoSlides(lesson, 0);
+    const twoColSlide = slides.find((s) => s.layout === "two-columns");
+    expect(twoColSlide).toBeDefined();
+    // All 3 blocks (left content, column-break, right content) are in the same slide
+    expect(twoColSlide!.blocks.length).toBe(3);
+    // The column-break block is preserved in the slide's blocks array
+    const hasColumnBreak = twoColSlide!.blocks.some(
+      (b) => b.content === COLUMN_BREAK_MARKER,
+    );
+    expect(hasColumnBreak).toBe(true);
+  });
+
+  it("column-break does NOT split the slide into two separate slides", () => {
+    const lesson = makeLessonV1([
+      {
+        __component: "droplets.generic",
+        id: 1,
+        content: SLIDE_BREAK_MARKER,
+        nextSlideLayout: "two-columns",
+      },
+      { __component: "droplets.generic", id: 2, content: "<p>Left</p>" },
+      { __component: "droplets.generic", id: 3, content: COLUMN_BREAK_MARKER },
+      { __component: "droplets.generic", id: 4, content: "<p>Right</p>" },
+      { __component: "droplets.generic", id: 5, content: SLIDE_BREAK_MARKER },
+    ]);
+
+    const slides = splitBlocksIntoSlides(lesson, 0);
+    // Should only have: lesson title card + 1 two-column slide (not 3 slides)
+    expect(slides.length).toBe(2);
+  });
+
+  it("column-break-only slide produces no slides (filtered from cleanBlocks)", () => {
+    const lesson = makeLessonV1([
+      { __component: "droplets.generic", id: 1, content: SLIDE_BREAK_MARKER },
+      { __component: "droplets.generic", id: 2, content: COLUMN_BREAK_MARKER },
+      { __component: "droplets.generic", id: 3, content: SLIDE_BREAK_MARKER },
+    ]);
+
+    // cleanBlocks filters out both slide-break and column-break blocks,
+    // so the lesson appears empty and returns no slides
+    const slides = splitBlocksIntoSlides(lesson, 0);
+    expect(slides.length).toBe(0);
+  });
+
+  it("column-break is filtered from cleanBlocks (does not count as real content)", () => {
+    // A lesson where the only non-marker blocks are column-breaks should return no slides
+    const lesson = makeLessonV1([
+      { __component: "droplets.generic", id: 1, content: COLUMN_BREAK_MARKER },
+    ]);
+
+    const slides = splitBlocksIntoSlides(lesson, 0);
+    expect(slides.length).toBe(0);
+  });
+
+  it("multiple column-breaks in one slide all pass through into blocks array", () => {
+    const lesson = makeLessonV1([
+      {
+        __component: "droplets.generic",
+        id: 1,
+        content: SLIDE_BREAK_MARKER,
+        nextSlideLayout: "two-columns",
+      },
+      { __component: "droplets.generic", id: 2, content: "<p>Block A</p>" },
+      { __component: "droplets.generic", id: 3, content: COLUMN_BREAK_MARKER },
+      { __component: "droplets.generic", id: 4, content: "<p>Block B</p>" },
+      { __component: "droplets.generic", id: 5, content: COLUMN_BREAK_MARKER },
+      { __component: "droplets.generic", id: 6, content: "<p>Block C</p>" },
+      { __component: "droplets.generic", id: 7, content: SLIDE_BREAK_MARKER },
+    ]);
+
+    const slides = splitBlocksIntoSlides(lesson, 0);
+    const twoColSlide = slides.find((s) => s.layout === "two-columns");
+    expect(twoColSlide).toBeDefined();
+    // 3 content blocks + 2 column-break markers = 5 blocks in the slide
+    expect(twoColSlide!.blocks.length).toBe(5);
   });
 });

--- a/frontend/tests/components/ui/blocknote/editor/slash-menu-config.test.tsx
+++ b/frontend/tests/components/ui/blocknote/editor/slash-menu-config.test.tsx
@@ -16,13 +16,14 @@ jest.mock("@/lib/blocknote/schema", () => ({
 }));
 
 jest.mock("@/lib/blocknote/types", () => ({
-  CalloutType: {} as any,
+  CalloutType: {},
 }));
 
 import {
   getCalloutSlashMenuItems,
   getQuizSlashMenuItems,
   getSandpackSlashMenuItems,
+  getColumnBreakSlashMenuItems,
 } from "@/components/ui/blocknote/editor/slash-menu-config";
 
 // Mock BlockNote editor
@@ -197,6 +198,53 @@ describe("getQuizSlashMenuItems", () => {
             ]),
           }),
         }),
+      ]),
+      expect.anything(),
+      "after",
+    );
+  });
+});
+
+describe("getColumnBreakSlashMenuItems", () => {
+  it("returns an array with one item titled 'Column Break'", () => {
+    const editor = createMockEditor();
+    const items = getColumnBreakSlashMenuItems(editor);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("Column Break");
+  });
+
+  it("has correct aliases including 'column' and 'col break'", () => {
+    const editor = createMockEditor();
+    const items = getColumnBreakSlashMenuItems(editor);
+
+    expect(items[0].aliases).toContain("column");
+    expect(items[0].aliases).toContain("col break");
+  });
+
+  it("belongs to the Presentation group", () => {
+    const editor = createMockEditor();
+    const items = getColumnBreakSlashMenuItems(editor);
+
+    expect(items[0].group).toBe("Presentation");
+  });
+
+  it("has an icon defined", () => {
+    const editor = createMockEditor();
+    const items = getColumnBreakSlashMenuItems(editor);
+
+    expect(items[0].icon).toBeDefined();
+  });
+
+  it("calls editor.insertBlocks with column-break type on click", () => {
+    const editor = createMockEditor();
+    const items = getColumnBreakSlashMenuItems(editor);
+
+    items[0].onItemClick?.();
+
+    expect(editor.insertBlocks).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "column-break" }),
       ]),
       expect.anything(),
       "after",

--- a/frontend/types/index.d.ts
+++ b/frontend/types/index.d.ts
@@ -139,7 +139,8 @@ export type Block =
       id?: number;
       sourceBlockIds?: number[]; // For grouped blocks - all source BlockNote block IDs
       _clientId?: string;
-      slideLayout?: "image-left" | "image-right" | "full-image";
+      slideLayout?: "image-left" | "image-right" | "full-image" | "two-columns";
+      nextSlideLayout?: "default" | "two-columns";
       slideLayoutImageUrl?: string;
     }
   | {


### PR DESCRIPTION
## Summary
- Increase font sizes across presentation mode for better projection readability
- Add confetti animation on end slide (lazy-loaded via next/dynamic)
- Add two-column layout toggle on slide-break blocks
- Add column-break block (`/column-break`) for explicit left/right content splitting
- General UI polish: spacing, arrow sizes, tag pills, author circles

## Test plan
- [ ] Open a droplet in presentation mode and verify larger text
- [ ] Navigate to end slide and confirm confetti fires
- [ ] Toggle a slide break to Two Columns and verify layout splits correctly
- [ ] Insert a `/column-break` between blocks and verify it controls the split point
- [ ] Verify fallback to midpoint split when no column-break is present
- [ ] Run `cd frontend && npm test` -- 36 new/updated tests pass

Closes ODY-387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dataset upload and management for droplets
  * Introduced presentation mode with slide breaks and auto-formatting
  * Added difficulty levels (beginner, intermediate, advanced) to droplets
  * Implemented responsive mobile-friendly admin interface
  * Added interactive code execution via Sandpack editor and notebook viewer
  * Enabled data exploration with interactive tables and summary statistics

* **Improvements**
  * Enhanced filtering capabilities across platform
  * Improved presentation slide overflow detection and warnings
  * Better dark mode styling consistency
  * More responsive chart visualizations

* **Bug Fixes**
  * Fixed email matching to be case-insensitive
  * Improved UI responsiveness on mobile devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->