### PR TITLE
Adding pills to explore page

### DIFF
--- a/frontend/components/dashboard/filter-selector.tsx
+++ b/frontend/components/dashboard/filter-selector.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import React from "react";
 import { cn } from "@/lib/utils";
-import { IconArchive, IconHeart } from "@tabler/icons-react";
 
 interface FilterSelectorProps {
   droplets: number;
@@ -20,24 +18,12 @@ export function FilterSelector({
   archived,
   favorited,
 }: FilterSelectorProps) {
-  const contentTypes: Array<{
-    name: string;
-    value: string;
-    icon?: React.ReactNode;
-  }> = [
+  const contentTypes = [
     { name: `Droplets (${droplets})`, value: "droplets" },
     { name: `Playlists (${playlists})`, value: "playlists" },
     { name: `Groups (${groups})`, value: "groups" },
-    {
-      name: `Archived (${archived})`,
-      value: "archived",
-      icon: <IconArchive className="h-3.5 w-3.5" stroke={2} />,
-    },
-    {
-      name: `Favorited (${favorited})`,
-      value: "favorited",
-      icon: <IconHeart className="h-3.5 w-3.5" stroke={2} />,
-    },
+    { name: `Archived (${archived})`, value: "archived" },
+    { name: `Favorited (${favorited})`, value: "favorited" },
   ];
   const router = useRouter();
   const pathname = usePathname();
@@ -65,17 +51,6 @@ export function FilterSelector({
               : "border-[#D0D5DD] text-[#667085] hover:bg-slate-50 dark:border-slate-600 dark:text-slate-400 dark:hover:bg-slate-800",
           )}
         >
-          {type.icon && (
-            <span
-              className={
-                currentType === type.value
-                  ? "text-white"
-                  : "text-black dark:text-white"
-              }
-            >
-              {type.icon}
-            </span>
-          )}
           {type.name}
         </button>
       ))}

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -15,7 +15,7 @@ import { StarRating } from "@/components/ui/rating-stars";
 import { useState, useEffect, useRef } from "react";
 import { Button } from "../ui/button";
 import { toast } from "sonner";
-import { Clock, Download } from "lucide-react";
+import { Clock } from "lucide-react";
 import { getDueDateBadgeColor } from "@/lib/utils";
 import { DateTime } from "luxon";
 import {
@@ -26,6 +26,7 @@ import {
 import {
   IconArchive,
   IconArchiveOff,
+  IconDownload,
   IconHeart,
   IconHeartFilled,
 } from "@tabler/icons-react";
@@ -520,7 +521,10 @@ ${
                 className={`${isAdmin ? "visible" : "invisible"} bg-slate-50 hover:bg-slate-300 dark:bg-slate-800 dark:hover:bg-slate-900`}
               >
                 <div className="group relative">
-                  <Download className="text-black dark:text-white" />
+                  <IconDownload
+                    className="h-[18px] w-[18px] text-black dark:text-white"
+                    stroke={1.8}
+                  />
                   <span className="absolute top-full left-1/2 mt-1 w-max -translate-x-1/2 transform rounded bg-gray-800 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100">
                     Export Markdown
                   </span>

--- a/frontend/components/explore/content-type-selector.tsx
+++ b/frontend/components/explore/content-type-selector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Button } from "../ui/button";
+import { cn } from "@/lib/utils";
 
 export function ContentTypeSelector({
   droplets,
@@ -32,21 +32,22 @@ export function ContentTypeSelector({
   };
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex flex-wrap gap-2">
       {contentTypes.map((type) => (
-        <Button
+        <button
           key={type.value}
-          className={
-            currentType === type.value
-              ? "h-10 w-24 bg-black dark:border dark:border-slate-900 dark:bg-white dark:text-black dark:hover:bg-slate-300"
-              : "h-10 w-24 border border-slate-500 bg-white text-black hover:bg-slate-100 dark:bg-black dark:text-white dark:hover:bg-slate-900"
-          }
           onClick={() => {
             router.push(`${pathname}?${createQueryString(type.value)}`);
           }}
+          className={cn(
+            "rounded-full border px-4 py-1.5 text-sm font-medium transition-colors",
+            currentType === type.value
+              ? "border-[#287697] bg-[#287697] text-white"
+              : "border-[#D0D5DD] text-[#667085] hover:bg-slate-50 dark:border-slate-600 dark:text-slate-400 dark:hover:bg-slate-800",
+          )}
         >
           {type.name}
-        </Button>
+        </button>
       ))}
     </div>
   );

--- a/frontend/components/explore/filter.tsx
+++ b/frontend/components/explore/filter.tsx
@@ -54,7 +54,7 @@ export function Filter({
         <Button
           variant="outline"
           size="sm"
-          className="gap-0.25 border-dashed dark:text-slate-300"
+          className="gap-0.25 border-[#D0D5DD] text-[#667085] dark:border-slate-700 dark:text-slate-400"
         >
           <PlusCircleIcon className="mr-2 h-4 w-4" />
 

--- a/frontend/components/explore/sort.tsx
+++ b/frontend/components/explore/sort.tsx
@@ -39,7 +39,11 @@ export function Sort({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-0.25 border-dashed">
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-0.25 border-[#D0D5DD] text-[#667085] dark:border-slate-700 dark:text-slate-400"
+        >
           <ArrowUpDownIcon className="mr-2 h-4 w-4" />
           {options.find((item) => item.slug === selectedValue)?.label}
         </Button>


### PR DESCRIPTION
 ## Description                                                                                                                                                                        
             
Updated tab/pill UI across the Explore and Dashboard pages to match the redesign:                                                                                                  
                                                                                                                                                                                     
- Explore tabs (ContentTypeSelector): Replaced Button component with plain <button> elements using the same pill style as the Dashboard — blue active state (#287697), #D0D5DD     
  border inactive, matching text color #667085                                                                                                                                       
- Explore filter/sort buttons: Updated border color from border-dashed to border-[#D0D5DD] and text to #667085 to match the search bar styling                                     
- Dashboard filter pills (FilterSelector): Removed icons from Archived and Favorited pills                                                                                         
- Droplet tile: Swapped lucide Download icon for IconDownload from @tabler/icons-react at 18px to match the project's icon library                                                 
                                                                                                                                                                                     
## Motivation and Context                                                                                                                                                             
                                                                                                                                                                                     
Explore page tabs did not match the redesign spec — they used a black/white filled button style instead of the pill shape used on the Dashboard. Filter and sort buttons had a dashed border that didn't visually match the adjacent search bar. The Dashboard's Archived/Favorited pills had icons that were removed per the redesign. The download icon on droplet tiles was inconsistent with the rest of the codebase which uses Tabler Icons.       

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed per-option icons from filter selector for a cleaner interface.
  * Updated button styling and color schemes across filter, sort, and content-type-selector components for improved visual consistency.
  * Refined export button icon styling and size adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->