### PR TITLE
fix: dataset upload error handling and block type descriptions

### DIFF
--- a/frontend/components/draft/dataset/dataset-upload.tsx
+++ b/frontend/components/draft/dataset/dataset-upload.tsx
@@ -53,6 +53,14 @@ export function DatasetUpload({ dropletId, datasets }: DatasetUploadProps) {
 
   const onDrop = useCallback(
     async (acceptedFiles: File[], rejectedFiles?: unknown[]) => {
+      // Reject oversized files immediately
+      const dropped = acceptedFiles[0];
+      if (dropped && dropped.size > MAX_DATASET_FILE_SIZE) {
+        toast.error("File is too large. Maximum file size is 25 MB.");
+        setUploadState({ status: "idle" });
+        return;
+      }
+
       // Handle rejected files (size or type)
       if (
         rejectedFiles &&
@@ -64,10 +72,8 @@ export function DatasetUpload({ dropletId, datasets }: DatasetUploadProps) {
         )[0];
         const firstError = firstRejected.errors[0];
         if (firstError?.code === "file-too-large") {
-          setUploadState({
-            status: "error",
-            message: "File is too large. Maximum file size is 25 MB.",
-          });
+          toast.error("File is too large. Maximum file size is 25 MB.");
+          setUploadState({ status: "idle" });
         } else {
           setUploadState({
             status: "error",
@@ -131,40 +137,54 @@ export function DatasetUpload({ dropletId, datasets }: DatasetUploadProps) {
 
     const { file, format } = uploadState;
 
+    if (file.size > MAX_DATASET_FILE_SIZE) {
+      toast.error("File is too large. Maximum file size is 25 MB.");
+      setUploadState({ status: "idle" });
+      return;
+    }
+
     setUploadState({ status: "uploading" });
 
-    // 1. Upload the file to S3
-    const formData = new FormData();
-    formData.append("file", file);
+    try {
+      // 1. Upload the file to S3
+      const formData = new FormData();
+      formData.append("file", file);
 
-    const uploadResult = await uploadDataset(formData);
+      const uploadResult = await uploadDataset(formData);
 
-    if (!uploadResult.ok || !uploadResult.url) {
-      toast.error(uploadResult.error ?? "Upload failed. Please try again.");
+      if (!uploadResult.ok || !uploadResult.url) {
+        toast.error(uploadResult.error ?? "Upload failed. Please try again.");
+        setUploadState({ status: "idle" });
+        return;
+      }
+
+      // 2. Create the dataset record in Strapi
+      const createResult = await createDataset({
+        name: file.name,
+        fileUrl: uploadResult.url,
+        format,
+        fileSize: file.size,
+        droplet: dropletId,
+      });
+
+      if (!createResult.ok || !createResult.data) {
+        toast.error(
+          createResult.error ?? "Failed to save dataset. Please try again.",
+        );
+        setUploadState({ status: "idle" });
+        return;
+      }
+
+      toast.success(`"${file.name}" uploaded successfully.`);
+      setLocalDatasets((prev) => [...prev, createResult.data!]);
       setUploadState({ status: "idle" });
-      return;
-    }
-
-    // 2. Create the dataset record in Strapi
-    const createResult = await createDataset({
-      name: file.name,
-      fileUrl: uploadResult.url,
-      format,
-      fileSize: file.size,
-      droplet: dropletId,
-    });
-
-    if (!createResult.ok || !createResult.data) {
+    } catch (err) {
+      console.error("Dataset upload failed:", err);
       toast.error(
-        createResult.error ?? "Failed to save dataset. Please try again.",
+        "Upload failed. The file may be too large — maximum size is 25 MB.",
       );
       setUploadState({ status: "idle" });
-      return;
     }
-
-    toast.success(`"${file.name}" uploaded successfully.`);
-    setLocalDatasets((prev) => [...prev, createResult.data!]);
-    setUploadState({ status: "idle" });
   };
 
   const handleCancel = () => {

--- a/frontend/components/draft/dataset/dataset-upload.tsx
+++ b/frontend/components/draft/dataset/dataset-upload.tsx
@@ -4,7 +4,10 @@ import { useState, useCallback } from "react";
 import { useDropzone } from "react-dropzone";
 import { Dataset } from "@/types";
 import { parseDatasetFile, ParsedDataset } from "@/lib/dataset-parser";
-import { uploadDataset } from "@/lib/actions";
+import {
+  uploadDataset,
+  deleteDataset as deleteDatasetFile,
+} from "@/lib/actions";
 import { createDataset } from "@/lib/requests/dataset";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -73,14 +76,12 @@ export function DatasetUpload({ dropletId, datasets }: DatasetUploadProps) {
         const firstError = firstRejected.errors[0];
         if (firstError?.code === "file-too-large") {
           toast.error("File is too large. Maximum file size is 25 MB.");
-          setUploadState({ status: "idle" });
         } else {
-          setUploadState({
-            status: "error",
-            message:
-              "Unsupported file type. Please upload a CSV, JSON, or XLSX file.",
-          });
+          toast.error(
+            "Unsupported file type. Please upload a CSV, JSON, or XLSX file.",
+          );
         }
+        setUploadState({ status: "idle" });
         return;
       }
 
@@ -168,6 +169,7 @@ export function DatasetUpload({ dropletId, datasets }: DatasetUploadProps) {
       });
 
       if (!createResult.ok || !createResult.data) {
+        await deleteDatasetFile(uploadResult.url).catch(() => {});
         toast.error(
           createResult.error ?? "Failed to save dataset. Please try again.",
         );

--- a/frontend/components/draft/lesson/blocknote-editor-client.tsx
+++ b/frontend/components/draft/lesson/blocknote-editor-client.tsx
@@ -613,10 +613,10 @@ export function BlockNoteEditorClient({
                 ...quizItems,
                 ...latexItems,
                 ...codeItems,
+                ...notebookCodeItems,
                 ...sandpackItems,
                 ...slideBreakItems,
                 ...columnBreakItems,
-                ...notebookCodeItems,
               ];
 
               return allItems.filter(

--- a/frontend/components/draft/metadata/datasets/datasets.tsx
+++ b/frontend/components/draft/metadata/datasets/datasets.tsx
@@ -118,22 +118,22 @@ export function Datasets({
         return;
       }
 
-      startTransition(async () => {
-        const response = await createDataset({
-          name: file.name,
-          format: ext as "csv" | "json" | "xlsx",
-          fileUrl: result.url!,
-          fileSize: file.size,
-          droplet: dropletId,
-        });
+      const response = await createDataset({
+        name: file.name,
+        format: ext as "csv" | "json" | "xlsx",
+        fileUrl: result.url!,
+        fileSize: file.size,
+        droplet: dropletId,
+      });
 
-        if (!response.ok) {
-          await deleteDatasetFile(result.url!);
-          toast.error("Failed to save dataset.");
-          return;
-        }
+      if (!response.ok) {
+        await deleteDatasetFile(result.url!);
+        toast.error("Failed to save dataset.");
+        return;
+      }
 
-        toast.success(`"${file.name}" uploaded.`);
+      toast.success(`"${file.name}" uploaded.`);
+      startTransition(() => {
         router.refresh();
       });
     } catch (err) {
@@ -178,7 +178,13 @@ export function Datasets({
         </h2>
         <Tooltip>
           <TooltipTrigger asChild>
-            <IconInfoCircle className="h-4 w-4 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300" />
+            <button
+              type="button"
+              aria-label="Dataset help"
+              className="inline-flex"
+            >
+              <IconInfoCircle className="h-4 w-4 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300" />
+            </button>
           </TooltipTrigger>
           <TooltipContent side="right" className="max-w-xs">
             <p>
@@ -242,7 +248,7 @@ export function Datasets({
         <input
           ref={inputRef}
           type="file"
-          accept=".csv,.json,.xlsx,.xls"
+          accept=".csv,.json,.xlsx"
           className="hidden"
           onChange={onFileChange}
         />

--- a/frontend/components/draft/metadata/datasets/datasets.tsx
+++ b/frontend/components/draft/metadata/datasets/datasets.tsx
@@ -12,8 +12,19 @@ import {
   deleteDataset as deleteDatasetRecord,
 } from "@/lib/requests/dataset";
 import { toast } from "sonner";
-import { IconUpload, IconFile, IconTrash } from "@tabler/icons-react";
+import {
+  IconUpload,
+  IconFile,
+  IconTrash,
+  IconInfoCircle,
+} from "@tabler/icons-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { MAX_DATASET_FILE_SIZE } from "@/lib/validations/dataset";
 
 const MAX_DATASETS = 5;
 
@@ -84,35 +95,51 @@ export function Datasets({
       return;
     }
 
-    const formData = new FormData();
-    formData.append("file", file);
-    const result = await uploadDataset(formData);
-
-    if (!result.ok || !result.url) {
-      toast.error(result.error ?? "Upload failed.");
+    if (file.size > MAX_DATASET_FILE_SIZE) {
+      toast.error("File is too large. Maximum file size is 25 MB.");
       return;
     }
 
     const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
+    if (!["csv", "json", "xlsx"].includes(ext)) {
+      toast.error(
+        "Unsupported file type. Please upload a CSV, JSON, or XLSX file.",
+      );
+      return;
+    }
 
-    startTransition(async () => {
-      const response = await createDataset({
-        name: file.name,
-        format: ext as "csv" | "json" | "xlsx",
-        fileUrl: result.url!,
-        fileSize: file.size,
-        droplet: dropletId,
-      });
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const result = await uploadDataset(formData);
 
-      if (!response.ok) {
-        await deleteDatasetFile(result.url!);
-        toast.error("Failed to save dataset.");
+      if (!result.ok || !result.url) {
+        toast.error(result.error ?? "Upload failed.");
         return;
       }
 
-      toast.success(`"${file.name}" uploaded.`);
-      router.refresh();
-    });
+      startTransition(async () => {
+        const response = await createDataset({
+          name: file.name,
+          format: ext as "csv" | "json" | "xlsx",
+          fileUrl: result.url!,
+          fileSize: file.size,
+          droplet: dropletId,
+        });
+
+        if (!response.ok) {
+          await deleteDatasetFile(result.url!);
+          toast.error("Failed to save dataset.");
+          return;
+        }
+
+        toast.success(`"${file.name}" uploaded.`);
+        router.refresh();
+      });
+    } catch (err) {
+      console.error("Dataset upload failed:", err);
+      toast.error("Upload failed. Please try again.");
+    }
   }
 
   async function handleRemove(dataset: Dataset) {
@@ -145,9 +172,24 @@ export function Datasets({
 
   return (
     <section className="w-full">
-      <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
-        Datasets
-      </h2>
+      <div className="flex items-center gap-2">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
+          Datasets
+        </h2>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <IconInfoCircle className="h-4 w-4 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300" />
+          </TooltipTrigger>
+          <TooltipContent side="right" className="max-w-xs">
+            <p>
+              Upload data files (CSV, JSON, or XLSX) for students to explore.
+              Datasets can only be used inside Notebook Code blocks (the
+              Jupyter-like Python cells). They are automatically available to
+              import and query in any notebook cell within this droplet.
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
       <div className="mt-1 flex items-center justify-between">
         <p className="text-slate-600 dark:text-slate-300">
           Upload data files for use in notebook code blocks (CSV, JSON, or XLSX)

--- a/frontend/components/ui/blocknote/editor/slash-menu-config.ts
+++ b/frontend/components/ui/blocknote/editor/slash-menu-config.ts
@@ -235,7 +235,7 @@ export const getCodeSlashMenuItems = (
     aliases: ["code", "snippet", "programming", "syntax"],
     group: "Code",
     subtext:
-      "Show read-only code examples with syntax highlighting and optional execution",
+      "Editable code block with syntax highlighting and optional execution",
   },
 ];
 

--- a/frontend/components/ui/blocknote/editor/slash-menu-config.ts
+++ b/frontend/components/ui/blocknote/editor/slash-menu-config.ts
@@ -49,7 +49,7 @@ export const getCalloutSlashMenuItems = (
     "warning",
     "Warning",
     ["warning", "warn", "alert"],
-    "Pink warning callout",
+    "Highlight common mistakes or pitfalls to avoid",
     createElement(TriangleAlert, { className: "h-4 w-4" }),
   ),
   createCalloutItem(
@@ -57,7 +57,7 @@ export const getCalloutSlashMenuItems = (
     "question",
     "Question",
     ["question", "q", "help"],
-    "Blue question callout",
+    "Pose a thought-provoking question for students to consider",
     createElement(CircleHelp, { className: "h-4 w-4" }),
   ),
   createCalloutItem(
@@ -65,7 +65,7 @@ export const getCalloutSlashMenuItems = (
     "important",
     "Important",
     ["important", "imp", "key"],
-    "Orange important callout",
+    "Emphasize key concepts or must-know information",
     createElement(CircleAlert, { className: "h-4 w-4" }),
   ),
   createCalloutItem(
@@ -73,7 +73,7 @@ export const getCalloutSlashMenuItems = (
     "definition",
     "Definition",
     ["definition", "def", "define"],
-    "Green definition callout",
+    "Define a term, concept, or technical vocabulary",
     createElement(BookOpenText, { className: "h-4 w-4" }),
   ),
   createCalloutItem(
@@ -81,7 +81,7 @@ export const getCalloutSlashMenuItems = (
     "more-information",
     "More Information",
     ["more", "info", "more information", "additional"],
-    "Purple info callout",
+    "Add optional deeper context for curious students",
     createElement(BadgeInfo, { className: "h-4 w-4" }),
   ),
   createCalloutItem(
@@ -89,7 +89,7 @@ export const getCalloutSlashMenuItems = (
     "caution",
     "Caution",
     ["caution", "careful", "watch"],
-    "Yellow caution callout",
+    "Warn about something that could cause errors or confusion",
     createElement(Bell, { className: "h-4 w-4" }),
   ),
   createCalloutItem(
@@ -97,7 +97,7 @@ export const getCalloutSlashMenuItems = (
     "default",
     "Default Callout",
     ["callout", "default", "note"],
-    "Gray default callout",
+    "General-purpose callout for notes or asides",
     createElement(Pin, { className: "h-4 w-4" }),
   ),
 ];
@@ -124,7 +124,7 @@ export const getQuizSlashMenuItems = (
     },
     aliases: ["true false", "tf", "quiz tf", "true/false", "quiz"],
     group: "Quizzes",
-    subtext: "Create a true/false question",
+    subtext: "Quick comprehension check with a true or false answer",
   },
   {
     title: "Open-Ended Quiz",
@@ -146,7 +146,7 @@ export const getQuizSlashMenuItems = (
     },
     aliases: ["open ended", "open", "essay", "free response", "quiz open"],
     group: "Quizzes",
-    subtext: "Create an open-ended question",
+    subtext: "Free-response question where students type their own answer",
   },
   {
     title: "Multiple Choice Quiz",
@@ -171,7 +171,7 @@ export const getQuizSlashMenuItems = (
     },
     aliases: ["multiple choice", "mc", "quiz mc", "mcq"],
     group: "Quizzes",
-    subtext: "Create a multiple choice question",
+    subtext: "Question with selectable answer options — great for assessments",
   },
 ];
 
@@ -205,7 +205,7 @@ export const getLatexSlashMenuItems = (
     },
     aliases: ["latex", "math", "formula", "equation"],
     group: "Math",
-    subtext: "Insert LaTeX math formula block",
+    subtext: "Use for equations, formulas, or mathematical notation",
   },
 ];
 
@@ -234,7 +234,8 @@ export const getCodeSlashMenuItems = (
     },
     aliases: ["code", "snippet", "programming", "syntax"],
     group: "Code",
-    subtext: "Display code with syntax highlighting",
+    subtext:
+      "Show read-only code examples with syntax highlighting and optional execution",
   },
 ];
 
@@ -260,9 +261,10 @@ export const getNotebookCodeSlashMenuItems = (
         "after",
       );
     },
-    aliases: ["notebook", "jupyter", "python", "colab"],
-    group: "Data Science",
-    subtext: "Interactive Python notebook cell with Pyodide",
+    aliases: ["notebook", "jupyter", "python", "colab", "dataset"],
+    group: "Code",
+    subtext:
+      "Jupyter-like cell where students write and run Python — only block that can use uploaded datasets",
   },
 ];
 
@@ -303,7 +305,8 @@ export const getSandpackSlashMenuItems = (
       "codepen",
     ],
     group: "Code",
-    subtext: "Interactive code sandbox with live preview",
+    subtext:
+      "Live HTML/CSS/JS sandbox with real-time preview — ideal for web dev lessons",
   },
 ];
 
@@ -322,7 +325,7 @@ export const getSlideBreakSlashMenuItems = (
     },
     aliases: ["slide", "break", "presentation", "page break", "divider"],
     group: "Presentation",
-    subtext: "Start a new presentation slide",
+    subtext: "Insert a divider to start a new slide in presentation mode",
   },
 ];
 
@@ -341,6 +344,7 @@ export const getColumnBreakSlashMenuItems = (
     },
     aliases: ["column", "col break", "split column", "column break"],
     group: "Presentation",
-    subtext: "Split content between left and right columns",
+    subtext:
+      "Split content into two columns — use within a slide for side-by-side layout",
   },
 ];

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -35,6 +35,7 @@ const nextConfig = {
       static: 180,
     },
     serverActions: {
+      bodySizeLimit: "30mb",
       allowedOrigins: [
         "localhost:3000",
         "dev2.khouryodyssey.org",

--- a/frontend/tests/components/draft/dataset-upload.test.tsx
+++ b/frontend/tests/components/draft/dataset-upload.test.tsx
@@ -181,10 +181,11 @@ describe("DatasetUpload", () => {
       capturedOnDrop!([], rejected);
     });
 
+    const { toast } = require("sonner");
     await waitFor(() => {
-      expect(
-        screen.getByText(/file is too large|exceeds the 25mb/i),
-      ).toBeInTheDocument();
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringMatching(/file is too large/i),
+      );
     });
   });
 

--- a/frontend/tests/components/draft/dataset-upload.test.tsx
+++ b/frontend/tests/components/draft/dataset-upload.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DatasetUpload } from "@/components/draft/dataset/dataset-upload";
+import { toast } from "sonner";
 import { Dataset } from "@/types";
 
 // Mock the Server Actions
@@ -181,7 +182,6 @@ describe("DatasetUpload", () => {
       capturedOnDrop!([], rejected);
     });
 
-    const { toast } = require("sonner");
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
         expect.stringMatching(/file is too large/i),
@@ -258,7 +258,6 @@ describe("DatasetUpload", () => {
   it("shows error toast when upload fails", async () => {
     const { parseDatasetFile } = require("@/lib/dataset-parser");
     const { uploadDataset } = require("@/lib/actions");
-    const { toast } = require("sonner");
 
     (parseDatasetFile as jest.Mock).mockResolvedValue(mockParsedDataset);
     (uploadDataset as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
## Summary
- Add `bodySizeLimit: '30mb'` to `next.config.mjs` so large dataset uploads reach the Server Action instead of silently failing
- Add client-side file size + file type validation with toast errors in both dataset upload paths (`dataset-upload.tsx` and `datasets.tsx`)
- Add try/catch around upload calls to prevent silent failures on dev
- Add dataset tooltip explaining that datasets only work in Notebook Code blocks
- Improve all slash menu block descriptions to explain when to use each type
- Group Notebook Code under "Code" alongside Code Block and Live Sandbox

## Test plan
- [ ] Upload a file > 25 MB → should see toast "File is too large" instantly, no server error
- [ ] Upload a valid file < 25 MB → should upload successfully
- [ ] Upload an unsupported file type → should see toast error
- [ ] Hover the (i) icon next to Datasets heading → tooltip mentions Notebook Code blocks
- [ ] Type `/` in the editor → verify block descriptions are helpful and Code group is together

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file format validation (CSV, JSON, XLSX) for dataset uploads
  * Introduced informational tooltips describing accepted file formats and upload constraints
  * Enhanced file size validation with clearer error feedback via toast notifications

* **Improvements**
  * Refined slash-menu descriptions in the editor for better user guidance
  * Extended maximum upload file size limit to 30MB

<!-- end of auto-generated comment: release notes by coderabbit.ai -->