### PR TITLE
Fix green plus icon to Odyssey blue in voyage form

### DIFF
--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -327,7 +327,7 @@ export function VoyageForm({ playlists, authorId }: VoyageFormProps) {
                       <span className="text-xs">
                         {playlist.droplets?.length ?? 0} droplets
                       </span>
-                      <PlusIcon className="h-4 w-4 text-green-600" />
+                      <PlusIcon className="h-4 w-4 text-[#297496]" />
                     </div>
                   </button>
                 ))


### PR DESCRIPTION
## Summary
- Changed green plus icon in playlist search results to Odyssey blue (#297496)
- Follow-up to merged #813 which missed this instance

## Test plan
- [x] Navigate to /new/voyage, search playlists — plus icon shows Odyssey blue

ODY-398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the color scheme of an icon in the voyage form interface for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->