### PR TITLE
fix locking with /api added

### DIFF
--- a/frontend/lib/requests/lesson-lock.ts
+++ b/frontend/lib/requests/lesson-lock.ts
@@ -3,7 +3,8 @@
 import { getCurrentUser } from "@/lib/auth/session";
 import { getAuthorizedUserByEmail } from "@/lib/requests/authorized-user";
 
-const STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
+const STRAPI_BASE_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
+const STRAPI_API_URL = `${STRAPI_BASE_URL}/api`;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
 
 function strapiHeaders(): HeadersInit {


### PR DESCRIPTION
## Description

Added missing `/api` prefix to Strapi URL in lesson lock request functions.

## Motivation and Context

The lesson lock Server Actions used raw `fetch()` without the `/api` prefix that `fetchAPI()` adds automatically. Since `NEXT_PUBLIC_STRAPI_API_URL` on develop is `http://backend-service:80` (no `/api`), all lock requests returned 405 Method Not Allowed, making the editor read-only for everyone.

## Screenshots (if appropriate):


## Checklist:

- [x] My code follows the code style of this project.
- [x] I have moved the ticket to "In Review"
- [x] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal API URL configuration structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->