### PR TITLE
logging for locking

### DIFF
--- a/backend/src/api/lesson/controllers/custom-lesson.ts
+++ b/backend/src/api/lesson/controllers/custom-lesson.ts
@@ -48,11 +48,13 @@ export default {
       lesson.lockedBy.id !== userId &&
       !isLockStale(lesson.lockedAt)
     ) {
-      return ctx.conflict({
+      ctx.status = 409;
+      ctx.body = {
         error: "Lesson is locked",
         lockedBy: lesson.lockedBy,
         lockedAt: lesson.lockedAt,
-      });
+      };
+      return;
     }
 
     await getStrapi().entityService.update("api::lesson.lesson", id, {

--- a/frontend/components/draft/lesson/lesson-renderer.tsx
+++ b/frontend/components/draft/lesson/lesson-renderer.tsx
@@ -63,6 +63,7 @@ export function LessonRenderer({
     isOwnLock,
     lockedBy,
     isLoading: lockLoading,
+    error: lockError,
   } = useEditingLock(lesson.id);
   const isReadOnly = lockLoading || !isOwnLock;
 
@@ -403,6 +404,12 @@ export function LessonRenderer({
             </strong>{" "}
             is currently editing this lesson. You can view but not edit.
           </span>
+        </div>
+      )}
+      {isReadOnly && !lockedBy && lockError && (
+        <div className="mx-auto mb-4 flex max-w-2xl items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
+          <IconLock className="h-4 w-4 shrink-0" />
+          <span>Unable to acquire editing lock. {lockError}</span>
         </div>
       )}
       {lockLoading && (

--- a/frontend/hooks/useEditingLock.ts
+++ b/frontend/hooks/useEditingLock.ts
@@ -18,6 +18,7 @@ type EditingLockState = {
   isOwnLock: boolean;
   lockedBy: LockStatus["lockedBy"];
   isLoading: boolean;
+  error: string | null;
 };
 
 export function useEditingLock(lessonId: number) {
@@ -26,6 +27,7 @@ export function useEditingLock(lessonId: number) {
     isOwnLock: false,
     lockedBy: null,
     isLoading: true,
+    error: null,
   });
   const userIdRef = useRef<number | null>(null);
   const heartbeatRef = useRef<ReturnType<typeof setTimeout>>();
@@ -42,6 +44,7 @@ export function useEditingLock(lessonId: number) {
       isOwnLock: false,
       lockedBy: null,
       isLoading: false,
+      error: null,
     });
   }, [lessonId]);
 
@@ -63,6 +66,7 @@ export function useEditingLock(lessonId: number) {
             isOwnLock: false,
             lockedBy: null,
             isLoading: false,
+            error: null,
           });
           startPolling();
           return;
@@ -91,6 +95,7 @@ export function useEditingLock(lessonId: number) {
               isOwnLock: true,
               lockedBy: null,
               isLoading: false,
+              error: null,
             });
             startHeartbeat();
             return;
@@ -118,6 +123,7 @@ export function useEditingLock(lessonId: number) {
           isOwnLock: false,
           lockedBy: null,
           isLoading: false,
+          error: "Could not resolve your user account",
         });
         return;
       }
@@ -131,6 +137,7 @@ export function useEditingLock(lessonId: number) {
           isOwnLock: true,
           lockedBy: null,
           isLoading: false,
+          error: null,
         });
         startHeartbeat();
       } else {
@@ -139,6 +146,7 @@ export function useEditingLock(lessonId: number) {
           isOwnLock: false,
           lockedBy: result.lockedBy ?? null,
           isLoading: false,
+          error: result.lockedBy ? null : result.error ?? null,
         });
         startPolling();
       }

--- a/frontend/lib/requests/lesson-lock.ts
+++ b/frontend/lib/requests/lesson-lock.ts
@@ -22,9 +22,20 @@ export type LockStatus = {
 /** Resolve the current user's authorized-user ID. Called once on mount. */
 export async function getCurrentAuthorizedUserId(): Promise<number | null> {
   const user = await getCurrentUser();
-  if (!user?.email) return null;
+  if (!user?.email) {
+    console.warn(
+      "[lesson-lock] No session user or email — cannot acquire lock",
+    );
+    return null;
+  }
   const authorizedUser = await getAuthorizedUserByEmail(user.email);
-  return authorizedUser?.id ?? null;
+  if (!authorizedUser?.id) {
+    console.warn(
+      `[lesson-lock] No authorized user found for email: ${user.email}`,
+    );
+    return null;
+  }
+  return authorizedUser.id;
 }
 
 export async function acquireLessonLock(
@@ -48,10 +59,13 @@ export async function acquireLessonLock(
     return {
       success: false,
       error: "Lesson is locked",
-      lockedBy: data.lockedBy,
+      lockedBy: data.lockedBy ?? data.error?.details?.lockedBy,
     };
   }
 
+  console.error(
+    `[lesson-lock] Failed to acquire lock: ${res.status} ${res.statusText}`,
+  );
   return { success: false, error: "Failed to acquire lock" };
 }
 
@@ -78,6 +92,11 @@ export async function heartbeatLessonLock(
     },
   );
 
+  if (!res.ok) {
+    console.error(
+      `[lesson-lock] Heartbeat failed: ${res.status} ${res.statusText}`,
+    );
+  }
   return res.ok;
 }
 

--- a/frontend/tests/components/draft/lesson-renderer.test.tsx
+++ b/frontend/tests/components/draft/lesson-renderer.test.tsx
@@ -68,6 +68,7 @@ const mockUseEditingLock = jest.fn().mockReturnValue({
   isOwnLock: true,
   lockedBy: null,
   isLoading: false,
+  error: null,
   release: jest.fn(),
 });
 jest.mock("@/hooks/useEditingLock", () => ({
@@ -726,6 +727,7 @@ describe("LessonRenderer", () => {
         isOwnLock: false,
         lockedBy: { id: 99, firstName: "Jane", lastName: "Doe" },
         isLoading: false,
+        error: null,
         release: jest.fn(),
       });
 
@@ -743,6 +745,7 @@ describe("LessonRenderer", () => {
         isOwnLock: false,
         lockedBy: { id: 99, firstName: "Jane", lastName: "Doe" },
         isLoading: false,
+        error: null,
         release: jest.fn(),
       });
 
@@ -760,6 +763,7 @@ describe("LessonRenderer", () => {
         isOwnLock: false,
         lockedBy: null,
         isLoading: true,
+        error: null,
         release: jest.fn(),
       });
 
@@ -776,6 +780,7 @@ describe("LessonRenderer", () => {
         isOwnLock: true,
         lockedBy: null,
         isLoading: false,
+        error: null,
         release: jest.fn(),
       });
 
@@ -786,6 +791,26 @@ describe("LessonRenderer", () => {
       expect(
         screen.queryByText(/is currently editing/),
       ).not.toBeInTheDocument();
+    });
+
+    it("shows error banner when lock acquisition fails", () => {
+      mockUseEditingLock.mockReturnValue({
+        isLocked: false,
+        isOwnLock: false,
+        lockedBy: null,
+        isLoading: false,
+        error: "Could not resolve your user account",
+        release: jest.fn(),
+      });
+
+      render(<LessonRenderer lesson={mockLesson} dropletSlug="test-droplet" />);
+
+      expect(
+        screen.getByText(/Unable to acquire editing lock/),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/Could not resolve your user account/),
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Description

Fixed the lesson editing lock system which was broken on the develop environment, causing the editor to be read-only for all users.

Three issues were addressed:

1. **Backend: `ctx.conflict()` discarded lock holder data.** Strapi's `ctx.conflict()` wraps responses through `formatHttpError`, which strips custom fields like `lockedBy`. Replaced with raw `ctx.status = 409` / `ctx.body = {...}` so the frontend can parse who holds the lock.

2. **Frontend: Silent failures with no diagnostics.** When `getCurrentAuthorizedUserId()` returned `null` or `acquireLessonLock()` failed (e.g. due to missing API token permissions), the editor silently became read-only with no logging and no UI feedback. Added `console.warn`/`console.error` at every failure point and an `error` state to the `useEditingLock` hook.

3. **Frontend: Error banner for failed lock acquisition.** Users now see a red banner ("Unable to acquire editing lock") instead of a mysteriously disabled editor when the lock system fails.

## Motivation and Context

On the develop environment, the lesson editor was locked (read-only) for everyone. No user could edit any lesson. The root cause was invisible because all lock failures were swallowed silently — no logs, no UI indicator. This made it impossible to diagnose whether the issue was a missing API token permission, a user resolution failure, or a backend error.

## Screenshots (if appropriate):


## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for lesson editing lock acquisition failures.
  * Added error banner that displays when users cannot acquire an editing lock, with specific error details.
  * Enhanced error feedback when user authorization cannot be resolved.
  * Strengthened lock conflict detection and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->