### PR TITLE
improvement: show all playlists in voyage form and fix connector overlap

### DIFF
--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -356,36 +356,34 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
             />
           </div>
 
-          {/* Search results */}
-          {searchQuery.length > 0 && (
-            <div className="max-h-48 overflow-y-auto rounded-md border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
-              {availablePlaylists.length === 0 ? (
-                <p className="px-4 py-3 text-sm text-slate-500">
-                  No playlists found.
-                </p>
-              ) : (
-                availablePlaylists.slice(0, 10).map((playlist) => (
-                  <button
-                    key={playlist.id}
-                    type="button"
-                    className="flex w-full items-center justify-between px-4 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
-                    onClick={() => addPlaylist(playlist)}
-                    disabled={isPending}
-                  >
-                    <span className="truncate font-medium">
-                      {playlist.name}
+          {/* Available playlists */}
+          <div className="max-h-48 overflow-y-auto rounded-md border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
+            {availablePlaylists.length === 0 ? (
+              <p className="px-4 py-3 text-sm text-slate-500">
+                {searchQuery
+                  ? "No playlists found."
+                  : "All playlists have been added."}
+              </p>
+            ) : (
+              availablePlaylists.map((playlist) => (
+                <button
+                  key={playlist.id}
+                  type="button"
+                  className="flex w-full items-center justify-between px-4 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
+                  onClick={() => addPlaylist(playlist)}
+                  disabled={isPending}
+                >
+                  <span className="truncate font-medium">{playlist.name}</span>
+                  <div className="ml-2 flex flex-shrink-0 items-center gap-1 text-slate-400">
+                    <span className="text-xs">
+                      {playlist.droplets?.length ?? 0} droplets
                     </span>
-                    <div className="ml-2 flex flex-shrink-0 items-center gap-1 text-slate-400">
-                      <span className="text-xs">
-                        {playlist.droplets?.length ?? 0} droplets
-                      </span>
-                      <PlusIcon className="h-4 w-4 text-[#297496]" />
-                    </div>
-                  </button>
-                ))
-              )}
-            </div>
-          )}
+                    <PlusIcon className="h-4 w-4 text-[#297496]" />
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
 
           {/* Selected islands list */}
           {sortedForDisplay.length > 0 ? (
@@ -544,7 +542,7 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
             </div>
           ) : (
             <p className="text-sm text-slate-400 dark:text-slate-500">
-              Search above to add playlists as islands.
+              Select playlists above to add them as islands.
             </p>
           )}
         </div>

--- a/frontend/components/voyages/voyage-tree-island.tsx
+++ b/frontend/components/voyages/voyage-tree-island.tsx
@@ -388,7 +388,7 @@ export function VoyageTreeIsland({
         {/* Step number badge */}
         {stepNumber && (
           <div
-            className="absolute -top-1 left-0 z-10 flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold text-white shadow-md"
+            className="absolute top-1/2 -left-10 z-10 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-xs font-bold text-white shadow-md"
             style={{ backgroundColor: isLocked ? "#475569" : "#297496" }}
           >
             {stepNumber}

--- a/frontend/components/voyages/voyage-tree-map.tsx
+++ b/frontend/components/voyages/voyage-tree-map.tsx
@@ -118,7 +118,11 @@ function assignPositions(
 }
 
 /** Smooth bezier from bottom of parent to top of child, anchored to the
- *  rendered SVG geometry (not the layout box) so the line meets the island. */
+ *  rendered SVG geometry (not the layout box) so the line meets the island.
+ *  A top offset prevents the line from overlapping the palm tree canopy. */
+const TREE_CANOPY_OFFSET = 45;
+const LABEL_BELOW_OFFSET = 40;
+
 function bezierPath(
   px: number,
   py: number,
@@ -127,8 +131,8 @@ function bezierPath(
   parentVisibleHeight: number,
   childVisibleHeight: number,
 ): string {
-  const sy = py + parentVisibleHeight / 2;
-  const ey = cy - childVisibleHeight / 2;
+  const sy = py + parentVisibleHeight / 2 + LABEL_BELOW_OFFSET;
+  const ey = cy - childVisibleHeight / 2 - TREE_CANOPY_OFFSET;
   const my = (sy + ey) / 2;
   return `M ${px} ${sy} C ${px} ${my}, ${cx} ${my}, ${cx} ${ey}`;
 }


### PR DESCRIPTION
## Summary
- Show all available playlists by default in the voyage editor instead of requiring a search query first
- Search input now filters the visible list rather than gating it
- Fix connector lines overlapping palm tree canopy and droplet count labels
- Move step number badge to the left of the island to avoid overlap
- Update empty state messaging

## Test plan
- [ ] Open voyage editor → all playlists visible immediately without typing
- [ ] Type in search → list filters correctly
- [ ] Add all playlists → shows "All playlists have been added."
- [ ] Check connector lines between islands → no overlap with trees or labels
- [ ] Step number badges don't overlap island artwork

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-state messaging in the playlists section with context-aware guidance that adapts to user actions
  * Increased visibility by displaying all available playlists (previously limited to first 10)

* **Style**
  * Refined positioning of step number badges for better alignment in the voyage visualization
  * Adjusted connector line positioning throughout the voyage tree for enhanced visual clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->