### PR TITLE
fix: disable PostHog tracking on localhost (ODY-417)

### DIFF
--- a/frontend/components/providers/posthog-provider.tsx
+++ b/frontend/components/providers/posthog-provider.tsx
@@ -27,6 +27,8 @@ export function PostHogProvider({
   const searchParams = useSearchParams();
 
   useEffect(() => {
+    if (process.env.NEXT_PUBLIC_APP_ENV === "local") return;
+
     // Initialize PostHog (only once)
     if (typeof window !== "undefined" && !window.posthog) {
       posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {

--- a/frontend/providers/PHProvider.tsx
+++ b/frontend/providers/PHProvider.tsx
@@ -50,12 +50,20 @@ function PostHogIdentify() {
   return null;
 }
 
+const isLocal = process.env.NEXT_PUBLIC_APP_ENV === "local";
+
 export function PHProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
+    if (isLocal) return;
+
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || "", {
       api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     });
   }, []);
+
+  if (isLocal) {
+    return <>{children}</>;
+  }
 
   return (
     <PostHogProvider client={posthog}>


### PR DESCRIPTION
## Summary
- Skip `posthog.init()` when `NEXT_PUBLIC_APP_ENV === "local"` to stop polluting analytics with dev data
- Both `PHProvider.tsx` (active) and `posthog-provider.tsx` (legacy) updated
- Uses the same `NEXT_PUBLIC_APP_ENV` pattern as the environment banner

Closes ODY-417

## Test plan
- [ ] Run `npm run dev` locally → verify no PostHog network requests in DevTools
- [ ] Deploy to dev (`NEXT_PUBLIC_APP_ENV=development`) → verify PostHog still tracks
- [ ] Production (`NEXT_PUBLIC_APP_ENV=production`) → verify PostHog still tracks