### PR TITLE
Admin: add Voyages management tab to dashboard

### DIFF
--- a/frontend/app/(general)/admin/voyages/page.tsx
+++ b/frontend/app/(general)/admin/voyages/page.tsx
@@ -48,10 +48,11 @@ function TableSkeleton() {
       <div className="hidden overflow-hidden rounded-[8px] border-2 border-[rgba(0,0,0,0.05)] md:block dark:border-slate-700">
         <table className="w-full table-fixed">
           <colgroup>
-            <col className="w-[35%]" />
-            <col className="w-[15%]" />
+            <col className="w-[30%]" />
+            <col className="w-[12%]" />
             <col className="w-[10%]" />
-            <col className="w-[20%]" />
+            <col className="w-[10%]" />
+            <col className="w-[18%]" />
             <col className="w-[10%]" />
             <col className="w-[10%]" />
           </colgroup>
@@ -60,7 +61,8 @@ function TableSkeleton() {
               {[
                 "Name",
                 "Status",
-                "Islands",
+                "Nodes",
+                "Playlists",
                 "Author",
                 "Created",
                 "Actions",
@@ -83,7 +85,7 @@ function TableSkeleton() {
                 <td className="h-[56px] py-3 pr-6 pl-[30px]">
                   <div className="h-4 w-[180px] animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
                 </td>
-                {Array.from({ length: 5 }).map((__, j) => (
+                {Array.from({ length: 6 }).map((__, j) => (
                   <td key={j} className="h-[56px] px-6 py-3">
                     <div className="h-4 w-[50px] animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
                   </td>

--- a/frontend/components/admin/admin-nav.tsx
+++ b/frontend/components/admin/admin-nav.tsx
@@ -12,6 +12,7 @@ import {
   IconUsers,
   IconUserPlus,
   IconMessageReport,
+  IconCompass,
   type IconProps,
 } from "@tabler/icons-react";
 
@@ -26,7 +27,8 @@ export type AdminNavVariant =
   | "Requests"
   | "Access Manager"
   | "Creators Manager"
-  | "Reports";
+  | "Reports"
+  | "Voyages";
 
 // ——— Per-icon sub-components ———
 function NavIcon({
@@ -77,6 +79,9 @@ export function CreatorsManagerIcon({ active }: { active: boolean }) {
 export function ReportsIcon({ active }: { active: boolean }) {
   return <NavIcon Icon={IconMessageReport} active={active} />;
 }
+export function VoyagesIcon({ active }: { active: boolean }) {
+  return <NavIcon Icon={IconCompass} active={active} />;
+}
 
 // ——— Nav item definitions ———
 export const NAV_ITEMS: {
@@ -103,6 +108,12 @@ export const NAV_ITEMS: {
     variant: "Playlists",
     href: "/admin/playlists",
     Icon: PlaylistIcon,
+  },
+  {
+    label: "Voyages",
+    variant: "Voyages",
+    href: "/admin/voyages",
+    Icon: VoyagesIcon,
   },
   {
     label: "Groups",

--- a/frontend/components/admin/voyages/voyages-admin-page-client.tsx
+++ b/frontend/components/admin/voyages/voyages-admin-page-client.tsx
@@ -203,11 +203,7 @@ function VoyageTableRow({
 }
 
 // ——— VoyageMobileCard ———
-function VoyageMobileCard({
-  voyage,
-}: {
-  voyage: VoyageWithCounts;
-}) {
+function VoyageMobileCard({ voyage }: { voyage: VoyageWithCounts }) {
   const statusConfig = STATUS_CONFIG[voyage.status] ?? null;
 
   return (
@@ -251,7 +247,11 @@ function VoyageMobileCard({
 }
 
 // ——— Main Client Component ———
-export function VoyagesAdminPageClient({ voyages: initialVoyages }: { voyages: Voyage[] }) {
+export function VoyagesAdminPageClient({
+  voyages: initialVoyages,
+}: {
+  voyages: Voyage[];
+}) {
   const [voyages, setVoyages] = useState<Voyage[]>(initialVoyages);
   const [deletingId, setDeletingId] = useState<number | null>(null);
 
@@ -282,10 +282,14 @@ export function VoyagesAdminPageClient({ voyages: initialVoyages }: { voyages: V
     searchFn: (v, q) => v.name.toLowerCase().includes(q),
     sortFn: (items, sort) => {
       const sorted = [...items];
-      if (sort === "name-asc") sorted.sort((a, b) => a.name.localeCompare(b.name));
-      else if (sort === "name-desc") sorted.sort((a, b) => b.name.localeCompare(a.name));
-      else if (sort === "nodes-asc") sorted.sort((a, b) => a.nodeCount - b.nodeCount);
-      else if (sort === "nodes-desc") sorted.sort((a, b) => b.nodeCount - a.nodeCount);
+      if (sort === "name-asc")
+        sorted.sort((a, b) => a.name.localeCompare(b.name));
+      else if (sort === "name-desc")
+        sorted.sort((a, b) => b.name.localeCompare(a.name));
+      else if (sort === "nodes-asc")
+        sorted.sort((a, b) => a.nodeCount - b.nodeCount);
+      else if (sort === "nodes-desc")
+        sorted.sort((a, b) => b.nodeCount - a.nodeCount);
       return sorted;
     },
     filterFn: (v, statuses) => statuses.includes(v.status),

--- a/frontend/components/admin/voyages/voyages-admin-page-client.tsx
+++ b/frontend/components/admin/voyages/voyages-admin-page-client.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { Voyage } from "@/types";
+import { Voyage, VoyagePlaylist } from "@/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { deleteVoyage } from "@/lib/requests/voyage";
@@ -15,6 +15,16 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useAdminTableFilters } from "@/hooks/use-admin-table-filters";
+import { SearchBar } from "@/components/admin/search-bar";
+import { SortButton } from "@/components/admin/sort-button";
+import { FilterButton } from "@/components/admin/filter-button";
+import {
+  AdminTable,
+  type AdminColumnDef,
+} from "@/components/admin/admin-table";
+import { SortRadioGroup } from "@/components/admin/sort-radio-group";
+import { FilterCheckboxGroup } from "@/components/admin/filter-checkbox-group";
 
 const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
   published: {
@@ -27,23 +37,269 @@ const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
   },
 };
 
-interface VoyagesAdminPageClientProps {
-  voyages: Voyage[];
+const VOYAGE_COLUMNS: AdminColumnDef[] = [
+  { label: "Name", width: "w-[30%]" },
+  { label: "Status", width: "w-[12%]" },
+  { label: "Nodes", width: "w-[10%]" },
+  { label: "Playlists", width: "w-[10%]" },
+  { label: "Author", width: "w-[18%]" },
+  { label: "Created", width: "w-[10%]" },
+  { label: "Actions", width: "w-[10%]" },
+];
+
+const DEFAULT_SORT = "name-asc";
+
+const SORT_GROUPS = [
+  {
+    header: "Name",
+    options: [
+      { value: "name-asc", label: "A\u2013Z" },
+      { value: "name-desc", label: "Z\u2013A" },
+    ],
+  },
+  {
+    header: "Nodes",
+    options: [
+      { value: "nodes-asc", label: "Ascending" },
+      { value: "nodes-desc", label: "Descending" },
+    ],
+  },
+] as const;
+
+const FILTER_STATUS_OPTIONS = [
+  { value: "published", label: "Published" },
+  { value: "draft", label: "Draft" },
+] as const;
+
+interface VoyageWithCounts extends Voyage {
+  nodeCount: number;
+  playlistCount: number;
+  dropletCount: number;
+  authorName: string;
 }
 
-export function VoyagesAdminPageClient({
-  voyages: initialVoyages,
-}: VoyagesAdminPageClientProps) {
-  const [search, setSearch] = useState("");
-  const [deletingId, setDeletingId] = useState<number | null>(null);
-  const [voyages, setVoyages] = useState<Voyage[]>(initialVoyages);
+function computeCounts(voyage: Voyage): VoyageWithCounts {
+  const nodeCount = voyage.voyage_nodes?.length ?? 0;
+  const playlistCount = voyage.voyage_playlists?.length ?? 0;
+  const dropletCount =
+    voyage.voyage_playlists?.reduce(
+      (acc: number, vp: VoyagePlaylist) =>
+        acc + (vp.playlist?.droplets?.length ?? 0),
+      0,
+    ) ?? 0;
+  const authorName =
+    voyage.authors && voyage.authors.length > 0
+      ? voyage.authors
+          .map((a) => {
+            if (a && typeof a === "object") {
+              if ("firstName" in a && a.firstName) return a.firstName;
+              if ("name" in a && a.name) return a.name as string;
+              if ("email" in a) return a.email;
+            }
+            return "Unknown";
+          })
+          .join(", ")
+      : "\u2014";
 
-  const filtered = useMemo(() => {
-    if (!search.trim()) return voyages;
-    return voyages.filter((v) =>
-      v.name.toLowerCase().includes(search.toLowerCase()),
-    );
-  }, [voyages, search]);
+  return { ...voyage, nodeCount, playlistCount, dropletCount, authorName };
+}
+
+// ——— VoyageTableRow ———
+function VoyageTableRow({
+  voyage,
+  onDelete,
+  isDeleting,
+}: {
+  voyage: VoyageWithCounts;
+  onDelete: (id: number) => void;
+  isDeleting: boolean;
+}) {
+  const statusConfig = STATUS_CONFIG[voyage.status] ?? null;
+
+  return (
+    <tr className="border-b border-[#eaecf0] transition-colors hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800/50">
+      <td className="h-[56px] py-3 pr-6 pl-[30px]">
+        <Link
+          href={`/v/${voyage.slug}`}
+          prefetch={false}
+          className="truncate text-[16px] font-medium text-[#101828] underline hover:text-[#2D7597] dark:text-white"
+        >
+          {voyage.name}
+        </Link>
+      </td>
+
+      <td className="h-[56px] px-6 py-[11px]">
+        {statusConfig ? (
+          <Badge
+            variant="outline"
+            className={cn(
+              "rounded-[16px] px-[9px] py-[4px] text-[14px] leading-[18px] font-medium",
+              statusConfig.className,
+            )}
+          >
+            {statusConfig.label}
+          </Badge>
+        ) : (
+          <span className="text-sm text-slate-400">&mdash;</span>
+        )}
+      </td>
+
+      <td className="h-[56px] px-6 py-3">
+        <span className="text-[16px] text-[#101828] dark:text-white">
+          {voyage.nodeCount}
+        </span>
+      </td>
+
+      <td className="h-[56px] px-6 py-3">
+        <span className="text-[16px] text-[#101828] dark:text-white">
+          {voyage.playlistCount}
+        </span>
+      </td>
+
+      <td className="h-[56px] px-6 py-3">
+        <span className="truncate text-[16px] text-[#101828] dark:text-white">
+          {voyage.authorName}
+        </span>
+      </td>
+
+      <td className="h-[56px] px-6 py-3">
+        <span className="text-[16px] text-[#101828] dark:text-white">
+          {voyage.createdAt
+            ? new Date(voyage.createdAt).toLocaleDateString()
+            : "\u2014"}
+        </span>
+      </td>
+
+      <td className="h-[56px] px-6 py-3">
+        <TooltipProvider delayDuration={300}>
+          <div className="flex items-center gap-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label="view voyage"
+                  className="h-8 w-8 p-0"
+                  asChild
+                >
+                  <Link href={`/v/${voyage.slug}`} prefetch={false}>
+                    <IconPencil className="h-4 w-4 text-sky-600" />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>View voyage</TooltipContent>
+            </Tooltip>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label="delete voyage"
+                  className="h-8 w-8 p-0"
+                  onClick={() => onDelete(voyage.id)}
+                  disabled={isDeleting}
+                >
+                  <IconTrash className="h-4 w-4 text-red-500" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Delete voyage</TooltipContent>
+            </Tooltip>
+          </div>
+        </TooltipProvider>
+      </td>
+    </tr>
+  );
+}
+
+// ——— VoyageMobileCard ———
+function VoyageMobileCard({
+  voyage,
+}: {
+  voyage: VoyageWithCounts;
+}) {
+  const statusConfig = STATUS_CONFIG[voyage.status] ?? null;
+
+  return (
+    <Link
+      href={`/v/${voyage.slug}`}
+      prefetch={false}
+      className="block w-full rounded-xl border border-[#e2e8f0] bg-white p-3 text-left transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800/50"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <p className="min-w-0 truncate text-sm font-semibold text-[#101828] dark:text-white">
+          {voyage.name}
+        </p>
+        <span className="shrink-0 text-slate-400">&#8250;</span>
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        {statusConfig && (
+          <Badge
+            variant="outline"
+            className={cn(
+              "rounded-full px-2 py-0.5 text-xs font-medium",
+              statusConfig.className,
+            )}
+          >
+            {statusConfig.label}
+          </Badge>
+        )}
+        <span className="text-xs text-[#667085] dark:text-slate-400">
+          {voyage.nodeCount} node{voyage.nodeCount !== 1 && "s"}
+        </span>
+        <span className="text-xs text-slate-300 dark:text-slate-600">|</span>
+        <span className="text-xs text-[#667085] dark:text-slate-400">
+          {voyage.playlistCount} playlist{voyage.playlistCount !== 1 && "s"}
+        </span>
+        <span className="text-xs text-slate-300 dark:text-slate-600">|</span>
+        <span className="text-xs text-[#667085] dark:text-slate-400">
+          {voyage.dropletCount} droplet{voyage.dropletCount !== 1 && "s"}
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+// ——— Main Client Component ———
+export function VoyagesAdminPageClient({ voyages: initialVoyages }: { voyages: Voyage[] }) {
+  const [voyages, setVoyages] = useState<Voyage[]>(initialVoyages);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  const voyagesWithCounts = useMemo(
+    () => voyages.map(computeCounts),
+    [voyages],
+  );
+
+  const {
+    currentPage,
+    setCurrentPage,
+    totalPages,
+    pageItems: pageVoyages,
+    searchTerm,
+    handleSearch,
+    draftSortBy,
+    setDraftSortBy,
+    handleSortApply,
+    handleSortReset,
+    draftFilters,
+    toggleDraftFilter,
+    handleFilterApply,
+    handleFilterReset,
+    hasActiveFilters,
+  } = useAdminTableFilters<VoyageWithCounts>({
+    items: voyagesWithCounts,
+    defaultSort: DEFAULT_SORT,
+    searchFn: (v, q) => v.name.toLowerCase().includes(q),
+    sortFn: (items, sort) => {
+      const sorted = [...items];
+      if (sort === "name-asc") sorted.sort((a, b) => a.name.localeCompare(b.name));
+      else if (sort === "name-desc") sorted.sort((a, b) => b.name.localeCompare(a.name));
+      else if (sort === "nodes-asc") sorted.sort((a, b) => a.nodeCount - b.nodeCount);
+      else if (sort === "nodes-desc") sorted.sort((a, b) => b.nodeCount - a.nodeCount);
+      return sorted;
+    },
+    filterFn: (v, statuses) => statuses.includes(v.status),
+  });
 
   async function handleDelete(id: number) {
     if (!confirm("Are you sure you want to delete this voyage?")) return;
@@ -67,229 +323,60 @@ export function VoyagesAdminPageClient({
     <div className="space-y-4">
       {/* Controls */}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <input
-          type="text"
+        <SearchBar
           placeholder="Search voyages..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="h-[44px] w-full rounded-[30px] border border-slate-200 bg-white px-4 text-sm text-slate-800 placeholder:text-slate-400 focus:ring-2 focus:ring-slate-300 focus:outline-none sm:w-[560px] dark:border-slate-700 dark:bg-slate-900 dark:text-white"
+          value={searchTerm}
+          onChange={handleSearch}
+          className="max-w-[700px]"
         />
-        <Link href="/new/voyage">
-          <Button className="shrink-0">New Voyage</Button>
-        </Link>
+        <div className="flex items-center gap-2">
+          <SortButton onApply={handleSortApply} onReset={handleSortReset}>
+            <SortRadioGroup
+              groups={SORT_GROUPS}
+              value={draftSortBy}
+              onChange={setDraftSortBy}
+            />
+          </SortButton>
+
+          <FilterButton
+            onApply={handleFilterApply}
+            onReset={handleFilterReset}
+            hasActiveFilters={hasActiveFilters}
+          >
+            <FilterCheckboxGroup
+              options={FILTER_STATUS_OPTIONS}
+              selected={draftFilters}
+              onToggle={toggleDraftFilter}
+            />
+          </FilterButton>
+
+          <Link href="/new/voyage">
+            <Button className="shrink-0">New Voyage</Button>
+          </Link>
+        </div>
       </div>
 
-      {/* Mobile cards */}
-      <div className="flex flex-col gap-2 md:hidden">
-        {filtered.length === 0 ? (
-          <p className="py-8 text-center text-sm text-slate-500">
-            No voyages found.
-          </p>
-        ) : (
-          filtered.map((voyage) => {
-            const islandCount = voyage.voyage_playlists?.length ?? 0;
-            const statusConfig = STATUS_CONFIG[voyage.status] ?? null;
-
-            return (
-              <div
-                key={voyage.id}
-                className="rounded-xl border border-[#e2e8f0] bg-white p-3 dark:border-slate-700 dark:bg-slate-900"
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <Link
-                    href={`/v/${voyage.slug}`}
-                    className="min-w-0 truncate text-sm font-semibold text-[#101828] underline hover:text-[#2D7597] dark:text-white"
-                  >
-                    {voyage.name}
-                  </Link>
-                  {statusConfig && (
-                    <Badge
-                      variant="outline"
-                      className={cn(
-                        "shrink-0 rounded-full px-2 py-0.5 text-xs font-medium",
-                        statusConfig.className,
-                      )}
-                    >
-                      {statusConfig.label}
-                    </Badge>
-                  )}
-                </div>
-                <div className="mt-2 flex flex-wrap items-center gap-3">
-                  <span className="text-xs text-[#667085] dark:text-slate-400">
-                    {islandCount} island{islandCount !== 1 && "s"}
-                  </span>
-                  {voyage.createdAt && (
-                    <span className="text-xs text-[#667085] dark:text-slate-400">
-                      {new Date(voyage.createdAt).toLocaleDateString()}
-                    </span>
-                  )}
-                </div>
-              </div>
-            );
-          })
-        )}
-      </div>
-
-      {/* Desktop table */}
-      <div className="hidden overflow-hidden rounded-[8px] border-2 border-[rgba(0,0,0,0.05)] md:block dark:border-slate-700">
-        <table className="w-full table-fixed">
-          <colgroup>
-            <col className="w-[35%]" />
-            <col className="w-[15%]" />
-            <col className="w-[10%]" />
-            <col className="w-[20%]" />
-            <col className="w-[10%]" />
-            <col className="w-[10%]" />
-          </colgroup>
-          <thead>
-            <tr className="border-b border-[#eaecf0] bg-[#fcfcfd] dark:border-slate-700 dark:bg-slate-800">
-              {[
-                "Name",
-                "Status",
-                "Islands",
-                "Author",
-                "Created",
-                "Actions",
-              ].map((h) => (
-                <th
-                  key={h}
-                  className="h-[55px] px-6 py-3 text-left text-[16px] font-medium text-[#667085] first:pl-[30px] dark:text-slate-400"
-                >
-                  {h}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody className="bg-white dark:bg-slate-900">
-            {filtered.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={6}
-                  className="py-12 text-center text-sm text-slate-500"
-                >
-                  No voyages found.
-                </td>
-              </tr>
-            ) : (
-              filtered.map((voyage) => {
-                const islandCount = voyage.voyage_playlists?.length ?? 0;
-                const statusConfig = STATUS_CONFIG[voyage.status] ?? null;
-                const authorName =
-                  voyage.authors && voyage.authors.length > 0
-                    ? voyage.authors
-                        .map(
-                          (a) =>
-                            (a && typeof a === "object" && "name" in a
-                              ? a.name
-                              : null) ??
-                            (a && typeof a === "object" && "email" in a
-                              ? a.email
-                              : "Unknown"),
-                        )
-                        .join(", ")
-                    : "—";
-
-                return (
-                  <tr
-                    key={voyage.id}
-                    className="border-b border-[#eaecf0] transition-colors hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800/50"
-                  >
-                    {/* Name */}
-                    <td className="h-[56px] py-3 pr-6 pl-[30px]">
-                      <Link
-                        href={`/v/${voyage.slug}`}
-                        className="truncate text-[16px] font-medium text-[#101828] underline hover:text-[#2D7597] dark:text-white"
-                      >
-                        {voyage.name}
-                      </Link>
-                    </td>
-
-                    {/* Status */}
-                    <td className="h-[56px] px-6 py-[11px]">
-                      {statusConfig ? (
-                        <Badge
-                          variant="outline"
-                          className={cn(
-                            "rounded-[16px] px-[9px] py-[4px] text-[14px] leading-[18px] font-medium",
-                            statusConfig.className,
-                          )}
-                        >
-                          {statusConfig.label}
-                        </Badge>
-                      ) : (
-                        <span className="text-sm text-slate-400">&mdash;</span>
-                      )}
-                    </td>
-
-                    {/* Islands */}
-                    <td className="h-[56px] px-6 py-3">
-                      <span className="text-[16px] text-[#101828] dark:text-white">
-                        {islandCount}
-                      </span>
-                    </td>
-
-                    {/* Author */}
-                    <td className="h-[56px] px-6 py-3">
-                      <span className="truncate text-[16px] text-[#101828] dark:text-white">
-                        {authorName}
-                      </span>
-                    </td>
-
-                    {/* Created */}
-                    <td className="h-[56px] px-6 py-3">
-                      <span className="text-[16px] text-[#101828] dark:text-white">
-                        {voyage.createdAt
-                          ? new Date(voyage.createdAt).toLocaleDateString()
-                          : "—"}
-                      </span>
-                    </td>
-
-                    {/* Actions */}
-                    <td className="h-[56px] px-6 py-3">
-                      <TooltipProvider delayDuration={300}>
-                        <div className="flex items-center gap-2">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                aria-label="view voyage"
-                                className="h-8 w-8 p-0"
-                                asChild
-                              >
-                                <Link href={`/v/${voyage.slug}`}>
-                                  <IconPencil className="h-4 w-4 text-sky-600" />
-                                </Link>
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>View voyage</TooltipContent>
-                          </Tooltip>
-
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                aria-label="delete voyage"
-                                className="h-8 w-8 p-0"
-                                onClick={() => handleDelete(voyage.id)}
-                                disabled={deletingId === voyage.id}
-                              >
-                                <IconTrash className="h-4 w-4 text-red-500" />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>Delete voyage</TooltipContent>
-                          </Tooltip>
-                        </div>
-                      </TooltipProvider>
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
-      </div>
+      {/* Table */}
+      <AdminTable
+        columns={VOYAGE_COLUMNS}
+        isEmpty={pageVoyages.length === 0}
+        emptyMessage="No voyages found."
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={setCurrentPage}
+        mobileCards={pageVoyages.map((voyage) => (
+          <VoyageMobileCard key={voyage.id} voyage={voyage} />
+        ))}
+      >
+        {pageVoyages.map((voyage) => (
+          <VoyageTableRow
+            key={voyage.id}
+            voyage={voyage}
+            onDelete={handleDelete}
+            isDeleting={deletingId === voyage.id}
+          />
+        ))}
+      </AdminTable>
     </div>
   );
 }

--- a/frontend/components/admin/voyages/voyages-admin-page-client.tsx
+++ b/frontend/components/admin/voyages/voyages-admin-page-client.tsx
@@ -87,19 +87,9 @@ function computeCounts(voyage: Voyage): VoyageWithCounts {
         acc + (vp.playlist?.droplets?.length ?? 0),
       0,
     ) ?? 0;
-  const authorName =
-    voyage.authors && voyage.authors.length > 0
-      ? voyage.authors
-          .map((a) => {
-            if (a && typeof a === "object") {
-              if ("firstName" in a && a.firstName) return a.firstName;
-              if ("name" in a && a.name) return a.name as string;
-              if ("email" in a) return a.email;
-            }
-            return "Unknown";
-          })
-          .join(", ")
-      : "\u2014";
+  const authorName = voyage.authors?.length
+    ? voyage.authors.map((a) => a.firstName || a.email).join(", ")
+    : "\u2014";
 
   return { ...voyage, nodeCount, playlistCount, dropletCount, authorName };
 }

--- a/frontend/lib/requests/voyage.ts
+++ b/frontend/lib/requests/voyage.ts
@@ -102,7 +102,10 @@ export async function getVoyagesAdmin(): Promise<Voyage[]> {
         sort: ["orderIndex:asc"],
       },
       authors: {
-        fields: ["id", "name", "email"],
+        fields: ["id", "firstName", "lastName", "email"],
+      },
+      voyage_nodes: {
+        fields: ["id"],
       },
     },
     sort: ["name:asc"],

--- a/frontend/lib/requests/voyage.ts
+++ b/frontend/lib/requests/voyage.ts
@@ -89,20 +89,16 @@ export async function getVoyagesAdmin(): Promise<Voyage[]> {
     publicationState: "preview",
     populate: {
       voyage_playlists: {
+        fields: ["id"],
         populate: {
           playlist: {
-            fields: ["id", "name", "slug", "isPublic"],
-            populate: {
-              droplets: {
-                fields: ["id"],
-              },
-            },
+            fields: ["id"],
+            populate: { droplets: { fields: ["id"] } },
           },
         },
-        sort: ["orderIndex:asc"],
       },
       authors: {
-        fields: ["id", "firstName", "lastName", "email"],
+        fields: ["id", "firstName", "email"],
       },
       voyage_nodes: {
         fields: ["id"],


### PR DESCRIPTION
## Summary
- Added Voyages tab to admin sidebar navigation with compass icon
- Admin voyages table with search, sort (name/nodes), and filter (draft/published)
- Table columns: Name, Status, Nodes, Playlists, Author, Created, Actions (view/delete)
- Mobile responsive card view with status badges and counts
- Delete with confirmation dialog and toast feedback
- Uses shared AdminTable, SearchBar, SortButton, FilterButton components
- Trimmed getVoyagesAdmin() populate to only fetch needed fields

## Test plan
- [x] Navigate to /admin → Voyages tab appears in sidebar with compass icon
- [x] Click Voyages → table loads with all voyages
- [x] Search filters by name
- [x] Sort by name (A-Z/Z-A) and node count
- [x] Filter by status (draft/published)
- [x] Delete voyage shows confirmation, removes from table, shows toast
- [x] Mobile view renders card layout
- [x] 272 test suites / 3619 tests passing

ODY-397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Voyages" navigation option to the admin section for streamlined voyage management access.

* **UI/UX Improvements**
  * Restructured voyages admin table with new "Nodes" and "Playlists" columns for enhanced data visibility.
  * Enhanced table functionality with pagination support and improved search, sorting, and filtering controls.
  * Updated author field to display first name or email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->