### PR TITLE
Improvement/ody 410 add spotlight tour to the lessons page

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -142,3 +142,87 @@ html:not(.dark) .sp-wrapper .cm-focused .cm-selectionBackground {
 html:not(.dark) .sp-wrapper .cm-editor ::selection {
   background: #b3d4fd;
 }
+
+/* driver.js tour — custom popover styling */
+.draft-tour-popover.driver-popover {
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow:
+    0 8px 30px rgba(0, 0, 0, 0.12),
+    0 2px 8px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e5e7eb;
+  max-width: 300px;
+  font-family: inherit;
+}
+
+.draft-tour-popover .driver-popover-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 6px;
+  text-align: left;
+  line-height: 1.4;
+}
+
+.draft-tour-popover .driver-popover-description {
+  font-size: 13px;
+  color: #4b5563;
+  line-height: 1.6;
+  text-align: left;
+  margin-bottom: 0;
+}
+
+.draft-tour-popover .driver-popover-footer {
+  margin-top: 16px;
+  gap: 6px;
+}
+
+.draft-tour-popover .driver-popover-progress-text {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+.draft-tour-popover .driver-popover-next-btn,
+.draft-tour-popover .driver-popover-prev-btn,
+.draft-tour-popover .driver-popover-done-btn {
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 500 !important;
+  padding: 6px 14px;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  text-shadow: none;
+}
+
+.draft-tour-popover .driver-popover-next-btn,
+.draft-tour-popover .driver-popover-done-btn {
+  background-color: #2d7597;
+  color: #fff;
+}
+
+.draft-tour-popover .driver-popover-next-btn:hover,
+.draft-tour-popover .driver-popover-done-btn:hover {
+  opacity: 0.88;
+}
+
+.draft-tour-popover .driver-popover-prev-btn {
+  background-color: transparent;
+  color: #111827;
+  border: 1px solid #d1d5db;
+}
+
+.draft-tour-popover .driver-popover-prev-btn:hover {
+  background-color: #f3f4f6;
+}
+
+.draft-tour-popover .driver-popover-close-btn {
+  color: #9ca3af;
+  font-size: 18px;
+  top: 14px;
+  right: 14px;
+}
+
+.draft-tour-popover .driver-popover-close-btn:hover {
+  color: #374151;
+}

--- a/frontend/components/draft/add-lesson.tsx
+++ b/frontend/components/draft/add-lesson.tsx
@@ -264,7 +264,7 @@ export function AddLesson({
                 />
               </div>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
+            <DropdownMenuContent align="start">
               <DropdownMenuItem onClick={() => setIsImportModalOpen(true)}>
                 Import from Markdown
               </DropdownMenuItem>
@@ -286,7 +286,7 @@ export function AddLesson({
                 />
               </div>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
+            <DropdownMenuContent align="start">
               <DropdownMenuItem onClick={handleClick}>
                 New Lesson
               </DropdownMenuItem>

--- a/frontend/components/draft/draft-layout-shell.tsx
+++ b/frontend/components/draft/draft-layout-shell.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { Sidebar } from "./sidebar";
+import { DraftTour, TOUR_KEY } from "./draft-tour";
 import { Droplet, User } from "@/types";
 
 interface DraftLayoutShellProps {
@@ -34,15 +35,31 @@ export function DraftLayoutShell({
   children,
 }: DraftLayoutShellProps) {
   const [expanded, setExpanded] = useState(true);
+  const [tourRun, setTourRun] = useState(false);
+
+  useEffect(() => {
+    const completed = localStorage.getItem(TOUR_KEY);
+    if (!completed) {
+      const t = setTimeout(() => setTourRun(true), 600);
+      return () => clearTimeout(t);
+    }
+  }, []);
+
+  const restartTour = () => {
+    localStorage.removeItem(TOUR_KEY);
+    setTourRun(true);
+  };
 
   return (
     <div className="flex min-h-screen flex-col md:border-2 md:border-dashed md:border-slate-200 xl:flex-row md:dark:border-slate-700">
+      <DraftTour run={tourRun} setRun={setTourRun} />
       <Sidebar
         droplet={droplet}
         user={user}
         availableDroplets={availableDroplets}
         expanded={expanded}
         setExpanded={setExpanded}
+        onRestartTour={restartTour}
       />
       <main
         className={cn(

--- a/frontend/components/draft/draft-tour.tsx
+++ b/frontend/components/draft/draft-tour.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { driver } from "driver.js";
+import "driver.js/dist/driver.css";
+
+export const TOUR_KEY = "draft-tour-v1";
+
+interface DraftTourProps {
+  run: boolean;
+  setRun: (v: boolean) => void;
+}
+
+export function DraftTour({ run, setRun }: DraftTourProps) {
+  const driverRef = useRef<ReturnType<typeof driver> | null>(null);
+
+  useEffect(() => {
+    if (!run) {
+      driverRef.current?.destroy();
+      return;
+    }
+
+    const d = driver({
+      showProgress: true,
+      animate: true,
+      overlayColor: "rgba(0,0,0,0.4)",
+      overlayOpacity: 0.4,
+      smoothScroll: true,
+      allowClose: true,
+      stagePadding: 6,
+      stageRadius: 8,
+      popoverOffset: 24,
+      popoverClass: "draft-tour-popover",
+      nextBtnText: "Next",
+      prevBtnText: "Back",
+      doneBtnText: "Done",
+      onCloseClick: () => {
+        setRun(false);
+        localStorage.setItem(TOUR_KEY, "completed");
+      },
+      onDestroyStarted: () => {
+        setRun(false);
+        localStorage.setItem(TOUR_KEY, "completed");
+      },
+      steps: [
+        {
+          popover: {
+            title: "Welcome to the Lesson Editor",
+            description:
+              "Let's take a quick tour of the tools available while drafting a droplet. You can skip at any time.",
+            side: "over",
+            align: "center",
+          },
+        },
+        {
+          element: "#tour-back-btn-icon",
+          popover: {
+            title: "Back to My Content",
+            description: "Click here to go back to your content library.",
+            side: "right",
+            align: "start",
+          },
+        },
+        {
+          element: "#tour-auto-format",
+          popover: {
+            title: "Auto-Format Slides",
+            description:
+              "Use AI to automatically insert slide breaks into your lesson content. This can only be used once per droplet.",
+            side: "right",
+            align: "start",
+          },
+        },
+        {
+          element: "#tour-present",
+          popover: {
+            title: "Present as Slides",
+            description:
+              "Once you've added slide breaks, launch your lesson as a slideshow presentation.",
+            side: "right",
+            align: "start",
+          },
+        },
+        {
+          element: "#tour-overview",
+          popover: {
+            title: "Droplet Overview",
+            description:
+              "Jump to the droplet overview page to edit the title, description, learning objectives, and other metadata.",
+            side: "right",
+            align: "start",
+          },
+        },
+        {
+          element: "#tour-add-lesson",
+          popover: {
+            title: "Add Lessons",
+            description:
+              "Create a new lesson, import one from Markdown, or upload a file (PDF, PPTX) to convert it into a lesson.",
+            side: "right",
+            align: "start",
+          },
+        },
+        {
+          element: "#tour-bottom-actions",
+          popover: {
+            title: "Preview & Publish",
+            description:
+              "Preview how your droplet looks to learners, or submit it for review / publish it when it's ready.",
+            side: "top",
+            align: "start",
+          },
+        },
+      ],
+    });
+
+    driverRef.current = d;
+    d.drive();
+  }, [run]);
+
+  return null;
+}

--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -40,6 +40,7 @@ import {
   IconPresentation,
   IconSearch,
   IconLayoutRows,
+  IconHelp,
 } from "@tabler/icons-react";
 import { toast } from "sonner";
 import Link from "next/link";
@@ -79,6 +80,7 @@ export function Sidebar({
   availableDroplets,
   expanded,
   setExpanded,
+  onRestartTour,
 }: {
   user: User;
   droplet: Pick<
@@ -100,6 +102,7 @@ export function Sidebar({
   availableDroplets: Pick<Droplet, "id" | "name" | "slug" | "lessons">[];
   expanded: boolean;
   setExpanded: (v: boolean) => void;
+  onRestartTour: () => void;
 }) {
   const [headerHeight, setHeaderHeight] = useState(69);
   const sidebarRef = useRef<HTMLElement>(null);
@@ -404,6 +407,7 @@ export function Sidebar({
             <div className="flex flex-row items-center justify-between pb-2">
               <button
                 type="button"
+                id="tour-back-btn"
                 data-testid="home"
                 onClick={() =>
                   droplet.status !== "draft"
@@ -412,66 +416,85 @@ export function Sidebar({
                 }
                 className="flex flex-1 items-center p-2"
               >
-                <IconArrowLeft className="h-5 w-5 flex-shrink-0" />
+                <span id="tour-back-btn-icon" className="flex items-center">
+                  <IconArrowLeft className="h-5 w-5 flex-shrink-0" />
+                </span>
               </button>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    {hasAutoFormatted ? (
-                      <button
-                        aria-disabled="true"
-                        onClick={(e) => e.preventDefault()}
-                        className="cursor-not-allowed p-2 text-slate-400 dark:text-slate-600"
-                      >
-                        <IconLayoutRows className="h-5 w-5" />
-                      </button>
-                    ) : (
-                      <button
-                        onClick={() => setShowAutoFormatConfirm(true)}
-                        disabled={isAutoFormatting}
-                        className="p-2 hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:text-slate-300"
-                      >
-                        {isAutoFormatting ? (
-                          <IconLoader2 className="h-5 w-5 animate-spin" />
-                        ) : (
+              <div id="tour-auto-format">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      {hasAutoFormatted ? (
+                        <button
+                          aria-disabled="true"
+                          onClick={(e) => e.preventDefault()}
+                          className="cursor-not-allowed p-2 text-slate-400 dark:text-slate-600"
+                        >
                           <IconLayoutRows className="h-5 w-5" />
-                        )}
-                      </button>
-                    )}
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {hasAutoFormatted
-                      ? "Slide breaks already generated"
-                      : "Generate slide breaks"}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() => setShowAutoFormatConfirm(true)}
+                          disabled={isAutoFormatting}
+                          className="p-2 hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:text-slate-300"
+                        >
+                          {isAutoFormatting ? (
+                            <IconLoader2 className="h-5 w-5 animate-spin" />
+                          ) : (
+                            <IconLayoutRows className="h-5 w-5" />
+                          )}
+                        </button>
+                      )}
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {hasAutoFormatted
+                        ? "Slide breaks already generated"
+                        : "Generate slide breaks"}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+              <div id="tour-present">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      {hasSlideBreaks ? (
+                        <Link
+                          href={`/d/${droplet.slug}/present`}
+                          target="_blank"
+                          className="p-2 text-indigo-500 hover:text-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-500"
+                        >
+                          <IconPresentation className="h-5 w-5" />
+                        </Link>
+                      ) : (
+                        <button
+                          aria-disabled="true"
+                          onClick={(e) => e.preventDefault()}
+                          className="cursor-not-allowed p-2 text-slate-400 dark:text-slate-600"
+                        >
+                          <IconPresentation className="h-5 w-5" />
+                        </button>
+                      )}
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {hasSlideBreaks
+                        ? "Present as slides"
+                        : "Add slide breaks to enable presentation mode"}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    {hasSlideBreaks ? (
-                      <Link
-                        href={`/d/${droplet.slug}/present`}
-                        target="_blank"
-                        className="p-2 text-indigo-500 hover:text-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-500"
-                      >
-                        <IconPresentation className="h-5 w-5" />
-                      </Link>
-                    ) : (
-                      <button
-                        aria-disabled="true"
-                        onClick={(e) => e.preventDefault()}
-                        className="cursor-not-allowed p-2 text-slate-400 dark:text-slate-600"
-                      >
-                        <IconPresentation className="h-5 w-5" />
-                      </button>
-                    )}
+                    <button
+                      onClick={onRestartTour}
+                      className="p-2 hover:text-slate-600 dark:hover:text-slate-300"
+                    >
+                      <IconHelp className="h-5 w-5" />
+                    </button>
                   </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {hasSlideBreaks
-                      ? "Present as slides"
-                      : "Add slide breaks to enable presentation mode"}
-                  </TooltipContent>
+                  <TooltipContent side="bottom">Replay tour</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
               <button
@@ -505,11 +528,12 @@ export function Sidebar({
             </Dialog>
 
             <div className="-mt-2 flex flex-col space-y-1.5">
-              <p className="mt-6 px-4 pb-3 text-xl leading-7 font-extrabold">
+              <p className="mt-6 px-4 pb-3 text-2xl leading-7 font-extrabold">
                 {droplet.name}
               </p>
 
               <Link
+                id="tour-overview"
                 href={`/draft/d/${droplet.slug}`}
                 className={
                   pathname === `/draft/d/${droplet.slug}`
@@ -560,7 +584,7 @@ export function Sidebar({
               </AlertDialog>
 
               {/* Add lesson section */}
-              <div>
+              <div id="tour-add-lesson">
                 <MantineProvider>
                   <AddLesson
                     droplet={droplet}
@@ -573,27 +597,29 @@ export function Sidebar({
               </div>
 
               {/* Sortable lessons list */}
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={handleDragEnd}
-              >
-                <SortableContext
-                  items={lessons.map((lesson) => lesson.id)}
-                  strategy={verticalListSortingStrategy}
+              <div id="tour-lessons-list">
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={handleDragEnd}
                 >
-                  <ul className="space-y-1.5">
-                    {lessons.map((lesson) => (
-                      <SortableLesson
-                        key={lesson.id}
-                        lesson={lesson}
-                        droplet={droplet}
-                        pathname={pathname}
-                      />
-                    ))}
-                  </ul>
-                </SortableContext>
-              </DndContext>
+                  <SortableContext
+                    items={lessons.map((lesson) => lesson.id)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    <ul className="space-y-1.5">
+                      {lessons.map((lesson) => (
+                        <SortableLesson
+                          key={lesson.id}
+                          lesson={lesson}
+                          droplet={droplet}
+                          pathname={pathname}
+                        />
+                      ))}
+                    </ul>
+                  </SortableContext>
+                </DndContext>
+              </div>
 
               {isProcessing && (
                 <div className="p-2 text-center text-sm text-slate-500 dark:text-slate-400">
@@ -603,7 +629,10 @@ export function Sidebar({
             </div>
           </div>
 
-          <div className="border-t border-slate-200 p-3 dark:border-slate-700">
+          <div
+            id="tour-bottom-actions"
+            className="border-t border-slate-200 p-3 dark:border-slate-700"
+          >
             <div className="flex gap-2 [&>*]:flex-1 [&>a]:flex-1 [&>button]:flex-1">
               <Link
                 href={

--- a/frontend/components/draft/sortable-lesson.tsx
+++ b/frontend/components/draft/sortable-lesson.tsx
@@ -80,7 +80,7 @@ export function SortableLesson({
           className="flex flex-grow"
           passHref
         >
-          <span className="pl-2 text-base leading-none font-medium">
+          <span className="pl-2 text-sm leading-none font-medium">
             {lesson.name}
           </span>
         </Link>

--- a/frontend/components/droplets/sidebar.tsx
+++ b/frontend/components/droplets/sidebar.tsx
@@ -282,7 +282,7 @@ export default function Sidebar({
             </div>
 
             <div className="-mt-2 flex flex-col space-y-1.5">
-              <p className="mt-6 px-4 pb-3 text-xl leading-7 font-extrabold">
+              <p className="mt-6 px-4 pb-3 text-2xl leading-7 font-extrabold">
                 {droplet.name}
               </p>
 
@@ -350,7 +350,7 @@ export default function Sidebar({
                                 : "bg-slate-300 dark:bg-slate-600",
                             )}
                           />
-                          <span className="pl-3 text-base leading-snug">
+                          <span className="pl-3 text-sm leading-snug">
                             {lesson.name}
                           </span>
                           {isLocked && (

--- a/frontend/components/ui/blocknote/editor/custom-blocknote.css
+++ b/frontend/components/ui/blocknote/editor/custom-blocknote.css
@@ -207,6 +207,12 @@
   color: inherit !important;
 }
 
+/* Heading sizes — BlockNote defaults (3em/2em/1.3em) are too aggressive.
+   Scale them down to a tighter, document-friendly hierarchy. */
+[data-content-type=heading]              { --level: 1.875em !important; }
+[data-content-type=heading][data-level="2"] { --level: 1.5em !important; }
+[data-content-type=heading][data-level="3"] { --level: 1.2em !important; }
+
 /* Placeholder text color — match overview page input text (#121216 light, slate-300 dark) */
 .bn-editor .bn-block-content[data-is-empty-and-focused] .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before,
 .bn-editor .bn-block-content[data-is-only-empty-block] .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before {

--- a/frontend/components/ui/user-multi-select.tsx
+++ b/frontend/components/ui/user-multi-select.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { CheckIcon, X } from "lucide-react";
+import { CheckIcon, Plus } from "lucide-react";
 import {
   Command,
   CommandEmpty,
@@ -16,7 +16,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { AuthorizedUser } from "@/types";
 import { fetchAuthorizedUsers } from "@/lib/requests/authorized-user";
 import { cn } from "@/lib/utils";
@@ -54,11 +53,6 @@ export function UserMultiSelect({
     });
   }, [users, search]);
 
-  const selectedUsers = useMemo(
-    () => users.filter((u) => selectedIds.includes(u.id)),
-    [users, selectedIds],
-  );
-
   const getUserLabel = (user: AuthorizedUser) =>
     user.firstName && user.lastName
       ? `${user.firstName} ${user.lastName}`
@@ -71,45 +65,10 @@ export function UserMultiSelect({
           type="button"
           role="combobox"
           variant="outline"
-          className={cn(
-            "h-auto min-h-10 w-full justify-start rounded-lg border border-[#D0D5DD] bg-white px-4 py-2 text-sm font-medium text-[#344054] transition-colors hover:border-slate-400 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-800",
-          )}
+          className="h-9 w-9 border-none bg-transparent p-0 text-[#344054] shadow-none transition-colors hover:bg-transparent hover:text-slate-600 dark:text-slate-300 dark:hover:text-slate-100"
+          aria-label={placeholder}
         >
-          {selectedUsers.length > 0 ? (
-            <div className="flex w-full flex-wrap items-center justify-start gap-1">
-              {selectedUsers.map((user) => (
-                <Badge
-                  variant="outline"
-                  key={user.id}
-                  className="flex items-center gap-1 rounded-full bg-white px-2 py-0.5 font-normal text-slate-800"
-                >
-                  {getUserLabel(user)}
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onChange(selectedIds.filter((id) => id !== user.id));
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        onChange(selectedIds.filter((id) => id !== user.id));
-                      }
-                    }}
-                    className="ml-0.5 cursor-pointer rounded-full hover:opacity-70"
-                  >
-                    <X className="h-3 w-3" />
-                  </span>
-                </Badge>
-              ))}
-            </div>
-          ) : (
-            <p className="font-normal text-[#121216] dark:text-slate-500">
-              {placeholder}
-            </p>
-          )}
+          <Plus className="h-4 w-4" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[400px] p-0" align="start">

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -84,6 +84,7 @@
         "cmdk": "^1.0.0",
         "dompurify": "^3.2.7",
         "dotenv": "^16.4.7",
+        "driver.js": "^1.4.0",
         "highlight.js": "^11.11.0",
         "husky": "^9.0.11",
         "isomorphic-dompurify": "^2.19.0",
@@ -3477,22 +3478,22 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/react": {
@@ -3511,12 +3512,12 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.4"
+        "@floating-ui/dom": "^1.7.6"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -3524,9 +3525,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@formatjs/ecma402-abstract": {
@@ -12745,6 +12746,12 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/driver.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -22766,9 +22773,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -116,6 +116,7 @@
     "cmdk": "^1.0.0",
     "dompurify": "^3.2.7",
     "dotenv": "^16.4.7",
+    "driver.js": "^1.4.0",
     "highlight.js": "^11.11.0",
     "husky": "^9.0.11",
     "isomorphic-dompurify": "^2.19.0",


### PR DESCRIPTION
## Description                                                                                                                             
                                                                                                                                          
  Adds a spotlight tour to the lesson editor (draft page) using driver.js. The tour walks content creators through the key UI elements: the back button, auto-format, present, overview, add lessons, and preview/publish actions. The tour runs once per user and is stored in localStorage so it doesn't repeat.
                                                                                                                                          
  Also includes several sidebar polish improvements made alongside the tour work:                                                         
  - Droplet title font size bumped to text-2xl in both the draft and preview sidebars
  - Lesson items reduced to text-sm to visually subordinate them under the nav items                                                      
  - BlockNote heading sizes scaled down from BlockNote's defaults (H1: 3em → 1.875em, H2: 2em → 1.5em, H3: 1.3em → 1.2em) for a more proportional document feel                                                                                                              
                                                                                                                                          
## Motivation and Context                                                                                                                  
                                                                                                                                          
  New content creators had no guidance on where key tools lived in the lesson editor. The spotlight tour provides a lightweight, one-time onboarding experience without requiring any backend changes.
                                                                                                                                          
  The sidebar and heading size changes address visual disproportionality — the droplet title was the same size as nav items, and BlockNote's default heading scale was excessively large relative to the surrounding UI.