### PR TITLE
fix: voyage form auth, slug, search, redirect, and sequential toggle (ODY-400)

### DIFF
--- a/backend/src/api/voyage/content-types/voyage/schema.json
+++ b/backend/src/api/voyage/content-types/voyage/schema.json
@@ -23,6 +23,11 @@
       "relation": "manyToMany",
       "target": "api::authorized-user.authorized-user"
     },
+    "isSequential": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
     "voyage_playlists": {
       "type": "relation",
       "relation": "oneToMany",

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -1788,6 +1788,9 @@ export interface ApiVoyageVoyage extends Schema.CollectionType {
     > &
       Attribute.Private;
     description: Attribute.Text;
+    isSequential: Attribute.Boolean &
+      Attribute.Required &
+      Attribute.DefaultTo<false>;
     name: Attribute.String & Attribute.Required & Attribute.Unique;
     publishedAt: Attribute.DateTime;
     slug: Attribute.UID<'api::voyage.voyage', 'name'> & Attribute.Required;

--- a/frontend/app/(creation)/new/voyage/page.tsx
+++ b/frontend/app/(creation)/new/voyage/page.tsx
@@ -19,9 +19,7 @@ export default async function NewVoyage() {
   const [authUser, publicPlaylists] = await Promise.all([
     getCachedUser(user.email),
     getPlaylists({
-      filters: {
-        $and: [{ isPublic: true }],
-      },
+      filters: { isPublic: true },
       populate: {
         droplets: {
           fields: ["id"],

--- a/frontend/app/(voyages)/v/[slug]/page.tsx
+++ b/frontend/app/(voyages)/v/[slug]/page.tsx
@@ -66,9 +66,10 @@ export default async function VoyagePage({ params }: Props) {
         .filter((id): id is number => id !== undefined),
     );
   }
-  const nodeStatuses = isEnrolled
-    ? computeNodeStatuses(voyageNodes, completedNodeIds)
-    : new Map<number, "completed" | "available" | "locked">();
+  const nodeStatuses =
+    isEnrolled && voyage.isSequential
+      ? computeNodeStatuses(voyageNodes, completedNodeIds)
+      : new Map<number, "completed" | "available" | "locked">();
 
   // In preview mode (not enrolled), all nodes show as "available" so the tree is browsable
   const getNodeStatus = (

--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -40,6 +40,7 @@ export function VoyageForm({ playlists, authorId }: VoyageFormProps) {
   const [description, setDescription] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedNodes, setSelectedNodes] = useState<SelectedNode[]>([]);
+  const [isSequential, setIsSequential] = useState(false);
   const [error, setError] = useState("");
 
   const availablePlaylists = useMemo(
@@ -237,6 +238,7 @@ export function VoyageForm({ playlists, authorId }: VoyageFormProps) {
         name: name.trim(),
         description: description.trim() || undefined,
         status,
+        isSequential,
         nodes: selectedNodes.map((n) => ({
           playlistId: n.playlistId,
           isMainPath: n.isMainPath,
@@ -253,7 +255,7 @@ export function VoyageForm({ playlists, authorId }: VoyageFormProps) {
         return;
       }
 
-      router.push("/admin/voyages");
+      router.push(`/v/${result.data?.slug}`);
     });
   }
 
@@ -503,6 +505,25 @@ export function VoyageForm({ playlists, authorId }: VoyageFormProps) {
             {error}
           </p>
         )}
+
+        {/* Sequential progression toggle */}
+        <label className="flex items-center gap-3 rounded-lg border border-slate-200 px-4 py-3 dark:border-slate-700">
+          <input
+            type="checkbox"
+            checked={isSequential}
+            onChange={(e) => setIsSequential(e.target.checked)}
+            disabled={isPending}
+            className="h-4 w-4 rounded border-slate-300 text-[#297496] focus:ring-[#297496]"
+          />
+          <div>
+            <span className="text-sm font-medium text-slate-900 dark:text-white">
+              Sequential progression
+            </span>
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Lock islands until the previous one is completed
+            </p>
+          </div>
+        </label>
 
         {/* Action buttons */}
         <div className="flex gap-3">

--- a/frontend/lib/requests/user-populates.ts
+++ b/frontend/lib/requests/user-populates.ts
@@ -20,7 +20,9 @@ export const USER_POPULATES = {
   },
   profile: {
     fields: PROFILE_FIELDS,
-    populate: {},
+    populate: {
+      roles: { fields: ["id", "title"] },
+    },
   },
   social: {
     fields: PROFILE_FIELDS,

--- a/frontend/lib/requests/voyage.ts
+++ b/frontend/lib/requests/voyage.ts
@@ -346,6 +346,7 @@ export async function createVoyageWithNodes(data: {
   name: string;
   description?: string;
   status?: "draft" | "published";
+  isSequential?: boolean;
   authorId?: number;
   nodes: {
     playlistId: number;
@@ -361,10 +362,17 @@ export async function createVoyageWithNodes(data: {
   }
   try {
     // Phase 1: create the voyage record
+    const slug = data.name
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
     const voyageBody: Record<string, unknown> = {
       name: data.name,
+      slug,
       description: data.description ?? "",
       status: data.status ?? "draft",
+      isSequential: data.isSequential ?? false,
     };
     if (data.authorId) {
       voyageBody.authors = { connect: [data.authorId] };
@@ -392,7 +400,10 @@ export async function createVoyageWithNodes(data: {
       };
     }
 
-    const voyage = flattenAttributes(voyageData.data) as { id: number };
+    const voyage = flattenAttributes(voyageData.data) as {
+      id: number;
+      slug: string;
+    };
     const voyageId = voyage.id;
 
     // Phase 2: create voyage nodes — main path first, then branches

--- a/frontend/types/index.d.ts
+++ b/frontend/types/index.d.ts
@@ -468,6 +468,7 @@ export interface Voyage {
   slug: string;
   description: string;
   status: "draft" | "published";
+  isSequential: boolean;
   authors?: AuthorizedUser[];
   voyage_playlists?: VoyagePlaylist[];
   voyage_nodes?: VoyageNode[];


### PR DESCRIPTION
## Description

Multiple voyage form fixes and a new sequential progression option:

- **Unauthorized error on save/publish**: `getCachedUser()` wasn't populating `roles`, so `requireAdminOrFaculty()` always failed. Added `roles` to `USER_POPULATES.profile`.
- **"slug must be defined" error**: `createVoyageWithNodes` wasn't sending a `slug` to Strapi. Now generates one from the voyage name.
- **Redirect after creation**: Changed from `/admin/voyages` to `/v/{slug}` so creators land on the new voyage page.
- **Playlist search returning empty**: Simplified malformed `$and` filter to plain `{ isPublic: true }` in the new voyage page.
- **Sequential progression toggle**: Added `isSequential` boolean to Voyage schema, form, and view page. Creators can opt in to locking nodes sequentially (default: all open).

## Motivation and Context

The voyage creation form had several bugs preventing successful creation (auth check always failing, missing required slug field, broken playlist search filter). Additionally, all voyages forced sequential locked progression — this adds a toggle so creators can choose.

Closes ODY-400

## Screenshots (if appropriate):

N/A — form behavior fixes and a new checkbox toggle before the submit buttons.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.