### PR TITLE
improvement: redesign voyage island SVG and tree map spacing (ODY-405)

### DIFF
--- a/frontend/components/voyages/voyage-tree-island.tsx
+++ b/frontend/components/voyages/voyage-tree-island.tsx
@@ -17,230 +17,289 @@ function IslandSvg({
   status: string;
 }) {
   const isLocked = status === "locked";
-  const w = size === "main" ? 130 : 100;
-  const h = size === "main" ? 110 : 85;
+  const w = size === "main" ? 200 : 160;
+  const h = size === "main" ? 180 : 145;
 
   return (
     <svg
       width={w}
       height={h}
-      viewBox="-10 -20 120 110"
+      viewBox="0 0 200 180"
       fill="none"
       className="block"
     >
       {isLocked ? (
         <>
-          {/* Locked island — gray, no trees */}
+          {/* Water shadow */}
           <ellipse
-            cx="50"
-            cy="62"
-            rx="42"
+            cx="100"
+            cy="140"
+            rx="70"
             ry="18"
-            fill="#cbd5e1"
-            opacity={0.5}
+            fill="#94a3b8"
+            opacity={0.15}
           />
-          <ellipse cx="50" cy="58" rx="40" ry="20" fill="#94a3b8" />
-          <ellipse cx="50" cy="54" rx="36" ry="18" fill="#64748b" />
-          <ellipse cx="46" cy="50" rx="28" ry="14" fill="#475569" />
-          {/* Dead tree stump */}
+          {/* Cliff side — dark rock */}
           <path
-            d="M52 50 Q53 42 51 36"
+            d="M40 120 Q38 132 42 138 Q60 150 100 152 Q140 150 158 138 Q162 132 160 120 Z"
+            fill="#4a5568"
+          />
+          {/* Island top surface */}
+          <ellipse cx="100" cy="120" rx="60" ry="24" fill="#64748b" />
+          <ellipse cx="100" cy="118" rx="54" ry="20" fill="#718096" />
+          {/* Dead stumps */}
+          <path
+            d="M105 118 Q107 106 104 96"
             stroke="#6b7280"
-            strokeWidth="2.5"
+            strokeWidth="3"
             strokeLinecap="round"
             fill="none"
           />
           <path
-            d="M51 36 Q46 34 42 37"
+            d="M104 96 Q98 93 93 97"
             stroke="#6b7280"
-            strokeWidth="1.5"
+            strokeWidth="2"
             strokeLinecap="round"
             fill="none"
           />
           <path
-            d="M51 36 Q56 33 59 36"
+            d="M104 96 Q110 93 114 96"
             stroke="#6b7280"
-            strokeWidth="1.5"
+            strokeWidth="2"
             strokeLinecap="round"
             fill="none"
           />
         </>
       ) : (
         <>
-          {/* Water shadow ring */}
+          {/* Ocean water ring */}
           <ellipse
-            cx="50"
-            cy="64"
-            rx="44"
-            ry="19"
-            fill="#93c5fd"
-            opacity={0.15}
+            cx="100"
+            cy="140"
+            rx="82"
+            ry="24"
+            fill="#297496"
+            opacity={0.3}
           />
-          {/* Sand base with texture */}
-          <ellipse cx="50" cy="60" rx="42" ry="18" fill="#F4E5C0" />
           <ellipse
-            cx="54"
-            cy="61"
-            rx="12"
-            ry="5"
-            fill="#E8D5A8"
-            opacity={0.6}
+            cx="100"
+            cy="138"
+            rx="74"
+            ry="21"
+            fill="#297496"
+            opacity={0.2}
           />
-          {/* Grass layers */}
-          <ellipse cx="50" cy="55" rx="38" ry="19" fill="#6ABF69" />
-          <ellipse cx="46" cy="51" rx="30" ry="15" fill="#4CAF50" />
-          <ellipse cx="42" cy="48" rx="20" ry="10" fill="#43A047" />
-          {/* Small bushes */}
-          <circle cx="30" cy="52" r="4" fill="#388E3C" opacity={0.7} />
-          <circle cx="64" cy="54" r="3.5" fill="#388E3C" opacity={0.6} />
-          <circle cx="38" cy="47" r="3" fill="#2E7D32" opacity={0.5} />
+
+          {/* Sand/beach ring */}
+          <ellipse cx="100" cy="124" rx="66" ry="28" fill="#F4E5C0" />
+
+          {/* Green island surface */}
+          <ellipse cx="100" cy="120" rx="58" ry="24" fill="#4CAF50" />
+          {/* Subtle top highlight */}
+          <ellipse
+            cx="94"
+            cy="114"
+            rx="36"
+            ry="14"
+            fill="#66BB6A"
+            opacity={0.45}
+          />
 
           {size === "main" ? (
             <>
-              {/* Main palm tree (tall, center-right) */}
+              {/* Main palm — tall, right of center */}
               <path
-                d="M55 50 Q58 36 54 18"
-                stroke="#6D4C2A"
+                d="M110 108 Q114 86 108 52"
+                stroke="#5D3E1A"
+                strokeWidth="5"
+                strokeLinecap="round"
+                fill="none"
+              />
+              {/* Trunk rings */}
+              <path
+                d="M111 94 Q112 93 110 92.5"
+                stroke="#8B6914"
+                strokeWidth="1"
+                opacity={0.3}
+              />
+              <path
+                d="M112 82 Q113 81 111 80.5"
+                stroke="#8B6914"
+                strokeWidth="1"
+                opacity={0.3}
+              />
+              <path
+                d="M111 70 Q112 69 110 68.5"
+                stroke="#8B6914"
+                strokeWidth="1"
+                opacity={0.3}
+              />
+
+              {/* Coconut cluster */}
+              <circle cx="108" cy="54" r="3.5" fill="#8D6E3F" />
+              <circle cx="112" cy="57" r="3" fill="#7D5E2F" />
+              <circle cx="105" cy="57" r="2.8" fill="#6D4E1F" />
+
+              {/* Main palm fronds */}
+              <path
+                d="M108 52 Q82 42 62 56"
+                stroke="#2E7D32"
                 strokeWidth="3.5"
                 strokeLinecap="round"
                 fill="none"
               />
-              {/* Coconuts */}
-              <circle cx="54" cy="19" r="2" fill="#8D6E3F" />
-              <circle cx="56" cy="21" r="1.8" fill="#7D5E2F" />
-              {/* Palm fronds — lush */}
               <path
-                d="M54 18 Q38 12 28 20"
-                stroke="#2E7D32"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                fill="none"
-              />
-              <path
-                d="M54 18 Q40 8 30 12"
+                d="M108 52 Q86 36 68 44"
                 stroke="#388E3C"
-                strokeWidth="2"
-                strokeLinecap="round"
-                fill="none"
-              />
-              <path
-                d="M54 18 Q64 10 74 16"
-                stroke="#2E7D32"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                fill="none"
-              />
-              <path
-                d="M54 18 Q66 6 76 10"
-                stroke="#388E3C"
-                strokeWidth="2"
-                strokeLinecap="round"
-                fill="none"
-              />
-              <path
-                d="M54 18 Q52 6 48 4"
-                stroke="#43A047"
-                strokeWidth="1.8"
-                strokeLinecap="round"
-                fill="none"
-              />
-
-              {/* Second smaller palm (left) */}
-              <path
-                d="M34 52 Q32 42 35 32"
-                stroke="#6D4C2A"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                fill="none"
-              />
-              <path
-                d="M35 32 Q26 28 20 32"
-                stroke="#2E7D32"
-                strokeWidth="2"
-                strokeLinecap="round"
-                fill="none"
-              />
-              <path
-                d="M35 32 Q28 24 24 26"
-                stroke="#388E3C"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                fill="none"
-              />
-              <path
-                d="M35 32 Q42 26 48 30"
-                stroke="#2E7D32"
-                strokeWidth="2"
-                strokeLinecap="round"
-                fill="none"
-              />
-
-              {/* Small rocks */}
-              <ellipse
-                cx="62"
-                cy="56"
-                rx="3"
-                ry="2"
-                fill="#a1887f"
-                opacity={0.5}
-              />
-              <ellipse
-                cx="68"
-                cy="58"
-                rx="2"
-                ry="1.5"
-                fill="#8d6e63"
-                opacity={0.4}
-              />
-            </>
-          ) : (
-            <>
-              {/* Branch palm (single, centered) */}
-              <path
-                d="M52 48 Q54 36 51 22"
-                stroke="#6D4C2A"
                 strokeWidth="3"
                 strokeLinecap="round"
                 fill="none"
               />
-              <circle cx="51" cy="23" r="1.8" fill="#8D6E3F" />
               <path
-                d="M51 22 Q40 17 32 22"
+                d="M108 52 Q130 40 150 52"
                 stroke="#2E7D32"
+                strokeWidth="3.5"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <path
+                d="M108 52 Q132 34 152 42"
+                stroke="#388E3C"
+                strokeWidth="3"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <path
+                d="M108 52 Q106 34 102 26"
+                stroke="#43A047"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <path
+                d="M108 52 Q114 36 118 28"
+                stroke="#43A047"
                 strokeWidth="2.2"
                 strokeLinecap="round"
                 fill="none"
               />
+              {/* Extra drooping fronds */}
               <path
-                d="M51 22 Q42 12 36 14"
-                stroke="#388E3C"
-                strokeWidth="1.8"
-                strokeLinecap="round"
-                fill="none"
-              />
-              <path
-                d="M51 22 Q60 15 68 20"
+                d="M108 52 Q78 50 58 64"
                 stroke="#2E7D32"
-                strokeWidth="2.2"
+                strokeWidth="2"
                 strokeLinecap="round"
                 fill="none"
+                opacity={0.6}
               />
               <path
-                d="M51 22 Q60 10 66 12"
-                stroke="#388E3C"
-                strokeWidth="1.8"
+                d="M108 52 Q136 48 154 60"
+                stroke="#2E7D32"
+                strokeWidth="2"
                 strokeLinecap="round"
                 fill="none"
+                opacity={0.6}
               />
 
-              {/* Small rock */}
-              <ellipse
-                cx="62"
-                cy="54"
-                rx="2.5"
-                ry="1.5"
-                fill="#a1887f"
-                opacity={0.4}
+              {/* Second palm — shorter, left */}
+              <path
+                d="M78 112 Q74 96 80 74"
+                stroke="#5D3E1A"
+                strokeWidth="3.5"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <circle cx="80" cy="75" r="2.5" fill="#8D6E3F" />
+              <path
+                d="M80 74 Q64 68 54 76"
+                stroke="#2E7D32"
+                strokeWidth="3"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <path
+                d="M80 74 Q68 62 60 66"
+                stroke="#388E3C"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <path
+                d="M80 74 Q92 66 102 72"
+                stroke="#2E7D32"
+                strokeWidth="3"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <path
+                d="M80 74 Q80 58 78 50"
+                stroke="#43A047"
+                strokeWidth="2"
+                strokeLinecap="round"
+                fill="none"
+              />
+            </>
+          ) : (
+            <>
+              {/* Branch — single palm, centered */}
+              <path
+                d="M104 108 Q107 88 103 60"
+                stroke="#5D3E1A"
+                strokeWidth="4.5"
+                strokeLinecap="round"
+                fill="none"
+              />
+              {/* Trunk rings */}
+              <path
+                d="M105 92 Q106 91 104 90.5"
+                stroke="#8B6914"
+                strokeWidth="1"
+                opacity={0.3}
+              />
+              <path
+                d="M105.5 78 Q106.5 77 104.5 76.5"
+                stroke="#8B6914"
+                strokeWidth="1"
+                opacity={0.3}
+              />
+
+              <circle cx="103" cy="62" r="3" fill="#8D6E3F" />
+              <circle cx="106" cy="64" r="2.5" fill="#7D5E2F" />
+
+              <path
+                d="M103 60 Q84 52 68 64"
+                stroke="#2E7D32"
+                strokeWidth="3.2"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <path
+                d="M103 60 Q86 44 74 50"
+                stroke="#388E3C"
+                strokeWidth="2.8"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <path
+                d="M103 60 Q120 50 138 60"
+                stroke="#2E7D32"
+                strokeWidth="3.2"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <path
+                d="M103 60 Q120 44 134 48"
+                stroke="#388E3C"
+                strokeWidth="2.8"
+                strokeLinecap="round"
+                fill="none"
+              />
+              <path
+                d="M103 60 Q102 42 100 34"
+                stroke="#43A047"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                fill="none"
               />
             </>
           )}
@@ -249,27 +308,27 @@ function IslandSvg({
       {/* Available glow ring */}
       {status === "available" && (
         <ellipse
-          cx="50"
-          cy="55"
-          rx="46"
-          ry="22"
+          cx="100"
+          cy="120"
+          rx="70"
+          ry="30"
           stroke="#60a5fa"
-          strokeWidth="2"
+          strokeWidth="2.5"
           fill="none"
-          opacity={0.5}
+          opacity={0.35}
         />
       )}
-      {/* Completed golden ring */}
+      {/* Completed ring */}
       {status === "completed" && (
         <ellipse
-          cx="50"
-          cy="55"
-          rx="46"
-          ry="22"
+          cx="100"
+          cy="120"
+          rx="70"
+          ry="30"
           stroke="#22c55e"
-          strokeWidth="2"
+          strokeWidth="2.5"
           fill="none"
-          opacity={0.4}
+          opacity={0.35}
         />
       )}
     </svg>
@@ -279,8 +338,8 @@ function IslandSvg({
 function LockIcon() {
   return (
     <svg
-      width="24"
-      height="24"
+      width="32"
+      height="32"
       viewBox="0 0 24 24"
       fill="none"
       stroke="#334155"
@@ -310,23 +369,21 @@ export function VoyageTreeIsland({
     <div
       className={`text-center transition-transform duration-200 ${
         !isLocked ? "cursor-pointer hover:scale-105" : ""
-      } ${isLocked ? "opacity-40" : ""} ${
-        status === "available" ? "animate-pulse-slow" : ""
-      }`}
+      } ${isLocked ? "opacity-40" : ""}`}
     >
       <div className="relative inline-block">
-        {/* Step number badge — top left */}
+        {/* Step number badge */}
         {stepNumber && (
           <div
-            className="absolute -top-2 -left-2 z-10 flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-bold text-white shadow"
+            className="absolute -top-1 left-0 z-10 flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold text-white shadow-md"
             style={{ backgroundColor: isLocked ? "#475569" : "#297496" }}
           >
             {stepNumber}
           </div>
         )}
-        {/* Completed checkmark — top right */}
+        {/* Completed checkmark */}
         {isCompleted && (
-          <div className="absolute -top-1 -right-1 z-10 flex h-5 w-5 items-center justify-center rounded-full border-2 border-white bg-green-500 text-[9px] text-white shadow">
+          <div className="absolute -top-1 right-0 z-10 flex h-6 w-6 items-center justify-center rounded-full border-2 border-white bg-green-500 text-[10px] text-white shadow-md">
             ✓
           </div>
         )}
@@ -337,12 +394,12 @@ export function VoyageTreeIsland({
       </div>
 
       {/* Label */}
-      <div className="mt-1 flex justify-center">
+      <div className="-mt-1 flex justify-center">
         <span
-          className={`rounded-md px-2.5 py-1 font-bold shadow ${
+          className={`rounded-lg px-3 py-1.5 font-bold shadow-sm ${
             isMain
-              ? "bg-white text-xs dark:bg-slate-800"
-              : "bg-white text-[10px] dark:bg-slate-800"
+              ? "max-w-[200px] bg-white text-sm dark:bg-slate-800"
+              : "max-w-[160px] bg-white text-xs dark:bg-slate-800"
           } ${isLocked ? "opacity-60" : ""} text-slate-900 dark:text-slate-100`}
         >
           {label}
@@ -352,7 +409,7 @@ export function VoyageTreeIsland({
       {/* Subtitle */}
       {dropletCount !== undefined && (
         <div
-          className={`mt-0.5 text-center text-[10px] font-semibold ${
+          className={`mt-1 text-center text-xs font-semibold ${
             isCompleted
               ? "text-green-700 dark:text-green-400"
               : isLocked
@@ -365,13 +422,13 @@ export function VoyageTreeIsland({
       )}
 
       {isCompleted && (
-        <div className="text-center text-[10px] font-bold text-green-700 dark:text-green-400">
+        <div className="text-center text-xs font-bold text-green-700 dark:text-green-400">
           Completed ✓
         </div>
       )}
 
       {isLocked && (
-        <div className="text-center text-[10px] font-medium text-slate-400">
+        <div className="text-center text-xs font-medium text-slate-400">
           Locked
         </div>
       )}

--- a/frontend/components/voyages/voyage-tree-island.tsx
+++ b/frontend/components/voyages/voyage-tree-island.tsx
@@ -1,5 +1,12 @@
 import Link from "next/link";
 
+// Rendered SVG dimensions — shared with voyage-tree-map so connectors can
+// anchor to actual island geometry, not the (larger) layout box.
+export const ISLAND_SVG_DIMENSIONS = {
+  main: { width: 200, height: 180 },
+  branch: { width: 160, height: 145 },
+} as const;
+
 interface VoyageTreeIslandProps {
   label: string;
   slug?: string;
@@ -7,18 +14,23 @@ interface VoyageTreeIslandProps {
   size: "main" | "branch";
   status?: "completed" | "available" | "locked";
   stepNumber?: number;
+  /** Visual scale factor for responsive sizing (1 = default). */
+  scale?: number;
 }
 
 function IslandSvg({
   size,
   status,
+  scale = 1,
 }: {
   size: "main" | "branch";
   status: string;
+  scale?: number;
 }) {
   const isLocked = status === "locked";
-  const w = size === "main" ? 200 : 160;
-  const h = size === "main" ? 180 : 145;
+  const base = ISLAND_SVG_DIMENSIONS[size];
+  const w = base.width * scale;
+  const h = base.height * scale;
 
   return (
     <svg
@@ -360,6 +372,7 @@ export function VoyageTreeIsland({
   size,
   status = "available",
   stepNumber,
+  scale = 1,
 }: VoyageTreeIslandProps) {
   const isMain = size === "main";
   const isLocked = status === "locked";
@@ -390,7 +403,7 @@ export function VoyageTreeIsland({
         {/* Lock icon */}
         {isLocked && <LockIcon />}
 
-        <IslandSvg size={size} status={status} />
+        <IslandSvg size={size} status={status} scale={scale} />
       </div>
 
       {/* Label */}

--- a/frontend/components/voyages/voyage-tree-map.tsx
+++ b/frontend/components/voyages/voyage-tree-map.tsx
@@ -19,10 +19,10 @@ interface VoyageTreeMapProps {
   nodes: TreeNode[];
 }
 
-const MAIN_SIZE = 150;
-const BRANCH_SIZE = 130;
-const H_GAP = 100;
-const V_GAP = 140;
+const MAIN_SIZE = 260;
+const BRANCH_SIZE = 210;
+const H_GAP = 80;
+const V_GAP = 160;
 const PADDING = 100;
 
 interface LayoutNode {
@@ -99,8 +99,8 @@ function bezierPath(
   parentSize: number,
   childSize: number,
 ): string {
-  const sy = py + parentSize * 0.4;
-  const ey = cy - childSize * 0.4;
+  const sy = py + parentSize * 0.52;
+  const ey = cy - childSize * 0.52;
   const my = (sy + ey) / 2;
   return `M ${px} ${sy} C ${px} ${my}, ${cx} ${my}, ${cx} ${ey}`;
 }

--- a/frontend/components/voyages/voyage-tree-map.tsx
+++ b/frontend/components/voyages/voyage-tree-map.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { useRef, useEffect, useState, useMemo } from "react";
-import {
-  VoyageTreeIsland,
-  ISLAND_SVG_DIMENSIONS,
-} from "./voyage-tree-island";
+import { VoyageTreeIsland, ISLAND_SVG_DIMENSIONS } from "./voyage-tree-island";
 
 export interface TreeNode {
   id: number;

--- a/frontend/components/voyages/voyage-tree-map.tsx
+++ b/frontend/components/voyages/voyage-tree-map.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useRef, useEffect, useState, useMemo } from "react";
-import { VoyageTreeIsland } from "./voyage-tree-island";
+import {
+  VoyageTreeIsland,
+  ISLAND_SVG_DIMENSIONS,
+} from "./voyage-tree-island";
 
 export interface TreeNode {
   id: number;
@@ -19,11 +22,36 @@ interface VoyageTreeMapProps {
   nodes: TreeNode[];
 }
 
-const MAIN_SIZE = 260;
-const BRANCH_SIZE = 210;
-const H_GAP = 80;
-const V_GAP = 160;
-const PADDING = 100;
+// Default desktop sizes. On narrower containers these scale down proportionally
+// so multi-branch rows stay within the viewport.
+const DEFAULT_MAIN_SIZE = 260;
+const DEFAULT_BRANCH_SIZE = 210;
+const DEFAULT_H_GAP = 80;
+const DEFAULT_V_GAP = 160;
+const PADDING = 60;
+const MIN_MAIN_SIZE = 140;
+const MIN_BRANCH_SIZE = 110;
+const MIN_H_GAP = 24;
+
+/** Compute layout sizes that fit within the container, accounting for
+ *  the widest branch row in the tree. */
+function computeLayoutSizes(containerWidth: number, maxBranches: number) {
+  // Available width for a branch row after padding.
+  const usable = Math.max(containerWidth - PADDING * 2, 0);
+  // Desktop ideal width for the widest branch row.
+  const idealBranchRow =
+    maxBranches > 0
+      ? maxBranches * DEFAULT_BRANCH_SIZE + (maxBranches - 1) * DEFAULT_H_GAP
+      : DEFAULT_MAIN_SIZE;
+  const scale = usable > 0 ? Math.min(1, usable / idealBranchRow) : 1;
+
+  const MAIN_SIZE = Math.max(DEFAULT_MAIN_SIZE * scale, MIN_MAIN_SIZE);
+  const BRANCH_SIZE = Math.max(DEFAULT_BRANCH_SIZE * scale, MIN_BRANCH_SIZE);
+  const H_GAP = Math.max(DEFAULT_H_GAP * scale, MIN_H_GAP);
+  const V_GAP = DEFAULT_V_GAP;
+
+  return { MAIN_SIZE, BRANCH_SIZE, H_GAP, V_GAP };
+}
 
 interface LayoutNode {
   node: TreeNode;
@@ -58,7 +86,9 @@ function buildTree(nodes: TreeNode[]): LayoutNode[] {
 function assignPositions(
   roots: LayoutNode[],
   containerWidth: number,
+  sizes: ReturnType<typeof computeLayoutSizes>,
 ): { all: LayoutNode[]; height: number } {
+  const { MAIN_SIZE, BRANCH_SIZE, H_GAP, V_GAP } = sizes;
   const all: LayoutNode[] = [];
   let y = PADDING;
   const cx = containerWidth / 2;
@@ -90,17 +120,18 @@ function assignPositions(
   return { all, height: y + PADDING };
 }
 
-/** Smooth bezier from bottom of parent to top of child */
+/** Smooth bezier from bottom of parent to top of child, anchored to the
+ *  rendered SVG geometry (not the layout box) so the line meets the island. */
 function bezierPath(
   px: number,
   py: number,
   cx: number,
   cy: number,
-  parentSize: number,
-  childSize: number,
+  parentVisibleHeight: number,
+  childVisibleHeight: number,
 ): string {
-  const sy = py + parentSize * 0.52;
-  const ey = cy - childSize * 0.52;
+  const sy = py + parentVisibleHeight / 2;
+  const ey = cy - childVisibleHeight / 2;
   const my = (sy + ey) / 2;
   return `M ${px} ${sy} C ${px} ${my}, ${cx} ${my}, ${cx} ${ey}`;
 }
@@ -123,10 +154,27 @@ export function VoyageTreeMap({ nodes }: VoyageTreeMapProps) {
   }, []);
 
   const tree = useMemo(() => buildTree(nodes), [nodes]);
-  const { all: layoutNodes, height: totalHeight } = useMemo(
-    () => assignPositions(tree, containerWidth),
-    [tree, containerWidth],
+
+  // Widest branch row drives the responsive scale.
+  const maxBranches = useMemo(
+    () => tree.reduce((max, root) => Math.max(max, root.children.length), 0),
+    [tree],
   );
+
+  const sizes = useMemo(
+    () => computeLayoutSizes(containerWidth, maxBranches),
+    [containerWidth, maxBranches],
+  );
+
+  const { all: layoutNodes, height: totalHeight } = useMemo(
+    () => assignPositions(tree, containerWidth, sizes),
+    [tree, containerWidth, sizes],
+  );
+
+  // Scale SVG visible heights by the same ratio used for layout sizing.
+  const svgScale = sizes.MAIN_SIZE / DEFAULT_MAIN_SIZE;
+  const mainVisibleHeight = ISLAND_SVG_DIMENSIONS.main.height * svgScale;
+  const branchVisibleHeight = ISLAND_SVG_DIMENSIONS.branch.height * svgScale;
 
   // Build connectors
   const connectors = useMemo(() => {
@@ -135,8 +183,8 @@ export function VoyageTreeMap({ nodes }: VoyageTreeMapProps) {
       py: number;
       cx: number;
       cy: number;
-      pSize: number;
-      cSize: number;
+      pVisible: number;
+      cVisible: number;
       key: string;
     }[] = [];
     const mainLayout = layoutNodes.filter((n) => n.node.isMainPath);
@@ -151,8 +199,8 @@ export function VoyageTreeMap({ nodes }: VoyageTreeMapProps) {
         py: from.y,
         cx: to.x,
         cy: to.y,
-        pSize: MAIN_SIZE,
-        cSize: MAIN_SIZE,
+        pVisible: mainVisibleHeight,
+        cVisible: mainVisibleHeight,
         key: `m${from.node.id}-m${to.node.id}`,
       });
     }
@@ -165,15 +213,15 @@ export function VoyageTreeMap({ nodes }: VoyageTreeMapProps) {
           py: layout.y,
           cx: child.x,
           cy: child.y,
-          pSize: MAIN_SIZE,
-          cSize: BRANCH_SIZE,
+          pVisible: mainVisibleHeight,
+          cVisible: branchVisibleHeight,
           key: `m${layout.node.id}-b${child.node.id}`,
         });
       }
     }
 
     return lines;
-  }, [layoutNodes]);
+  }, [layoutNodes, mainVisibleHeight, branchVisibleHeight]);
 
   const ready = containerWidth > 0;
   let mainStep = 0;
@@ -197,10 +245,10 @@ export function VoyageTreeMap({ nodes }: VoyageTreeMapProps) {
             aria-hidden="true"
             style={{ zIndex: 1 }}
           >
-            {connectors.map(({ px, py, cx, cy, pSize, cSize, key }) => (
+            {connectors.map(({ px, py, cx, cy, pVisible, cVisible, key }) => (
               <path
                 key={key}
-                d={bezierPath(px, py, cx, cy, pSize, cSize)}
+                d={bezierPath(px, py, cx, cy, pVisible, cVisible)}
                 stroke="rgba(45,106,79,0.3)"
                 strokeWidth="2.5"
                 fill="none"
@@ -212,7 +260,7 @@ export function VoyageTreeMap({ nodes }: VoyageTreeMapProps) {
           {layoutNodes.map((layout) => {
             const isMain = layout.node.isMainPath;
             if (isMain) mainStep++;
-            const size = isMain ? MAIN_SIZE : BRANCH_SIZE;
+            const size = isMain ? sizes.MAIN_SIZE : sizes.BRANCH_SIZE;
 
             return (
               <div
@@ -248,6 +296,7 @@ export function VoyageTreeMap({ nodes }: VoyageTreeMapProps) {
                   size={isMain ? "main" : "branch"}
                   status={layout.node.status}
                   stepNumber={isMain ? mainStep : undefined}
+                  scale={svgScale}
                 />
               </div>
             );


### PR DESCRIPTION
## Description

- Redesigned island SVG with sand beach ring, Odyssey blue water, clean green surface, and detailed palm trees
- Bigger islands: main 200x180px, branch 160x145px (up from 130x110 / 100x85)
- Layout spacing: MAIN_SIZE 260, BRANCH_SIZE 210, V_GAP 160 for better breathing room
- Fixed connector line gap: bezier endpoints reach closer to island edges
- Colored branch type badges: blue for required, yellow for optional

## Motivation and Context

Visual polish for client demo. Islands looked like petri dishes and were too small. Connector lines had visible gaps.

Closes ODY-405

## Screenshots (if appropriate):

N/A — visual SVG changes, view on `/v/web-development-foundations`

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned island and palm-tree artwork with updated visuals for locked/unlocked states
  * Adjusted badge sizes, positions, and label typography for clearer step/complete indicators
  * Increased lock icon size for better visibility
  * Refined responsive layout, node scaling, spacing, and connector geometry for more consistent voyage-tree presentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->