### PR TITLE
Small UI fixes

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -6,7 +6,10 @@
     "react-hooks/exhaustive-deps": "warn",
     "react/no-unescaped-entities": "warn",
     "@typescript-eslint/no-explicit-any": "warn",
-    "@typescript-eslint/no-unused-vars": ["warn", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }
+    ],
     "@next/next/no-img-element": "warn",
     "react/jsx-key": "warn",
     "prefer-const": "warn",

--- a/frontend/app/(creation)/new/voyage/page.tsx
+++ b/frontend/app/(creation)/new/voyage/page.tsx
@@ -35,11 +35,11 @@ export default async function NewVoyage() {
   }
 
   return (
-    <div className="flex min-h-screen w-full flex-col items-center bg-white px-4 pt-12 md:px-12 dark:bg-slate-900">
-      <h1 className="mb-7 text-2xl font-bold tracking-tight text-slate-900 sm:text-4xl dark:text-white">
-        Create New Voyage
-      </h1>
-      <div className="w-full max-w-6xl">
+    <div className="bg-white px-4 pt-4 pb-8 md:px-16 md:pt-8 md:pb-16 lg:px-24 dark:bg-zinc-950">
+      <div className="flex w-full flex-col">
+        <h1 className="mb-7 text-4xl font-semibold text-black dark:text-white">
+          Create a Voyage
+        </h1>
         <VoyageForm playlists={publicPlaylists} authorId={authUser.id} />
       </div>
     </div>

--- a/frontend/app/(general)/page.tsx
+++ b/frontend/app/(general)/page.tsx
@@ -6,6 +6,9 @@ import { GradientBackground } from "@/components/gradient-bg";
 import { FunFact } from "@/components/droplets/fun-fact";
 import { getRandomFunFactDroplet } from "@/lib/requests/droplet";
 
+const outlineLinkCls =
+  "inline-flex items-center gap-2 rounded-[8px] border border-[#d0d5dd] bg-white px-[14px] py-[10px] text-sm font-medium text-[#344054] shadow-[0px_1px_2px_0px_rgba(16,24,40,0.05)] transition-colors hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700";
+
 export default async function HomeRoute() {
   const user = await getCurrentUser();
 
@@ -13,42 +16,34 @@ export default async function HomeRoute() {
   const droplet = droplets[Math.floor(Math.random() * droplets.length)];
 
   return (
-    <GradientBackground className="flex-grow">
-      <div className="isolate px-6 lg:px-8">
-        <div
-          className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
-          aria-hidden="true"
-        >
-          <div
-            className="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] opacity-30 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]"
-            style={{
-              clipPath:
-                "polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)",
-            }}
-          ></div>
-        </div>
-
-        <div className="mx-auto max-w-2xl py-0 lg:py-4">
-          <div className="text-center">
+    <GradientBackground className="px-12 lg:px-24">
+      <div className="mx-auto max-w-5xl">
+        <p className="mb-4 text-sm font-semibold tracking-widest text-sky-600 uppercase">
+          Khoury College
+        </p>
+        <div className="grid grid-cols-1 items-stretch gap-4 lg:grid-cols-2">
+          {/* Left: hero text */}
+          <div>
             <h1
-              className="text-4xl font-black tracking-tight text-balance text-slate-900 sm:text-6xl dark:text-white"
+              className="text-4xl leading-tight font-black tracking-tight text-slate-900 sm:text-5xl lg:text-6xl dark:text-white"
               role="heading"
             >
-              Reinforce Your Learning and Fuel Your Future
+              Reinforce Your
+              <br />
+              Learning.
             </h1>
-            <p className="mt-6 text-lg leading-8 text-slate-600 dark:text-slate-300">
-              Odyssey is a new platform designed to provide on-demand access to
-              modern knowledge and skills pertinent to {"today's"} undergraduate
-              Khoury students.
+            <p className="mt-6 text-base leading-7 text-slate-600 dark:text-slate-400">
+              On-demand knowledge and skills for {"today's"} Khoury students.
+              Bite-sized, modern, and built for you.
             </p>
-            <div className="mt-10 flex flex-col items-center justify-center gap-x-6 gap-y-3 md:flex-row">
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
               <Button
                 size="lg"
-                className="dark:border dark:border-slate-500 dark:bg-slate-800 dark:text-white dark:hover:text-black"
+                className="bg-[#2D7597] text-white hover:bg-[#255e78]"
                 after={<ArrowRightIcon />}
                 asChild
               >
-                <Link href="/explore">Explore</Link>
+                <Link href="/explore">Start Exploring</Link>
               </Button>
               {user?.roles?.some(
                 (role) =>
@@ -56,14 +51,9 @@ export default async function HomeRoute() {
                   role === "Faculty" ||
                   role === "System Admin",
               ) && (
-                <Button
-                  size="lg"
-                  className="bg-sky-200 text-slate-900 hover:bg-sky-300 dark:bg-blue-400 dark:text-slate-900 dark:hover:bg-blue-500"
-                  after={<ArrowRightIcon />}
-                  asChild
-                >
-                  <Link href="/my-content">Create a Droplet</Link>
-                </Button>
+                <Link href="/my-content" className={outlineLinkCls}>
+                  Create a Droplet <ArrowRightIcon className="h-4 w-4" />
+                </Link>
               )}
               {user?.roles?.some((role) => role === "User") &&
                 !user?.roles?.some(
@@ -72,41 +62,24 @@ export default async function HomeRoute() {
                     role === "Faculty" ||
                     role === "System Admin",
                 ) && (
-                  <Button
-                    size="lg"
-                    className="bg-sky-200 text-slate-900 hover:bg-sky-300 dark:bg-blue-400 dark:text-slate-900 dark:hover:bg-blue-500"
-                    after={<ArrowRightIcon />}
-                    asChild
-                  >
-                    <Link href="/creation-request">Request Creation Role</Link>
-                  </Button>
+                  <Link href="/creation-request" className={outlineLinkCls}>
+                    Request Creation Role <ArrowRightIcon className="h-4 w-4" />
+                  </Link>
                 )}
               {!user && (
-                <Button
-                  size="lg"
-                  className="dark:bg-black dark:text-white dark:hover:text-black"
-                  after={<ArrowRightIcon />}
-                  asChild
-                >
-                  <Link href="/request-access">Request Access</Link>
-                </Button>
+                <Link href="/request-access" className={outlineLinkCls}>
+                  Request Access <ArrowRightIcon className="h-4 w-4" />
+                </Link>
               )}
             </div>
-            {user && droplet && <FunFact droplet={droplet} />}
           </div>
-        </div>
 
-        <div
-          className="absolute inset-x-0 top-[calc(100%-18rem)] -z-10 transform-gpu overflow-hidden blur-3xl sm:top-[calc(100%-40rem)]"
-          aria-hidden="true"
-        >
-          <div
-            className="relative left-[calc(50%+3rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 opacity-30 sm:left-[calc(50%+36rem)] sm:w-[72.1875rem]"
-            style={{
-              clipPath:
-                "polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)",
-            }}
-          ></div>
+          {/* Right: Fun Fact card */}
+          {user && droplet && (
+            <div className="h-full">
+              <FunFact droplet={droplet} />
+            </div>
+          )}
         </div>
       </div>
     </GradientBackground>

--- a/frontend/app/(general)/page.tsx
+++ b/frontend/app/(general)/page.tsx
@@ -5,6 +5,7 @@ import { getCurrentUser } from "@/lib/auth/session";
 import { GradientBackground } from "@/components/gradient-bg";
 import { FunFact } from "@/components/droplets/fun-fact";
 import { getRandomFunFactDroplet } from "@/lib/requests/droplet";
+import { cn } from "@/lib/utils";
 
 const outlineLinkCls =
   "inline-flex items-center gap-2 rounded-[8px] border border-[#d0d5dd] bg-white px-[14px] py-[10px] text-sm font-medium text-[#344054] shadow-[0px_1px_2px_0px_rgba(16,24,40,0.05)] transition-colors hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700";
@@ -21,7 +22,12 @@ export default async function HomeRoute() {
         <p className="mb-4 text-sm font-semibold tracking-widest text-sky-600 uppercase">
           Khoury College
         </p>
-        <div className="grid grid-cols-1 items-stretch gap-4 lg:grid-cols-2">
+        <div
+          className={cn(
+            "grid grid-cols-1 items-stretch gap-4",
+            user && droplet && "lg:grid-cols-2",
+          )}
+        >
           {/* Left: hero text */}
           <div>
             <h1

--- a/frontend/components/dashboard/enrolled-droplets-grid-client.tsx
+++ b/frontend/components/dashboard/enrolled-droplets-grid-client.tsx
@@ -166,7 +166,7 @@ export function EnrolledDropletsGridClient({
 
   return (
     <>
-      <ul className="grid grid-flow-row auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <ul className="grid grid-flow-row auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2">
         {paginatedDroplets.map((droplet) => (
           <DropletTile
             key={droplet.id}

--- a/frontend/components/dashboard/enrolled-droplets-grid.tsx
+++ b/frontend/components/dashboard/enrolled-droplets-grid.tsx
@@ -73,6 +73,7 @@ export async function EnrolledDropletsGrid({
         }
         title="No enrolled droplets"
         message="You haven't enrolled in any droplets yet."
+        className="min-h-[calc(100vh-var(--header-h)-196px)]"
       />
     );
   }

--- a/frontend/components/dashboard/favorited-droplet-grid.tsx
+++ b/frontend/components/dashboard/favorited-droplet-grid.tsx
@@ -54,6 +54,7 @@ export async function FavoriteDropletsGrid({ sortKey }: { sortKey?: string }) {
         }
         title="No favorited droplets"
         message="You haven't favorited any droplets yet."
+        className="min-h-[calc(100vh-var(--header-h)-196px)]"
       />
     );
   }

--- a/frontend/components/dashboard/my-content.tsx
+++ b/frontend/components/dashboard/my-content.tsx
@@ -75,6 +75,7 @@ export async function MyContent({
                 }
                 title="No enrolled groups"
                 message="You haven't enrolled in any groups yet."
+                className="min-h-[calc(100vh-var(--header-h)-196px)]"
               />
             )}
             <UserGroups
@@ -87,11 +88,9 @@ export async function MyContent({
           <>
             <div className="pb-2 text-xl font-bold">Droplets</div>
             <ArchivedDropletsGrid sortKey={sortKey} />
-            <hr className="pb-2" />
-            <div className="pb-2 text-xl font-bold">Playlists</div>
+            <div className="mt-6 pb-2 text-xl font-bold">Playlists</div>
             <ArchivedPlaylistsGrid sortKey={sortKey} />
-            <hr className="pb-2" />
-            <div className="pb-2 text-xl font-bold">Groups</div>
+            <div className="mt-6 pb-2 text-xl font-bold">Groups</div>
             {archivedGroups.length === 0 && (
               <EmptyState
                 icon={
@@ -121,6 +120,7 @@ export async function MyContent({
               }
               title="No enrolled voyages"
               message="You haven't enrolled in any voyages yet."
+              className="min-h-[calc(100vh-var(--header-h)-196px)]"
             />
           ) : (
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/frontend/components/dashboard/user-playlists-grid.tsx
+++ b/frontend/components/dashboard/user-playlists-grid.tsx
@@ -61,6 +61,7 @@ export async function UserPlaylistsGrid({ sortKey }: { sortKey?: string }) {
         }
         title="No saved playlists"
         message="You haven't saved any playlists yet. Browse the explore page to find playlists to save."
+        className="min-h-[calc(100vh-var(--header-h)-196px)]"
       />
     );
   }

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -522,7 +522,7 @@ ${
                   e.stopPropagation();
                   exportDropletMarkdown();
                 }}
-                className={`${isAdmin ? "visible" : "invisible"} bg-slate-50 hover:bg-slate-300 dark:bg-slate-800 dark:hover:bg-slate-900`}
+                className={`${isAdmin ? "visible" : "invisible"} bg-transparent shadow-none hover:bg-transparent dark:bg-transparent dark:hover:bg-transparent`}
               >
                 <div className="group relative">
                   <IconDownload

--- a/frontend/components/droplets/fun-fact.tsx
+++ b/frontend/components/droplets/fun-fact.tsx
@@ -1,24 +1,29 @@
 import { ArrowRightIcon } from "lucide-react";
-import { Button } from "../ui/button";
 import Link from "next/link";
 import { Droplet } from "@/types";
 
+const outlineLinkCls =
+  "inline-flex items-center gap-2 rounded-[8px] border border-[#d0d5dd] bg-white px-[14px] py-[10px] text-sm font-medium text-[#344054] shadow-[0px_1px_2px_0px_rgba(16,24,40,0.05)] transition-colors hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700";
+
 export function FunFact({ droplet }: { droplet: Droplet }) {
   return (
-    <div className="mt-12 flex flex-col items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 p-6 dark:border-slate-500 dark:bg-slate-800">
-      <p className="text-left text-lg text-slate-600 dark:text-slate-300">
-        <strong className="mr-2 text-2xl text-black dark:text-slate-300">
+    <div className="flex h-full flex-col justify-between gap-6 rounded-lg border border-slate-200 bg-slate-50 p-8 dark:border-slate-500 dark:bg-slate-800">
+      <div className="w-full">
+        <strong className="text-2xl text-black dark:text-slate-300">
           Did you know?
         </strong>
-        {droplet?.funFact}
-      </p>
-      <Link className="w-full" href={`/d/${droplet.slug}`}>
-        <Button className="h-auto w-full bg-sky-200 text-lg text-slate-900 hover:scale-105 hover:bg-sky-200 md:w-1/2 dark:bg-blue-400 dark:hover:bg-blue-400">
-          <p className="text-wrap whitespace-normal">
-            Dive deeper in <strong className="">{droplet.name}</strong>
-          </p>
-          <ArrowRightIcon />
-        </Button>
+        <p className="mt-3 text-lg text-slate-600 dark:text-slate-300">
+          {droplet?.funFact}
+        </p>
+      </div>
+      <Link
+        href={`/d/${droplet.slug}`}
+        className={`${outlineLinkCls} w-full justify-between`}
+      >
+        <span>
+          Dive deeper in <strong>{droplet.name}</strong>
+        </span>
+        <ArrowRightIcon className="h-4 w-4 shrink-0" />
       </Link>
     </div>
   );

--- a/frontend/components/feed/feed-container.tsx
+++ b/frontend/components/feed/feed-container.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useLayoutEffect, useEffect, useRef } from "react";
+import React, { useState, useLayoutEffect, useEffect, useRef } from "react";
 import { AuthorizedUser } from "@/types";
 import { FriendRequests } from "../friends/friend-requests";
 import { Button } from "../ui/button";
@@ -59,7 +59,10 @@ export function FeedContainer({
       </nav>
 
       {/* Content row: center + right column */}
-      <div className="flex items-start md:ml-[260px]">
+      <div
+        className="flex items-stretch md:ml-[260px]"
+        style={{ "--header-h": `${headerHeight}px` } as React.CSSProperties}
+      >
         {/* Center */}
         <div
           className="min-w-0 flex-1"
@@ -76,11 +79,8 @@ export function FeedContainer({
         </div>
 
         {/* Right column — normal flow */}
-        <div className="hidden w-[280px] shrink-0 p-4 pt-6 md:block">
-          <div
-            className="overflow-hidden rounded-2xl border border-[#D0D5DD] bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900"
-            style={{ minHeight: `calc(100vh - ${headerHeight + 48}px)` }}
-          >
+        <div className="hidden w-[280px] shrink-0 flex-col px-4 py-6 md:flex">
+          <div className="flex-1 overflow-hidden rounded-2xl border border-[#D0D5DD] bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
             <div className="p-5">
               <h2 className="mb-3 text-base font-semibold text-black dark:text-white">
                 Friend Requests

--- a/frontend/components/ui/blocknote/editor/custom-blocknote.css
+++ b/frontend/components/ui/blocknote/editor/custom-blocknote.css
@@ -209,17 +209,33 @@
 
 /* Heading sizes — BlockNote defaults (3em/2em/1.3em) are too aggressive.
    Scale them down to a tighter, document-friendly hierarchy. */
-[data-content-type=heading]              { --level: 1.875em !important; }
-[data-content-type=heading][data-level="2"] { --level: 1.5em !important; }
-[data-content-type=heading][data-level="3"] { --level: 1.2em !important; }
+[data-content-type="heading"] {
+  --level: 1.875em !important;
+}
+[data-content-type="heading"][data-level="2"] {
+  --level: 1.5em !important;
+}
+[data-content-type="heading"][data-level="3"] {
+  --level: 1.2em !important;
+}
 
 /* Placeholder text color — match overview page input text (#121216 light, slate-300 dark) */
-.bn-editor .bn-block-content[data-is-empty-and-focused] .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before,
-.bn-editor .bn-block-content[data-is-only-empty-block] .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before {
+.bn-editor
+  .bn-block-content[data-is-empty-and-focused]
+  .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before,
+.bn-editor
+  .bn-block-content[data-is-only-empty-block]
+  .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before {
   color: #121216;
 }
 
-.dark .bn-editor .bn-block-content[data-is-empty-and-focused] .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before,
-.dark .bn-editor .bn-block-content[data-is-only-empty-block] .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before {
+.dark
+  .bn-editor
+  .bn-block-content[data-is-empty-and-focused]
+  .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before,
+.dark
+  .bn-editor
+  .bn-block-content[data-is-only-empty-block]
+  .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before {
   color: rgb(203 213 225); /* slate-300 */
 }

--- a/frontend/components/ui/empty-state.tsx
+++ b/frontend/components/ui/empty-state.tsx
@@ -1,16 +1,24 @@
 import { type ReactNode } from "react";
+import { cn } from "@/lib/utils";
 
 export function EmptyState({
   icon,
   title,
   message,
+  className,
 }: {
   icon: ReactNode;
   title: string;
   message: string;
+  className?: string;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-xl border border-[#D0D5DD] py-16 text-center dark:border-slate-600">
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center rounded-xl border border-[#D0D5DD] py-16 text-center dark:border-slate-600",
+        className,
+      )}
+    >
       <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full border border-[#D0D5DD] bg-[#fcfcfd] dark:border-slate-600 dark:bg-slate-800">
         {icon}
       </div>

--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useCallback,
   useRef,
+  useEffect,
   ReactNode,
 } from "react";
 import { useRouter } from "next/navigation";
@@ -65,11 +66,20 @@ function initNodesFromVoyage(voyage: Voyage): SelectedNode[] {
   }));
 }
 
-function SectionLabel({ children }: { children: ReactNode }) {
+function SectionLabel({
+  children,
+  htmlFor,
+}: {
+  children: ReactNode;
+  htmlFor?: string;
+}) {
   return (
-    <div className="py-0.5 pb-2 text-xl font-bold text-slate-900 dark:text-white">
+    <label
+      htmlFor={htmlFor}
+      className="block py-0.5 pb-2 text-xl font-bold text-slate-900 dark:text-white"
+    >
       {children}
-    </div>
+    </label>
   );
 }
 
@@ -90,6 +100,12 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [error, setError] = useState("");
+
+  useEffect(() => {
+    return () => {
+      if (blurTimer.current) clearTimeout(blurTimer.current);
+    };
+  }, []);
 
   const availablePlaylists = useMemo(
     () =>
@@ -329,7 +345,7 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
     <div className="flex w-full flex-col gap-8 lg:flex-row">
       <div className="flex w-full flex-col gap-6 lg:w-1/2">
         <div className="flex flex-col gap-2">
-          <SectionLabel>
+          <SectionLabel htmlFor="voyage-name">
             Voyage Name <span className="text-red-500">*</span>
           </SectionLabel>
           <Input
@@ -342,7 +358,7 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
         </div>
 
         <div className="flex flex-col gap-2">
-          <SectionLabel>Description</SectionLabel>
+          <SectionLabel htmlFor="voyage-description">Description</SectionLabel>
           <textarea
             id="voyage-description"
             className="min-h-[100px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus:ring-2 focus:ring-slate-400 focus:outline-none disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:placeholder:text-slate-500"

--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { useState, useTransition, useMemo, useCallback } from "react";
+import {
+  useState,
+  useTransition,
+  useMemo,
+  useCallback,
+  useRef,
+  ReactNode,
+} from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Playlist, Voyage } from "@/types";
 import { cn } from "@/lib/utils";
 import {
@@ -59,6 +65,14 @@ function initNodesFromVoyage(voyage: Voyage): SelectedNode[] {
   }));
 }
 
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <div className="py-0.5 pb-2 text-xl font-bold text-slate-900 dark:text-white">
+      {children}
+    </div>
+  );
+}
+
 export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -73,6 +87,8 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
   const [isSequential, setIsSequential] = useState(
     voyage?.isSequential ?? false,
   );
+  const [isSearchFocused, setIsSearchFocused] = useState(false);
+  const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [error, setError] = useState("");
 
   const availablePlaylists = useMemo(
@@ -311,13 +327,11 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
 
   return (
     <div className="flex w-full flex-col gap-8 lg:flex-row">
-      {/* Left: Form panel */}
       <div className="flex w-full flex-col gap-6 lg:w-1/2">
-        {/* Name */}
         <div className="flex flex-col gap-2">
-          <Label htmlFor="voyage-name">
+          <SectionLabel>
             Voyage Name <span className="text-red-500">*</span>
-          </Label>
+          </SectionLabel>
           <Input
             id="voyage-name"
             placeholder="e.g. Introduction to Machine Learning"
@@ -327,9 +341,8 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
           />
         </div>
 
-        {/* Description */}
         <div className="flex flex-col gap-2">
-          <Label htmlFor="voyage-description">Description</Label>
+          <SectionLabel>Description</SectionLabel>
           <textarea
             id="voyage-description"
             className="min-h-[100px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus:ring-2 focus:ring-slate-400 focus:outline-none disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:placeholder:text-slate-500"
@@ -340,11 +353,9 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
           />
         </div>
 
-        {/* Playlist picker */}
         <div className="flex flex-col gap-3">
-          <Label>Islands (Playlists)</Label>
+          <SectionLabel>Islands (Playlists)</SectionLabel>
 
-          {/* Search input */}
           <div className="relative">
             <SearchIcon className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
             <Input
@@ -352,12 +363,21 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
               placeholder="Search public playlists..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
+              onFocus={() => {
+                if (blurTimer.current) clearTimeout(blurTimer.current);
+                setIsSearchFocused(true);
+              }}
+              onBlur={() => {
+                blurTimer.current = setTimeout(
+                  () => setIsSearchFocused(false),
+                  150,
+                );
+              }}
               disabled={isPending}
             />
           </div>
 
-          {/* Search results */}
-          {searchQuery.length > 0 && (
+          {isSearchFocused && (
             <div className="max-h-48 overflow-y-auto rounded-md border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
               {availablePlaylists.length === 0 ? (
                 <p className="px-4 py-3 text-sm text-slate-500">
@@ -387,7 +407,6 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
             </div>
           )}
 
-          {/* Selected islands list */}
           {sortedForDisplay.length > 0 ? (
             <div className="space-y-1">
               {sortedForDisplay.map((node) => {
@@ -549,14 +568,12 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
           )}
         </div>
 
-        {/* Error */}
         {error && (
           <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
             {error}
           </p>
         )}
 
-        {/* Sequential progression toggle */}
         <label className="flex items-center gap-3 rounded-lg border border-slate-200 px-4 py-3 dark:border-slate-700">
           <input
             type="checkbox"
@@ -575,19 +592,7 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
           </div>
         </label>
 
-        {/* Action buttons */}
         <div className="flex gap-3">
-          <Button
-            type="button"
-            onClick={() => handleSubmit("published")}
-            disabled={isPending}
-            className="flex-1"
-          >
-            {isPending && isEditing && "Updating..."}
-            {isPending && !isEditing && "Publishing..."}
-            {!isPending && isEditing && "Update & Publish"}
-            {!isPending && !isEditing && "Publish Voyage"}
-          </Button>
           <Button
             type="button"
             variant="outline"
@@ -599,15 +604,23 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
             {!isPending && isEditing && "Save Changes"}
             {!isPending && !isEditing && "Save as Draft"}
           </Button>
+          <Button
+            type="button"
+            onClick={() => handleSubmit("published")}
+            disabled={isPending}
+            className="flex-1 bg-[#2D7597] text-white hover:bg-[#255e78]"
+          >
+            {isPending && isEditing && "Updating..."}
+            {isPending && !isEditing && "Publishing..."}
+            {!isPending && isEditing && "Update & Publish"}
+            {!isPending && !isEditing && "Publish Voyage"}
+          </Button>
         </div>
       </div>
 
-      {/* Right: Live tree preview */}
       <div className="w-full lg:w-1/2">
         <div className="sticky top-8">
-          <h3 className="mb-3 text-sm font-medium text-slate-700 dark:text-slate-300">
-            Live Preview
-          </h3>
+          <SectionLabel>Live Preview</SectionLabel>
           <VoyageTreeMap nodes={treeNodes} />
         </div>
       </div>

--- a/frontend/tests/components/dashboard/my-content.test.tsx
+++ b/frontend/tests/components/dashboard/my-content.test.tsx
@@ -531,13 +531,10 @@ describe("MyContent", () => {
   });
 
   describe("Archived Content Section", () => {
-    it("includes dividers between archived sections", async () => {
-      const { container } = render(
-        await MyContent({ searchParams: { contentType: "archived" } }),
-      );
+    it("renders archived sections with spacing between them", async () => {
+      render(await MyContent({ searchParams: { contentType: "archived" } }));
 
-      const dividers = container.querySelectorAll("hr");
-      expect(dividers.length).toBeGreaterThan(0);
+      expect(screen.getByTestId("archived-grid")).toBeInTheDocument();
     });
 
     it("renders archived droplets grid", async () => {

--- a/frontend/tests/components/dashboard/my-content.test.tsx
+++ b/frontend/tests/components/dashboard/my-content.test.tsx
@@ -535,6 +535,7 @@ describe("MyContent", () => {
       render(await MyContent({ searchParams: { contentType: "archived" } }));
 
       expect(screen.getByTestId("archived-grid")).toBeInTheDocument();
+      expect(screen.getByTestId("archived-playlists-grid")).toBeInTheDocument();
     });
 
     it("renders archived droplets grid", async () => {


### PR DESCRIPTION
## Description                                                                                                                             
                                                                                                                                          
  A collection of small UI polish fixes across the home page, dashboard, voyage form, and feed layout.                                    
                                                                                                                                          
  - Home page: Redesigned hero into a two-column layout (headline/CTAs left, FunFact card right); shortened copy; replaced Button-wrapped secondary CTAs with outline-style links                                                                                                 
  - Feed container: Switched to items-stretch so the right sidebar matches the main column height; injects --header-h CSS variable consumed by dashboard empty states                                                                                                      
  - Empty state: Added optional className prop (used to set min-h on dashboard tab empties so they fill the viewport)
  - Dashboard grids: Enrolled droplets grid reduced from 3 → 2 columns; empty states in enrolled, favorited, playlists, voyages, and groups sections now fill the full viewport height                                                                                       
  - Voyage form: Replaced <Label> with larger section headings; search dropdown now opens on focus rather than requiring typed input; swapped button order (Save Draft → Publish)                                                                                             
  - New Voyage page: Updated page heading and layout padding
  - Droplet tile: Admin download button made transparent/borderless                                                                       
                  
## Motivation and Context                                                                                                                  
                  
  Addresses visual inconsistencies and layout issues flagged in ODY-415: empty states that didn't fill their containers, cramped grids, and mismatched button/label styles across forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved voyage form experience with focused search behavior and clearer section labels.

* **Style**
  * Redesigned home/hero layout with responsive two-column grid and updated CTAs.
  * Unified CTA/link styling across components and adjusted fun-fact card layout.
  * Updated empty-state sizing and various spacing/typography refinements across dashboards and forms.
  * Export/interaction buttons updated to cleaner, transparent styling.

* **Tests**
  * Updated archived-content test to assert section rendering and spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->