### PR TITLE
Fix voyage form badges and branch dropdown layout

### DIFF
--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -416,8 +416,8 @@ export function VoyageForm({ playlists, authorId }: VoyageFormProps) {
                       {/* Bottom row: branch controls */}
                       <div className="flex flex-wrap items-center gap-3">
                         {/* "Branches from" select */}
-                        <div className="flex items-center gap-1.5">
-                          <label className="text-xs text-slate-500">
+                        <div className="flex flex-1 items-center gap-1.5">
+                          <label className="shrink-0 text-xs text-slate-500">
                             Branches from
                           </label>
                           <select
@@ -430,7 +430,7 @@ export function VoyageForm({ playlists, authorId }: VoyageFormProps) {
                               );
                             }}
                             disabled={isPending}
-                            className="max-w-[300px] min-w-[180px] rounded border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 focus:ring-1 focus:ring-slate-400 focus:outline-none disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
+                            className="w-full rounded border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 focus:ring-1 focus:ring-slate-400 focus:outline-none disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
                           >
                             <option value="">None (main path)</option>
                             {mainPathNodes

--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -355,7 +355,7 @@ export function VoyageForm({ playlists, authorId }: VoyageFormProps) {
                       <div className="flex items-center gap-2">
                         {/* Order badge (main path only) */}
                         {!isBranch && (
-                          <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-green-700 text-xs font-bold text-white">
+                          <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-[#297496] text-xs font-bold text-white">
                             {node.orderIndex + 1}
                           </div>
                         )}

--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -430,7 +430,7 @@ export function VoyageForm({ playlists, authorId }: VoyageFormProps) {
                               );
                             }}
                             disabled={isPending}
-                            className="rounded border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 focus:ring-1 focus:ring-slate-400 focus:outline-none disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
+                            className="max-w-[300px] min-w-[180px] rounded border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 focus:ring-1 focus:ring-slate-400 focus:outline-none disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
                           >
                             <option value="">None (main path)</option>
                             {mainPathNodes

--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -414,9 +414,9 @@ export function VoyageForm({ playlists, authorId }: VoyageFormProps) {
                       </div>
 
                       {/* Bottom row: branch controls */}
-                      <div className="flex flex-wrap items-center gap-3">
+                      <div className="flex flex-col gap-2">
                         {/* "Branches from" select */}
-                        <div className="flex flex-1 items-center gap-1.5">
+                        <div className="flex items-center gap-1.5">
                           <label className="shrink-0 text-xs text-slate-500">
                             Branches from
                           </label>


### PR DESCRIPTION
## Summary
- Changed step badges from green to Odyssey blue (#297496)
- Made "Branches from" dropdown full-width for long playlist names
- Stacked branch controls vertically (dropdown + type toggle) to prevent squeeze

## Test plan
- [x] Navigate to /new/voyage, add playlists — badges show Odyssey blue
- [x] Set a playlist as branch — dropdown shows full parent name, type toggle on its own line
- [x] 273 suites / 3634 tests passing

ODY-398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated order badge color styling for improved visual consistency
  * Reorganized branch controls layout to display vertically for clearer organization
  * Enhanced dropdown field width and spacing for better form usability and readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->