### PR TITLE
fix: dataset upload, delete, and notebook loading (ODY-406)

### DIFF
--- a/frontend/components/draft/dataset/dataset-list.tsx
+++ b/frontend/components/draft/dataset/dataset-list.tsx
@@ -122,10 +122,10 @@ export function DatasetList({ datasets, onDelete }: DatasetListProps) {
               variant="outline"
               className={cn(
                 "shrink-0 text-xs",
-                formatBadgeClass(dataset.fileType),
+                formatBadgeClass(dataset.format),
               )}
             >
-              {dataset.fileType.toUpperCase()}
+              {dataset.format.toUpperCase()}
             </Badge>
 
             {/* Delete button */}

--- a/frontend/components/draft/dataset/dataset-upload.tsx
+++ b/frontend/components/draft/dataset/dataset-upload.tsx
@@ -43,7 +43,7 @@ interface DatasetUploadProps {
   datasets: Dataset[];
 }
 
-export function DatasetUpload({ datasets }: DatasetUploadProps) {
+export function DatasetUpload({ dropletId, datasets }: DatasetUploadProps) {
   const [uploadState, setUploadState] = useState<UploadState>({
     status: "idle",
   });
@@ -148,9 +148,10 @@ export function DatasetUpload({ datasets }: DatasetUploadProps) {
     // 2. Create the dataset record in Strapi
     const createResult = await createDataset({
       name: file.name,
-      url: uploadResult.url,
-      fileType: format,
+      fileUrl: uploadResult.url,
+      format,
       fileSize: file.size,
+      droplet: dropletId,
     });
 
     if (!createResult.ok || !createResult.data) {

--- a/frontend/components/draft/metadata/datasets/datasets.tsx
+++ b/frontend/components/draft/metadata/datasets/datasets.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { useRef, useState, useTransition } from "react";
+import { useRef, useState, useTransition, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Dataset } from "@/types";
-import { uploadDataset, deleteDataset } from "@/lib/actions";
-import { updateDroplet } from "@/lib/requests/droplet";
+import {
+  uploadDataset,
+  deleteDataset as deleteDatasetFile,
+} from "@/lib/actions";
+import {
+  createDataset,
+  deleteDataset as deleteDatasetRecord,
+} from "@/lib/requests/dataset";
 import { toast } from "sonner";
 import { IconUpload, IconFile, IconTrash } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
@@ -26,8 +32,52 @@ export function Datasets({
 }) {
   const router = useRouter();
   const [isDragging, setIsDragging] = useState(false);
+  const [pageIsDragging, setPageIsDragging] = useState(false);
   const [isPending, startTransition] = useTransition();
   const inputRef = useRef<HTMLInputElement>(null);
+  const dragCounterRef = useRef(0);
+
+  // Page-level drag detection
+  useEffect(() => {
+    if (datasets.length >= MAX_DATASETS) return;
+
+    function handleDragEnter(e: DragEvent) {
+      e.preventDefault();
+      dragCounterRef.current++;
+      if (e.dataTransfer?.types.includes("Files")) {
+        setPageIsDragging(true);
+      }
+    }
+    function handleDragLeave(e: DragEvent) {
+      e.preventDefault();
+      dragCounterRef.current--;
+      if (dragCounterRef.current === 0) {
+        setPageIsDragging(false);
+      }
+    }
+    function handleDragOver(e: DragEvent) {
+      e.preventDefault();
+    }
+    function handleDrop(e: DragEvent) {
+      e.preventDefault();
+      dragCounterRef.current = 0;
+      setPageIsDragging(false);
+      const file = e.dataTransfer?.files?.[0];
+      if (file) handleUpload(file);
+    }
+
+    document.addEventListener("dragenter", handleDragEnter);
+    document.addEventListener("dragleave", handleDragLeave);
+    document.addEventListener("dragover", handleDragOver);
+    document.addEventListener("drop", handleDrop);
+    return () => {
+      document.removeEventListener("dragenter", handleDragEnter);
+      document.removeEventListener("dragleave", handleDragLeave);
+      document.removeEventListener("dragover", handleDragOver);
+      document.removeEventListener("drop", handleDrop);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasets.length]);
 
   async function handleUpload(file: File) {
     if (datasets.length >= MAX_DATASETS) {
@@ -47,21 +97,16 @@ export function Datasets({
     const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
 
     startTransition(async () => {
-      const response = await updateDroplet(dropletId, {
-        datasets: [
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          ...datasets.map(({ id: _id, ...d }) => d),
-          {
-            name: file.name,
-            url: result.url!,
-            fileType: ext,
-            fileSize: file.size,
-          },
-        ],
+      const response = await createDataset({
+        name: file.name,
+        format: ext as "csv" | "json" | "xlsx",
+        fileUrl: result.url!,
+        fileSize: file.size,
+        droplet: dropletId,
       });
 
       if (!response.ok) {
-        await deleteDataset(result.url!);
+        await deleteDatasetFile(result.url!);
         toast.error("Failed to save dataset.");
         return;
       }
@@ -73,19 +118,14 @@ export function Datasets({
 
   async function handleRemove(dataset: Dataset) {
     startTransition(async () => {
-      const response = await updateDroplet(dropletId, {
-        datasets: datasets
-          .filter((d) => d.id !== dataset.id)
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          .map(({ id: _id, ...d }) => d),
-      });
+      const response = await deleteDatasetRecord(dataset.id);
 
       if (!response.ok) {
         toast.error("Failed to remove dataset.");
         return;
       }
 
-      await deleteDataset(dataset.url);
+      await deleteDatasetFile(dataset.fileUrl);
       toast.success(`"${dataset.name}" removed.`);
       router.refresh();
     });
@@ -126,7 +166,7 @@ export function Datasets({
             tabIndex={0}
             aria-label="Upload dataset"
             className={cn(
-              "flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-8 transition-colors",
+              "flex cursor-pointer items-center gap-3 rounded-lg border-2 border-dashed px-5 py-5 transition-colors",
               isDragging
                 ? "border-sky-400 bg-sky-50 dark:border-sky-500 dark:bg-sky-950/30"
                 : "border-[#D0D5DD] bg-[#fcfcfd] hover:border-[#2D7597] dark:border-slate-600 dark:bg-slate-800 dark:hover:border-[#2D7597]",
@@ -143,16 +183,18 @@ export function Datasets({
             onDragLeave={() => setIsDragging(false)}
             onDrop={onDrop}
           >
-            <IconUpload className="h-6 w-6 text-[#121216] dark:text-slate-300" />
-            <p className="text-sm text-[#121216] dark:text-slate-300">
-              Drag &amp; drop a file here, or{" "}
-              <span className="text-sky-600 underline dark:text-sky-400">
-                click to browse
-              </span>
-            </p>
-            <p className="text-xs text-[#121216] dark:text-slate-400">
-              CSV, JSON, XLSX — max 25 MB
-            </p>
+            <IconUpload className="h-5 w-5 shrink-0 text-[#121216] dark:text-slate-300" />
+            <div>
+              <p className="text-sm text-[#121216] dark:text-slate-300">
+                Drag &amp; drop a file here, or{" "}
+                <span className="text-sky-600 underline dark:text-sky-400">
+                  click to browse
+                </span>
+              </p>
+              <p className="text-xs text-slate-400 dark:text-slate-500">
+                CSV, JSON, XLSX — max 25 MB
+              </p>
+            </div>
           </div>
         )}
 
@@ -164,14 +206,9 @@ export function Datasets({
           onChange={onFileChange}
         />
 
-        {/* Dataset list */}
-        <div className="rounded-lg border border-[#D0D5DD] bg-[#fcfcfd] dark:border-slate-600 dark:bg-slate-800">
-          {datasets.length === 0 ? (
-            <div className="flex flex-col items-center justify-center gap-2 py-8 text-[#121216] dark:text-slate-300">
-              <IconFile className="h-6 w-6" />
-              <p className="text-sm">No datasets uploaded yet</p>
-            </div>
-          ) : (
+        {/* Dataset list — only show when there are datasets */}
+        {datasets.length > 0 && (
+          <div className="rounded-lg border border-[#D0D5DD] bg-[#fcfcfd] dark:border-slate-600 dark:bg-slate-800">
             <ul className="divide-y divide-slate-200 dark:divide-slate-600">
               {datasets.map((dataset) => (
                 <li
@@ -185,7 +222,7 @@ export function Datasets({
                         {dataset.name}
                       </p>
                       <p className="text-xs text-slate-400 uppercase">
-                        {dataset.fileType} · {formatBytes(dataset.fileSize)}
+                        {dataset.format} · {formatBytes(dataset.fileSize)}
                       </p>
                     </div>
                   </div>
@@ -201,9 +238,24 @@ export function Datasets({
                 </li>
               ))}
             </ul>
-          )}
-        </div>
+          </div>
+        )}
       </div>
+
+      {/* Full-page drop overlay */}
+      {pageIsDragging && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="flex flex-col items-center gap-4 rounded-2xl border-2 border-dashed border-white/60 bg-white/90 px-16 py-12 shadow-2xl dark:border-slate-400 dark:bg-slate-800/90">
+            <IconUpload className="h-12 w-12 text-[#297496]" />
+            <p className="text-xl font-bold text-slate-900 dark:text-white">
+              Drop your dataset here
+            </p>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              CSV, JSON, or XLSX — max 25 MB
+            </p>
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/components/draft/metadata/datasets/datasets.tsx
+++ b/frontend/components/draft/metadata/datasets/datasets.tsx
@@ -76,7 +76,6 @@ export function Datasets({
       document.removeEventListener("dragover", handleDragOver);
       document.removeEventListener("drop", handleDrop);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [datasets.length]);
 
   async function handleUpload(file: File) {

--- a/frontend/components/notebook/notebook-code-viewer.tsx
+++ b/frontend/components/notebook/notebook-code-viewer.tsx
@@ -50,7 +50,7 @@ export function NotebookCodeViewer({
     await Promise.all(
       unloaded.map((ds) =>
         pyodide
-          .loadDataset(ds.name, ds.url)
+          .loadDataset(ds.name, ds.fileUrl)
           .then(() => datasetsLoadedRef.current.add(ds.id))
           .catch((err) =>
             console.warn(`Failed to load dataset "${ds.name}":`, err),

--- a/frontend/components/ui/blocknote/blocks/notebook-code-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/notebook-code-block.tsx
@@ -93,7 +93,7 @@ const NotebookCodeBlockComponent = ({ block, editor }: any) => {
     await Promise.all(
       unloaded.map((ds) =>
         pyodide
-          .loadDataset(ds.name, ds.url)
+          .loadDataset(ds.name, ds.fileUrl)
           .then(() => {
             datasetsLoadedRef.current.add(ds.id);
           })

--- a/frontend/lib/actions.ts
+++ b/frontend/lib/actions.ts
@@ -84,6 +84,17 @@ export async function uploadImage(formData: FormData) {
 
 export async function deleteDataset(fileUrl: string) {
   try {
+    // Local file deletion
+    if (isLocal && fileUrl.startsWith("/uploads/")) {
+      const filePath = path.join(
+        LOCAL_UPLOADS_DIR,
+        fileUrl.replace("/uploads/", ""),
+      );
+      await unlink(filePath).catch(() => {});
+      revalidateTag(CACHE_TAGS.datasets);
+      return { ok: true, error: null };
+    }
+
     const bucketName = process.env.AWS_S3_BUCKET_NAME!;
     const bucketUrl = process.env.AWS_S3_BUCKET_URL!;
     const prefix = bucketUrl.endsWith("/") ? bucketUrl : `${bucketUrl}/`;

--- a/frontend/lib/actions.ts
+++ b/frontend/lib/actions.ts
@@ -86,11 +86,18 @@ export async function deleteDataset(fileUrl: string) {
   try {
     // Local file deletion
     if (isLocal && fileUrl.startsWith("/uploads/")) {
-      const filePath = path.join(
-        LOCAL_UPLOADS_DIR,
-        fileUrl.replace("/uploads/", ""),
-      );
-      await unlink(filePath).catch(() => {});
+      const relativePath = fileUrl.slice("/uploads/".length);
+      const resolved = path.resolve(LOCAL_UPLOADS_DIR, relativePath);
+      // Prevent path traversal — ensure resolved path stays inside uploads dir
+      if (!resolved.startsWith(LOCAL_UPLOADS_DIR + path.sep)) {
+        return { ok: false, error: "Invalid file path." };
+      }
+      try {
+        await unlink(resolved);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT") throw err;
+      }
       revalidateTag(CACHE_TAGS.datasets);
       return { ok: true, error: null };
     }

--- a/frontend/lib/validations/dataset.ts
+++ b/frontend/lib/validations/dataset.ts
@@ -5,10 +5,18 @@ export const MAX_DATASET_FILE_SIZE = 25 * 1024 * 1024;
 
 export const datasetSchema = z.object({
   name: z.string().min(1).max(255),
-  fileUrl: z.string().min(1),
+  fileUrl: z
+    .string()
+    .min(1)
+    .refine(
+      (value) => value.startsWith("/uploads/") || /^https?:\/\/.+/i.test(value),
+      {
+        message: 'fileUrl must be an http(s) URL or a "/uploads/" path.',
+      },
+    ),
   format: z.enum(["csv", "json", "xlsx"]),
   fileSize: z.number().max(MAX_DATASET_FILE_SIZE),
-  droplet: z.number().int(),
+  droplet: z.number().int().positive(),
 });
 
 export type DatasetInput = z.infer<typeof datasetSchema>;

--- a/frontend/lib/validations/dataset.ts
+++ b/frontend/lib/validations/dataset.ts
@@ -5,9 +5,10 @@ export const MAX_DATASET_FILE_SIZE = 25 * 1024 * 1024;
 
 export const datasetSchema = z.object({
   name: z.string().min(1).max(255),
-  url: z.string().url(),
-  fileType: z.string().min(1),
+  fileUrl: z.string().min(1),
+  format: z.enum(["csv", "json", "xlsx"]),
   fileSize: z.number().max(MAX_DATASET_FILE_SIZE),
+  droplet: z.number().int(),
 });
 
 export type DatasetInput = z.infer<typeof datasetSchema>;

--- a/frontend/tests/components/draft/dataset-list.test.tsx
+++ b/frontend/tests/components/draft/dataset-list.test.tsx
@@ -25,22 +25,22 @@ const mockDatasets: Dataset[] = [
   {
     id: 1,
     name: "sales_data.csv",
-    url: "https://example.com/sales.csv",
-    fileType: "csv",
+    fileUrl: "https://example.com/sales.csv",
+    format: "csv",
     fileSize: 10240,
   },
   {
     id: 2,
     name: "products.json",
-    url: "https://example.com/products.json",
-    fileType: "json",
+    fileUrl: "https://example.com/products.json",
+    format: "json",
     fileSize: 5120,
   },
   {
     id: 3,
     name: "inventory.xlsx",
-    url: "https://example.com/inventory.xlsx",
-    fileType: "xlsx",
+    fileUrl: "https://example.com/inventory.xlsx",
+    format: "xlsx",
     fileSize: 20480,
   },
 ];

--- a/frontend/tests/components/draft/dataset-upload.test.tsx
+++ b/frontend/tests/components/draft/dataset-upload.test.tsx
@@ -94,8 +94,8 @@ describe("DatasetUpload", () => {
       {
         id: 1,
         name: "test.csv",
-        url: "https://example.com/test.csv",
-        fileType: "csv",
+        fileUrl: "https://example.com/test.csv",
+        format: "csv",
         fileSize: 1024,
       },
     ];
@@ -107,8 +107,8 @@ describe("DatasetUpload", () => {
     const fiveDatasets: Dataset[] = Array.from({ length: 5 }, (_, i) => ({
       id: i + 1,
       name: `dataset${i + 1}.csv`,
-      url: `https://example.com/dataset${i + 1}.csv`,
-      fileType: "csv",
+      fileUrl: `https://example.com/dataset${i + 1}.csv`,
+      format: "csv",
       fileSize: 1024,
     }));
     render(<DatasetUpload dropletId={1} datasets={fiveDatasets} />);
@@ -204,8 +204,8 @@ describe("DatasetUpload", () => {
       data: {
         id: 42,
         name: "data.csv",
-        url: "https://example.com/uploaded.csv",
-        fileType: "csv",
+        fileUrl: "https://example.com/uploaded.csv",
+        format: "csv",
         fileSize: 100,
       },
       error: null,
@@ -247,8 +247,8 @@ describe("DatasetUpload", () => {
       expect(uploadDataset).toHaveBeenCalled();
       expect(createDataset).toHaveBeenCalledWith(
         expect.objectContaining({
-          fileType: "csv",
-          url: "https://example.com/uploaded.csv",
+          format: "csv",
+          fileUrl: "https://example.com/uploaded.csv",
         }),
       );
     });

--- a/frontend/types/index.d.ts
+++ b/frontend/types/index.d.ts
@@ -8,8 +8,8 @@ export type DropletType = "knowledge" | "skill";
 export type Dataset = {
   id: number;
   name: string;
-  url: string;
-  fileType: string;
+  fileUrl: string;
+  format: string;
   fileSize: number;
 };
 


### PR DESCRIPTION
## Description

- **Dataset type mismatch**: Frontend `Dataset` type used `url`/`fileType` but Strapi schema uses `fileUrl`/`format`. Aligned the type, Zod validation, and all references.
- **Upload broken**: Was using `updateDroplet` to save datasets inline, but `datasets` is a `oneToMany` relation. Now creates records via `createDataset()` API with `droplet` foreign key.
- **Delete broken locally**: `deleteDataset` only handled S3 URLs. Added local file deletion for `/uploads/` paths in dev.
- **Notebook CSV loading broken**: `ds.url` was undefined after type change. Fixed both `notebook-code-viewer.tsx` and `notebook-code-block.tsx` to use `ds.fileUrl`.
- **UX improvements**: Removed redundant "No datasets uploaded yet" empty state. Added full-page drag overlay when dragging files anywhere on the page.
- **Tests updated**: All mock data aligned with new field names.

## Motivation and Context

Dataset upload, deletion, and notebook integration were all broken due to a mismatch between the frontend type definitions and the Strapi schema field names. This fix aligns everything and adds local dev support.

Closes ODY-406

## Screenshots (if appropriate):

N/A

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-page drag-and-drop for uploading datasets with a visual overlay.
  * Datasets can be associated with droplets for organization.

* **Improvements**
  * Dataset display now shows format labels (e.g., CSV/JSON/XLSX).
  * Improved dataset loading and more robust file deletion/cleanup handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->