### PR TITLE
feat: voyage droplet nodes with claiming system

### DIFF
--- a/backend/src/api/creation-request/content-types/creation-request/schema.json
+++ b/backend/src/api/creation-request/content-types/creation-request/schema.json
@@ -23,6 +23,11 @@
       "relation": "oneToOne",
       "target": "api::authorized-user.authorized-user",
       "inversedBy": "creationRequest"
+    },
+    "voyageNode": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::voyage-node.voyage-node"
     }
   }
 }

--- a/backend/src/api/voyage-node/content-types/voyage-node/schema.json
+++ b/backend/src/api/voyage-node/content-types/voyage-node/schema.json
@@ -22,7 +22,7 @@
     },
     "nodeType": {
       "type": "enumeration",
-      "enum": ["playlist", "checkpoint"],
+      "enum": ["playlist", "droplet"],
       "required": true,
       "default": "playlist"
     },
@@ -44,6 +44,20 @@
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::playlist.playlist"
+    },
+    "droplet": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::droplet.droplet"
+    },
+    "claimedBy": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::authorized-user.authorized-user"
+    },
+    "claimStatus": {
+      "type": "enumeration",
+      "enum": ["unclaimed", "claimed", "authored"]
     },
     "parentNode": {
       "type": "relation",

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -753,6 +753,11 @@ export interface ApiCreationRequestCreationRequest
       'oneToOne',
       'api::authorized-user.authorized-user'
     >;
+    voyageNode: Attribute.Relation<
+      'api::creation-request.creation-request',
+      'manyToOne',
+      'api::voyage-node.voyage-node'
+    >;
   };
 }
 
@@ -1697,6 +1702,12 @@ export interface ApiVoyageNodeVoyageNode extends Schema.CollectionType {
       'oneToMany',
       'api::voyage-node.voyage-node'
     >;
+    claimedBy: Attribute.Relation<
+      'api::voyage-node.voyage-node',
+      'manyToOne',
+      'api::authorized-user.authorized-user'
+    >;
+    claimStatus: Attribute.Enumeration<['unclaimed', 'claimed', 'authored']>;
     createdAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
       'api::voyage-node.voyage-node',
@@ -1704,11 +1715,16 @@ export interface ApiVoyageNodeVoyageNode extends Schema.CollectionType {
       'admin::user'
     > &
       Attribute.Private;
+    droplet: Attribute.Relation<
+      'api::voyage-node.voyage-node',
+      'manyToOne',
+      'api::droplet.droplet'
+    >;
     isMainPath: Attribute.Boolean &
       Attribute.Required &
       Attribute.DefaultTo<true>;
     label: Attribute.String & Attribute.Required;
-    nodeType: Attribute.Enumeration<['playlist', 'checkpoint']> &
+    nodeType: Attribute.Enumeration<['playlist', 'droplet']> &
       Attribute.Required &
       Attribute.DefaultTo<'playlist'>;
     orderIndex: Attribute.Integer & Attribute.Required;

--- a/frontend/app/(creation)/new/voyage/page.tsx
+++ b/frontend/app/(creation)/new/voyage/page.tsx
@@ -2,6 +2,7 @@ import { getCurrentUser } from "@/lib/auth/session";
 import { redirect } from "next/navigation";
 import { isAuthorizedUserAdmin, isAuthorizedUserFaculty } from "@/lib/utils";
 import { getPlaylists } from "@/lib/requests/playlist";
+import { getDroplets } from "@/lib/requests/droplet";
 import { VoyageForm } from "@/components/voyages/voyage-form";
 import { getCachedUser } from "@/lib/requests/cached";
 
@@ -16,7 +17,7 @@ export default async function NewVoyage() {
     redirect("/explore");
   }
 
-  const [authUser, publicPlaylists] = await Promise.all([
+  const [authUser, publicPlaylists, publishedDroplets] = await Promise.all([
     getCachedUser(user.email),
     getPlaylists({
       filters: { isPublic: true },
@@ -28,6 +29,12 @@ export default async function NewVoyage() {
       fields: ["id", "name", "slug"],
       sort: ["name:asc"],
     }),
+    getDroplets({
+      filters: { status: "published", isHidden: false },
+      fields: ["id", "name", "slug"],
+      populate: {},
+      sort: ["name:asc"],
+    }),
   ]);
 
   if (!authUser) {
@@ -35,12 +42,16 @@ export default async function NewVoyage() {
   }
 
   return (
-    <div className="bg-white px-4 pt-4 pb-8 md:px-16 md:pt-8 md:pb-16 lg:px-24 dark:bg-zinc-950">
-      <div className="flex w-full flex-col">
-        <h1 className="mb-7 text-4xl font-semibold text-black dark:text-white">
-          Create a Voyage
-        </h1>
-        <VoyageForm playlists={publicPlaylists} authorId={authUser.id} />
+    <div className="flex min-h-screen w-full flex-col items-center bg-white px-4 pt-12 md:px-12 dark:bg-slate-900">
+      <h1 className="mb-7 text-2xl font-bold tracking-tight text-slate-900 sm:text-4xl dark:text-white">
+        Create New Voyage
+      </h1>
+      <div className="w-full max-w-6xl">
+        <VoyageForm
+          playlists={publicPlaylists}
+          droplets={publishedDroplets}
+          authorId={authUser.id}
+        />
       </div>
     </div>
   );

--- a/frontend/app/(editing)/draft/v/[slug]/page.tsx
+++ b/frontend/app/(editing)/draft/v/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { getCurrentUser } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
 import { isAuthorizedUserAdmin, isAuthorizedUserFaculty } from "@/lib/utils";
 import { getPlaylists } from "@/lib/requests/playlist";
+import { getDroplets } from "@/lib/requests/droplet";
 import { getVoyageBySlug } from "@/lib/requests/voyage";
 import { VoyageForm } from "@/components/voyages/voyage-form";
 import { getCachedUser } from "@/lib/requests/cached";
@@ -21,16 +22,23 @@ export default async function EditVoyagePage({ params }: Props) {
 
   const { slug } = await params;
 
-  const [authUser, voyage, publicPlaylists] = await Promise.all([
-    getCachedUser(user.email),
-    getVoyageBySlug(slug, { includeDrafts: true }),
-    getPlaylists({
-      filters: { isPublic: true },
-      populate: { droplets: { fields: ["id"] } },
-      fields: ["id", "name", "slug"],
-      sort: ["name:asc"],
-    }),
-  ]);
+  const [authUser, voyage, publicPlaylists, publishedDroplets] =
+    await Promise.all([
+      getCachedUser(user.email),
+      getVoyageBySlug(slug, { includeDrafts: true }),
+      getPlaylists({
+        filters: { isPublic: true },
+        populate: { droplets: { fields: ["id"] } },
+        fields: ["id", "name", "slug"],
+        sort: ["name:asc"],
+      }),
+      getDroplets({
+        filters: { status: "published", isHidden: false },
+        fields: ["id", "name", "slug"],
+        populate: {},
+        sort: ["name:asc"],
+      }),
+    ]);
 
   if (!authUser || !voyage) return notFound();
 
@@ -42,6 +50,7 @@ export default async function EditVoyagePage({ params }: Props) {
       <div className="w-full max-w-6xl">
         <VoyageForm
           playlists={publicPlaylists}
+          droplets={publishedDroplets}
           authorId={authUser.id}
           voyage={voyage}
         />

--- a/frontend/app/(general)/creation-request/page.tsx
+++ b/frontend/app/(general)/creation-request/page.tsx
@@ -6,7 +6,11 @@ import { getCachedUser } from "@/lib/requests/cached";
 import { fetchCreationRequestByUser } from "@/lib/actions";
 import { notFound } from "next/navigation";
 
-export default async function RequestContentCreatorRole() {
+export default async function RequestContentCreatorRole({
+  searchParams,
+}: {
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
   const user = await getCurrentUser();
   if (!user || !user?.email) return notFound();
 
@@ -24,9 +28,26 @@ export default async function RequestContentCreatorRole() {
     );
   }
 
+  const params = (await searchParams) ?? {};
+  const rawVoyageNodeId = params["voyageNodeId"];
+  const voyageNodeId = rawVoyageNodeId
+    ? parseInt(String(rawVoyageNodeId), 10) || undefined
+    : undefined;
+  const voyageName = params["voyageName"]
+    ? String(params["voyageName"])
+    : undefined;
+  const nodeLabel = params["nodeLabel"]
+    ? String(params["nodeLabel"])
+    : undefined;
+
   return (
     <GradientBackground>
-      <ContentCreatorRequestForm user={authUser} />
+      <ContentCreatorRequestForm
+        user={authUser}
+        voyageNodeId={voyageNodeId}
+        voyageName={voyageName}
+        nodeLabel={nodeLabel}
+      />
     </GradientBackground>
   );
 }

--- a/frontend/app/(voyages)/v/[slug]/page.tsx
+++ b/frontend/app/(voyages)/v/[slug]/page.tsx
@@ -91,17 +91,31 @@ export default async function VoyagePage({ params }: Props) {
   };
 
   // Map VoyageNode[] to TreeNode[] for VoyageTreeMap
-  const treeNodes: TreeNode[] = voyageNodes.map((node) => ({
-    id: node.id,
-    label: node.label,
-    slug: node.playlist?.slug,
-    dropletCount: node.playlist?.droplets?.length,
-    isMainPath: node.isMainPath,
-    branchType: node.branchType,
-    parentId: node.parentNode?.id ?? null,
-    orderIndex: node.orderIndex,
-    status: getNodeStatus(node),
-  }));
+  const treeNodes: TreeNode[] = voyageNodes.map((node) => {
+    const isDropletNode = node.nodeType === "droplet";
+    const slug = isDropletNode ? node.droplet?.slug : node.playlist?.slug;
+    const dropletCount = isDropletNode
+      ? undefined
+      : node.playlist?.droplets?.length;
+    const href =
+      isDropletNode && !slug
+        ? `/v/${voyage.slug}/unclaimed/${node.id}`
+        : undefined;
+    return {
+      id: node.id,
+      label: node.label,
+      slug,
+      href,
+      dropletCount,
+      isMainPath: node.isMainPath,
+      branchType: node.branchType,
+      parentId: node.parentNode?.id ?? null,
+      orderIndex: node.orderIndex,
+      status: getNodeStatus(node),
+      nodeType: node.nodeType,
+      claimStatus: node.claimStatus,
+    };
+  });
 
   // Completion metrics (only meaningful when enrolled)
   const completionPercentage = isEnrolled
@@ -257,6 +271,25 @@ export default async function VoyagePage({ params }: Props) {
                         const mainStatus = main.status ?? "available";
                         const isLocked = mainStatus === "locked";
                         const isCompleted = mainStatus === "completed";
+                        const isDroplet = main.nodeType === "droplet";
+                        const isPlaceholder =
+                          isDroplet && main.claimStatus === "unclaimed";
+                        const isClaimed =
+                          isDroplet && main.claimStatus === "claimed";
+
+                        const nodeHref = isDroplet
+                          ? main.slug
+                            ? `/d/${main.slug}`
+                            : `/v/${voyage.slug}/unclaimed/${main.id}`
+                          : `/p/${main.slug ?? ""}`;
+
+                        const nodeSubtitle = isPlaceholder
+                          ? "Become author!"
+                          : isClaimed
+                            ? "In Progress"
+                            : isDroplet
+                              ? "1 droplet"
+                              : `${main.dropletCount ?? 0} droplets`;
 
                         const mainNode = (
                           <div key={main.id}>
@@ -269,8 +302,10 @@ export default async function VoyagePage({ params }: Props) {
                                   <p className="truncate text-sm font-medium text-slate-500 dark:text-slate-400">
                                     {main.label}
                                   </p>
-                                  <p className="text-xs text-slate-400">
-                                    {main.dropletCount ?? 0} droplets
+                                  <p
+                                    className={`text-xs ${isPlaceholder ? "text-amber-600 dark:text-amber-400" : "text-slate-400"}`}
+                                  >
+                                    {nodeSubtitle}
                                   </p>
                                 </div>
                                 <svg
@@ -292,12 +327,18 @@ export default async function VoyagePage({ params }: Props) {
                               </div>
                             ) : (
                               <Link
-                                href={`/p/${main.slug ?? ""}`}
+                                href={nodeHref}
                                 className="flex items-center gap-2.5 rounded-lg border border-slate-200 bg-white px-3 py-2 transition-all hover:border-slate-300 hover:shadow-sm dark:border-slate-700 dark:bg-slate-800"
                               >
                                 <div
                                   className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white"
-                                  style={{ backgroundColor: "#297496" }}
+                                  style={{
+                                    backgroundColor: isPlaceholder
+                                      ? "#d97706"
+                                      : isDroplet
+                                        ? "#0e7490"
+                                        : "#297496",
+                                  }}
                                 >
                                   {isCompleted ? "✓" : step}
                                 </div>
@@ -305,8 +346,10 @@ export default async function VoyagePage({ params }: Props) {
                                   <p className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
                                     {main.label}
                                   </p>
-                                  <p className="text-xs text-slate-400">
-                                    {main.dropletCount ?? 0} droplets
+                                  <p
+                                    className={`text-xs ${isPlaceholder ? "text-amber-600 dark:text-amber-400" : "text-slate-400"}`}
+                                  >
+                                    {nodeSubtitle}
                                   </p>
                                 </div>
                                 {isCompleted && (
@@ -335,6 +378,20 @@ export default async function VoyagePage({ params }: Props) {
                           const branchStatus = branch.status ?? "available";
                           const branchLocked = branchStatus === "locked";
                           const branchCompleted = branchStatus === "completed";
+                          const branchIsDroplet = branch.nodeType === "droplet";
+                          const branchIsPlaceholder =
+                            branchIsDroplet &&
+                            branch.claimStatus === "unclaimed";
+                          const branchHref = branchIsDroplet
+                            ? branch.slug
+                              ? `/d/${branch.slug}`
+                              : `/v/${voyage.slug}/unclaimed/${branch.id}`
+                            : `/p/${branch.slug ?? ""}`;
+                          const branchSubtitle = branchIsPlaceholder
+                            ? "Become author!"
+                            : branchIsDroplet
+                              ? "1 droplet"
+                              : `${branch.dropletCount ?? 0} droplets`;
 
                           return branchLocked ? (
                             <div
@@ -345,8 +402,10 @@ export default async function VoyagePage({ params }: Props) {
                                 <p className="truncate text-xs font-medium text-slate-500 dark:text-slate-400">
                                   {branch.label}
                                 </p>
-                                <p className="text-[10px] text-slate-400">
-                                  {branch.dropletCount ?? 0} droplets
+                                <p
+                                  className={`text-[10px] ${branchIsPlaceholder ? "text-amber-600 dark:text-amber-400" : "text-slate-400"}`}
+                                >
+                                  {branchSubtitle}
                                 </p>
                               </div>
                               <span
@@ -364,15 +423,17 @@ export default async function VoyagePage({ params }: Props) {
                           ) : (
                             <Link
                               key={branch.id}
-                              href={`/p/${branch.slug ?? ""}`}
+                              href={branchHref}
                               className="ml-5 flex items-center gap-2 rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-1.5 transition-all hover:border-slate-300 dark:border-slate-700 dark:bg-slate-800/50"
                             >
                               <div className="min-w-0 flex-1">
                                 <p className="truncate text-xs font-medium text-slate-700 dark:text-slate-300">
                                   {branch.label}
                                 </p>
-                                <p className="text-[10px] text-slate-400">
-                                  {branch.dropletCount ?? 0} droplets
+                                <p
+                                  className={`text-[10px] ${branchIsPlaceholder ? "text-amber-600 dark:text-amber-400" : "text-slate-400"}`}
+                                >
+                                  {branchSubtitle}
                                 </p>
                               </div>
                               {branchCompleted && (

--- a/frontend/app/(voyages)/v/[slug]/page.tsx
+++ b/frontend/app/(voyages)/v/[slug]/page.tsx
@@ -132,7 +132,15 @@ export default async function VoyagePage({ params }: Props) {
   const firstIncompleteNode = isEnrolled
     ? findFirstIncompleteNode(voyageNodes, completedNodeIds)
     : null;
-  const firstIncompleteSlug = firstIncompleteNode?.playlist?.slug ?? undefined;
+  const firstIncompleteHref = firstIncompleteNode
+    ? firstIncompleteNode.nodeType === "droplet"
+      ? firstIncompleteNode.droplet?.slug
+        ? `/d/${firstIncompleteNode.droplet.slug}`
+        : `/v/${voyage.slug}/unclaimed/${firstIncompleteNode.id}`
+      : firstIncompleteNode.playlist?.slug
+        ? `/p/${firstIncompleteNode.playlist.slug}`
+        : "#"
+    : undefined;
 
   const totalDroplets = treeNodes.reduce(
     (sum, n) => sum + (n.dropletCount ?? 0),
@@ -185,7 +193,7 @@ export default async function VoyagePage({ params }: Props) {
                     voyageId={voyage.id}
                     enrollment={enrollment}
                     completionPercentage={completionPercentage}
-                    firstIncompleteSlug={firstIncompleteSlug}
+                    firstIncompleteHref={firstIncompleteHref}
                   />
                 ) : null}
 
@@ -281,7 +289,9 @@ export default async function VoyagePage({ params }: Props) {
                           ? main.slug
                             ? `/d/${main.slug}`
                             : `/v/${voyage.slug}/unclaimed/${main.id}`
-                          : `/p/${main.slug ?? ""}`;
+                          : main.slug
+                            ? `/p/${main.slug}`
+                            : "#";
 
                         const nodeSubtitle = isPlaceholder
                           ? "Become author!"
@@ -386,7 +396,9 @@ export default async function VoyagePage({ params }: Props) {
                             ? branch.slug
                               ? `/d/${branch.slug}`
                               : `/v/${voyage.slug}/unclaimed/${branch.id}`
-                            : `/p/${branch.slug ?? ""}`;
+                            : branch.slug
+                              ? `/p/${branch.slug}`
+                              : "#";
                           const branchSubtitle = branchIsPlaceholder
                             ? "Become author!"
                             : branchIsDroplet

--- a/frontend/app/(voyages)/v/[slug]/unclaimed/[nodeId]/page.tsx
+++ b/frontend/app/(voyages)/v/[slug]/unclaimed/[nodeId]/page.tsx
@@ -1,0 +1,165 @@
+import { fetchAPI } from "@/lib/utils";
+import { VoyageNode } from "@/types";
+import { CACHE_TAGS } from "@/lib/cache-tags";
+import { getCurrentUser } from "@/lib/auth/session";
+import { getCachedUser } from "@/lib/requests/cached";
+import {
+  isAuthorizedUserAdmin,
+  isAuthorizedUserFaculty,
+  isContentCreator,
+  isContentEditor,
+} from "@/lib/utils";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { ClaimNodeButton } from "@/components/voyages/claim-node-button";
+import { ContentCreatorRequestForm } from "@/components/requests/content-creation-request";
+import { fetchCreationRequestByUser } from "@/lib/actions";
+import { PendingRequestCard } from "@/components/requests/pending-request-card";
+
+type Props = {
+  params: Promise<{ slug: string; nodeId: string }>;
+};
+
+export default async function UnclaimedDropletPage({ params }: Props) {
+  const p = await params;
+  const nodeId = parseInt(p.nodeId, 10);
+  if (isNaN(nodeId)) return notFound();
+
+  const nodes = await fetchAPI<VoyageNode[]>("/voyage-nodes", {
+    urlParams: {
+      filters: { id: { $eq: nodeId } },
+      fields: ["id", "label", "nodeType", "claimStatus"],
+      populate: {
+        voyage: { fields: ["id", "name", "slug"] },
+        claimedBy: { fields: ["id", "name"] },
+        droplet: { fields: ["id", "slug"] },
+      },
+      pagination: { pageSize: 1, page: 1 },
+    },
+    next: { tags: [CACHE_TAGS.voyages], revalidate: 0 },
+  });
+
+  const node = nodes[0];
+  if (!node || node.nodeType !== "droplet") return notFound();
+  if (node.voyage?.slug && node.voyage.slug !== p.slug) return notFound();
+
+  if (node.droplet?.slug) {
+    redirect(`/d/${node.droplet.slug}`);
+  }
+
+  const voyageName = node.voyage?.name ?? "Voyage";
+  const voyageSlug = node.voyage?.slug ?? p.slug;
+
+  const sessionUser = await getCurrentUser();
+  const authUser = sessionUser?.email
+    ? await getCachedUser(sessionUser.email)
+    : null;
+
+  const canClaim =
+    !!sessionUser &&
+    (isContentCreator(sessionUser.roles) ||
+      isContentEditor(sessionUser.roles) ||
+      isAuthorizedUserFaculty(sessionUser.roles) ||
+      isAuthorizedUserAdmin(sessionUser.roles));
+
+  const isClaimed = node.claimStatus === "claimed";
+  const isUnclaimed = node.claimStatus === "unclaimed";
+
+  const existingRequest = authUser
+    ? await fetchCreationRequestByUser(authUser.id)
+    : null;
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-white px-8 dark:bg-zinc-950">
+      <div className="w-full max-w-lg text-center">
+        <Link
+          href={`/v/${voyageSlug}`}
+          className="mb-8 inline-block text-sm text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+        >
+          &larr; Back to {voyageName}
+        </Link>
+
+        <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-[#297496]/10 dark:bg-[#297496]/20">
+          <svg
+            className="h-10 w-10 text-[#297496]"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+            />
+          </svg>
+        </div>
+
+        <h1 className="text-3xl font-bold text-slate-900 dark:text-white">
+          {node.label}
+        </h1>
+
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          Part of{" "}
+          <Link
+            href={`/v/${voyageSlug}`}
+            className="font-medium text-[#297496] hover:underline"
+          >
+            {voyageName}
+          </Link>
+        </p>
+
+        <div className="mt-10">
+          {isClaimed && node.claimedBy ? (
+            <div className="rounded-xl border border-slate-200 bg-slate-50 px-6 py-8 dark:border-slate-700 dark:bg-slate-800/50">
+              <p className="text-lg font-medium text-slate-700 dark:text-slate-300">
+                Being written by
+              </p>
+              <p className="mt-1 text-xl font-bold text-slate-900 dark:text-white">
+                {node.claimedBy.name}
+              </p>
+              <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+                This droplet is currently being authored. Check back soon!
+              </p>
+            </div>
+          ) : isUnclaimed && canClaim ? (
+            <div className="rounded-xl border-2 border-[#297496]/30 bg-[#297496]/5 px-6 py-8 dark:border-[#297496]/50 dark:bg-[#297496]/10">
+              <p className="text-xl font-bold text-slate-900 dark:text-white">
+                This droplet needs you!
+              </p>
+              <p className="mt-2 text-slate-600 dark:text-slate-300">
+                Be the first to write content for this topic. Claim it and start
+                creating.
+              </p>
+              <div className="mt-6">
+                <ClaimNodeButton voyageNodeId={nodeId} />
+              </div>
+            </div>
+          ) : isUnclaimed && !canClaim && sessionUser ? (
+            <div className="mt-4 text-left">
+              {existingRequest ? (
+                <PendingRequestCard />
+              ) : (
+                <ContentCreatorRequestForm
+                  user={authUser ?? undefined}
+                  voyageNodeId={nodeId}
+                  voyageName={voyageName}
+                  nodeLabel={node.label}
+                />
+              )}
+            </div>
+          ) : (
+            <div className="rounded-xl border border-slate-200 bg-slate-50 px-6 py-8 dark:border-slate-700 dark:bg-slate-800/50">
+              <p className="text-lg font-medium text-slate-700 dark:text-slate-300">
+                This droplet hasn&apos;t been written yet.
+              </p>
+              <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+                Sign in to apply to write this droplet.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/requests/content-creation-request.tsx
+++ b/frontend/components/requests/content-creation-request.tsx
@@ -11,18 +11,35 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Sparkles, Lightbulb } from "lucide-react";
+import { Sparkles, Lightbulb, MapPin } from "lucide-react";
 import { AuthorizedUser } from "@/types";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 
+type ContentCreatorRequestFormProps = {
+  user: AuthorizedUser | undefined;
+  voyageNodeId?: number;
+  voyageName?: string;
+  nodeLabel?: string;
+};
+
 export function ContentCreatorRequestForm({
   user,
-}: {
-  user: AuthorizedUser | undefined;
-}) {
+  voyageNodeId,
+  voyageName,
+  nodeLabel,
+}: ContentCreatorRequestFormProps) {
+  const hasVoyageContext =
+    voyageNodeId !== undefined &&
+    voyageName !== undefined &&
+    nodeLabel !== undefined;
+
+  const defaultIdeas = hasVoyageContext
+    ? `I'd like to write the droplet for '${nodeLabel}' in the voyage '${voyageName}'`
+    : "";
+
   const [motivation, setMotivation] = useState("");
-  const [ideas, setIdeas] = useState("");
+  const [ideas, setIdeas] = useState(defaultIdeas);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
 
@@ -39,6 +56,7 @@ export function ContentCreatorRequestForm({
         motivation,
         dropletIdea: ideas,
         user: user.id,
+        ...(hasVoyageContext ? { voyageNodeId } : {}),
       });
 
       if (result.ok) {
@@ -80,6 +98,18 @@ export function ContentCreatorRequestForm({
 
         <CardContent>
           <div className="space-y-6">
+            {/* Voyage context banner */}
+            {hasVoyageContext && (
+              <div className="flex items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 dark:border-blue-800 dark:bg-blue-950">
+                <MapPin className="h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-400" />
+                <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
+                  You&apos;re applying to contribute to{" "}
+                  <span className="font-semibold">{voyageName}</span> &mdash;{" "}
+                  <span className="font-semibold">{nodeLabel}</span>
+                </p>
+              </div>
+            )}
+
             {/* Motivation Section */}
             <div className="space-y-3">
               <div className="flex items-start gap-2">

--- a/frontend/components/shared/creation-request-manager/view-request.tsx
+++ b/frontend/components/shared/creation-request-manager/view-request.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { Check, X, Lightbulb, Sparkles } from "lucide-react";
+import { Check, X, Lightbulb, Sparkles, MapPin } from "lucide-react";
 import { CreationRequest } from "@/types";
 import { approveCreationRequest, deleteCreationRequest } from "@/lib/actions";
 import { toast } from "sonner";
@@ -121,6 +121,35 @@ export function CreationRequestModal({
               </p>
             </div>
           </div>
+
+          {/* Voyage Node Context (when request is tied to a specific node) */}
+          {request.voyageNode && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <MapPin className="h-5 w-5 text-black dark:text-white" />
+                <h3 className="text-lg font-semibold text-black dark:text-white">
+                  Voyage Node
+                </h3>
+              </div>
+              <div className="flex items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 dark:border-blue-800 dark:bg-blue-950">
+                <p className="text-sm text-blue-800 dark:text-blue-200">
+                  This application is tied to voyage node:{" "}
+                  <span className="font-semibold">
+                    {request.voyageNode.label}
+                  </span>
+                  {request.voyageNode.voyage && (
+                    <>
+                      {" "}
+                      in{" "}
+                      <span className="font-semibold">
+                        {request.voyageNode.voyage.name}
+                      </span>
+                    </>
+                  )}
+                </p>
+              </div>
+            </div>
+          )}
         </div>
 
         <DialogFooter className="flex gap-3 sm:gap-3">

--- a/frontend/components/voyages/claim-node-button.tsx
+++ b/frontend/components/voyages/claim-node-button.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import {
+  claimVoyageDropletNode,
+  unclaimVoyageDropletNode,
+} from "@/lib/requests/voyage-enrollment";
+
+interface ClaimNodeButtonProps {
+  voyageNodeId: number;
+  mode?: "claim" | "unclaim";
+}
+
+export function ClaimNodeButton({
+  voyageNodeId,
+  mode = "claim",
+}: ClaimNodeButtonProps) {
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  function handleClick() {
+    startTransition(async () => {
+      if (mode === "claim") {
+        const result = await claimVoyageDropletNode(voyageNodeId);
+        if (result.ok && "data" in result && result.data?.dropletSlug) {
+          router.push(`/d/${result.data.dropletSlug}`);
+        } else if (!result.ok) {
+          console.error("Failed to claim node:", result.error);
+        }
+      } else {
+        const result = await unclaimVoyageDropletNode(voyageNodeId);
+        if (!result.ok) {
+          console.error("Failed to unclaim node:", result.error);
+        }
+      }
+    });
+  }
+
+  if (mode === "unclaim") {
+    return (
+      <button
+        onClick={handleClick}
+        disabled={isPending}
+        className={cn(
+          "inline-flex items-center rounded-md border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-600 transition-colors hover:border-red-300 hover:bg-red-50 hover:text-red-600",
+          "dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-red-700 dark:hover:bg-red-950/20 dark:hover:text-red-400",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+        )}
+      >
+        {isPending ? "Unclaiming..." : "Unclaim"}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isPending}
+      className={cn(
+        "inline-flex items-center rounded-lg bg-[#297496] px-6 py-3 text-base font-semibold text-white shadow-sm transition-colors hover:bg-[#225f7a]",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+      )}
+    >
+      {isPending ? "Claiming..." : "Claim this Droplet"}
+    </button>
+  );
+}

--- a/frontend/components/voyages/claim-node-button.tsx
+++ b/frontend/components/voyages/claim-node-button.tsx
@@ -25,7 +25,7 @@ export function ClaimNodeButton({
       if (mode === "claim") {
         const result = await claimVoyageDropletNode(voyageNodeId);
         if (result.ok && "data" in result && result.data?.dropletSlug) {
-          router.push(`/d/${result.data.dropletSlug}`);
+          router.push(`/draft/d/${result.data.dropletSlug}`);
         } else if (!result.ok) {
           console.error("Failed to claim node:", result.error);
         }

--- a/frontend/components/voyages/voyage-card.tsx
+++ b/frontend/components/voyages/voyage-card.tsx
@@ -7,11 +7,26 @@ interface VoyageCardProps {
 
 export function VoyageCard({ voyage }: VoyageCardProps) {
   const nodes = voyage.voyage_nodes ?? [];
-  const playlistCount = nodes.filter((n) => n.isMainPath).length;
-  const dropletCount = nodes.reduce(
-    (acc, n) => acc + (n.playlist?.droplets?.length ?? 0),
-    0,
-  );
+
+  // Count playlist nodes vs claimed droplet nodes vs unclaimed placeholders
+  const playlistNodeCount = nodes.filter(
+    (n) => n.nodeType === "playlist",
+  ).length;
+  const claimedDropletCount = nodes.filter(
+    (n) => n.nodeType === "droplet" && n.claimStatus !== "unclaimed",
+  ).length;
+  const unclaimedCount = nodes.filter(
+    (n) => n.nodeType === "droplet" && n.claimStatus === "unclaimed",
+  ).length;
+
+  // Total droplets: droplets inside playlists + standalone droplet nodes (1 each)
+  const dropletCount =
+    nodes.reduce(
+      (acc, n) =>
+        acc +
+        (n.nodeType === "playlist" ? n.playlist?.droplets?.length ?? 0 : 0),
+      0,
+    ) + claimedDropletCount;
 
   return (
     <Link
@@ -33,8 +48,22 @@ export function VoyageCard({ voyage }: VoyageCardProps) {
           </p>
         )}
         <p className="mt-auto pt-2 text-sm text-slate-500 dark:text-slate-400">
-          {playlistCount} {playlistCount === 1 ? "playlist" : "playlists"}{" "}
-          &middot; {dropletCount} {dropletCount === 1 ? "droplet" : "droplets"}
+          {playlistNodeCount > 0 && (
+            <>
+              {playlistNodeCount}{" "}
+              {playlistNodeCount === 1 ? "playlist" : "playlists"}
+            </>
+          )}
+          {playlistNodeCount > 0 && dropletCount > 0 && <> &middot; </>}
+          {dropletCount > 0 && (
+            <>
+              {dropletCount} {dropletCount === 1 ? "droplet" : "droplets"}
+            </>
+          )}
+          {unclaimedCount > 0 && <> &middot; {unclaimedCount} unclaimed</>}
+          {playlistNodeCount === 0 &&
+            dropletCount === 0 &&
+            unclaimedCount === 0 && <>No content yet</>}
         </p>
       </div>
     </Link>

--- a/frontend/components/voyages/voyage-enroll-button.tsx
+++ b/frontend/components/voyages/voyage-enroll-button.tsx
@@ -11,14 +11,14 @@ interface VoyageEnrollButtonProps {
   voyageId: number;
   enrollment: VoyageEnrollment | null;
   completionPercentage: number;
-  firstIncompleteSlug?: string;
+  firstIncompleteHref?: string;
 }
 
 export function VoyageEnrollButton({
   voyageId,
   enrollment,
   completionPercentage,
-  firstIncompleteSlug,
+  firstIncompleteHref,
 }: VoyageEnrollButtonProps) {
   const [isPending, startTransition] = useTransition();
 
@@ -56,8 +56,8 @@ export function VoyageEnrollButton({
         </Button>
       )}
 
-      {isEnrolled && !isCompleted && firstIncompleteSlug && (
-        <Link href={`/p/${firstIncompleteSlug}`}>
+      {isEnrolled && !isCompleted && firstIncompleteHref && (
+        <Link href={firstIncompleteHref}>
           <Button
             variant="outline"
             className="border-[#297496] text-[#297496] hover:bg-[#297496]/10"

--- a/frontend/components/voyages/voyage-form-tour.tsx
+++ b/frontend/components/voyages/voyage-form-tour.tsx
@@ -23,8 +23,8 @@ export function VoyageFormTour({ run, setRun }: VoyageFormTourProps) {
     const d = driver({
       showProgress: true,
       animate: true,
-      overlayColor: "rgba(0,0,0,0.4)",
-      overlayOpacity: 0.4,
+      overlayColor: "rgba(0,0,0,0.75)",
+      overlayOpacity: 0.75,
       smoothScroll: true,
       allowClose: true,
       stagePadding: 6,
@@ -45,9 +45,9 @@ export function VoyageFormTour({ run, setRun }: VoyageFormTourProps) {
       steps: [
         {
           popover: {
-            title: "Welcome to Voyage Builder",
+            title: "Let's build a Voyage!",
             description:
-              "Voyages are structured learning paths made of islands. Each island can be a playlist, a droplet, or a placeholder for someone to claim. Let's walk through the tools.",
+              "A voyage is a learning path your students follow, island by island. You can mix playlists, individual droplets, and even leave spots open for others to contribute.",
             side: "over",
             align: "center",
           },
@@ -55,9 +55,9 @@ export function VoyageFormTour({ run, setRun }: VoyageFormTourProps) {
         {
           element: "#tour-voyage-name",
           popover: {
-            title: "Voyage Name",
+            title: "Name your Voyage",
             description:
-              "Give your voyage a descriptive name. This is what students will see when browsing voyages.",
+              "Pick something students will recognize. This shows up on the explore page and their dashboard.",
             side: "bottom",
             align: "start",
           },
@@ -65,9 +65,9 @@ export function VoyageFormTour({ run, setRun }: VoyageFormTourProps) {
         {
           element: "#tour-node-type-tabs",
           popover: {
-            title: "Island Types",
+            title: "Islands",
             description:
-              "Choose what type of island to add:\n\n• Playlist — a collection of droplets\n• Droplet — a single learning unit\n• Placeholder — an empty spot for someone to claim and write",
+              "Each island is one stop on the journey. Use the Playlist tab to add a group of droplets, the Droplet tab to add a single piece of content, or the Placeholder tab to leave a spot for someone else to claim and write.",
             side: "bottom",
             align: "center",
           },
@@ -75,9 +75,9 @@ export function VoyageFormTour({ run, setRun }: VoyageFormTourProps) {
         {
           element: "#tour-node-list",
           popover: {
-            title: "Your Islands",
+            title: "Build your path",
             description:
-              "Islands appear here as you add them. Drag the grip handle to reorder main path islands. Use 'Branches from' to create optional side paths.",
+              "Your islands show up here as you add them. Reorder them with the arrows, or use the Branches from dropdown to create optional side paths.",
             side: "right",
             align: "start",
           },
@@ -85,9 +85,9 @@ export function VoyageFormTour({ run, setRun }: VoyageFormTourProps) {
         {
           element: "#tour-sequential-toggle",
           popover: {
-            title: "Sequential Progression",
+            title: "Sequential progression",
             description:
-              "When enabled, students must complete each island before unlocking the next. Placeholder islands are skipped automatically.",
+              "Turn this on if you want students to go through islands one at a time. They need to finish each stop before the next one unlocks. Placeholders are skipped automatically.",
             side: "top",
             align: "start",
           },
@@ -97,7 +97,7 @@ export function VoyageFormTour({ run, setRun }: VoyageFormTourProps) {
           popover: {
             title: "Live Preview",
             description:
-              "See how your voyage tree looks in real-time as you build it. The preview updates as you add, remove, and reorder islands.",
+              "This preview updates as you go. Add an island and watch it appear on the map. This is the same tree view students will see.",
             side: "left",
             align: "start",
           },
@@ -105,9 +105,9 @@ export function VoyageFormTour({ run, setRun }: VoyageFormTourProps) {
         {
           element: "#tour-publish-buttons",
           popover: {
-            title: "Save & Publish",
+            title: "Save and Publish",
             description:
-              "Save as draft to continue editing later, or publish to make the voyage available to students. You can always edit after publishing.",
+              "Click Save as Draft if you are still working on it, or Publish Voyage to make it live. You can always come back and edit.",
             side: "top",
             align: "center",
           },

--- a/frontend/components/voyages/voyage-form-tour.tsx
+++ b/frontend/components/voyages/voyage-form-tour.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { driver } from "driver.js";
+import "driver.js/dist/driver.css";
+
+export const VOYAGE_TOUR_KEY = "voyage-form-tour-v1";
+
+interface VoyageFormTourProps {
+  run: boolean;
+  setRun: (v: boolean) => void;
+}
+
+export function VoyageFormTour({ run, setRun }: VoyageFormTourProps) {
+  const driverRef = useRef<ReturnType<typeof driver> | null>(null);
+
+  useEffect(() => {
+    if (!run) {
+      driverRef.current?.destroy();
+      return;
+    }
+
+    const d = driver({
+      showProgress: true,
+      animate: true,
+      overlayColor: "rgba(0,0,0,0.4)",
+      overlayOpacity: 0.4,
+      smoothScroll: true,
+      allowClose: true,
+      stagePadding: 6,
+      stageRadius: 8,
+      popoverOffset: 24,
+      popoverClass: "draft-tour-popover",
+      nextBtnText: "Next",
+      prevBtnText: "Back",
+      doneBtnText: "Got it!",
+      onCloseClick: () => {
+        setRun(false);
+        localStorage.setItem(VOYAGE_TOUR_KEY, "completed");
+      },
+      onDestroyStarted: () => {
+        setRun(false);
+        localStorage.setItem(VOYAGE_TOUR_KEY, "completed");
+      },
+      steps: [
+        {
+          popover: {
+            title: "Welcome to Voyage Builder",
+            description:
+              "Voyages are structured learning paths made of islands. Each island can be a playlist, a droplet, or a placeholder for someone to claim. Let's walk through the tools.",
+            side: "over",
+            align: "center",
+          },
+        },
+        {
+          element: "#tour-voyage-name",
+          popover: {
+            title: "Voyage Name",
+            description:
+              "Give your voyage a descriptive name. This is what students will see when browsing voyages.",
+            side: "bottom",
+            align: "start",
+          },
+        },
+        {
+          element: "#tour-node-type-tabs",
+          popover: {
+            title: "Island Types",
+            description:
+              "Choose what type of island to add:\n\n• Playlist — a collection of droplets\n• Droplet — a single learning unit\n• Placeholder — an empty spot for someone to claim and write",
+            side: "bottom",
+            align: "center",
+          },
+        },
+        {
+          element: "#tour-node-list",
+          popover: {
+            title: "Your Islands",
+            description:
+              "Islands appear here as you add them. Drag the grip handle to reorder main path islands. Use 'Branches from' to create optional side paths.",
+            side: "right",
+            align: "start",
+          },
+        },
+        {
+          element: "#tour-sequential-toggle",
+          popover: {
+            title: "Sequential Progression",
+            description:
+              "When enabled, students must complete each island before unlocking the next. Placeholder islands are skipped automatically.",
+            side: "top",
+            align: "start",
+          },
+        },
+        {
+          element: "#tour-preview",
+          popover: {
+            title: "Live Preview",
+            description:
+              "See how your voyage tree looks in real-time as you build it. The preview updates as you add, remove, and reorder islands.",
+            side: "left",
+            align: "start",
+          },
+        },
+        {
+          element: "#tour-publish-buttons",
+          popover: {
+            title: "Save & Publish",
+            description:
+              "Save as draft to continue editing later, or publish to make the voyage available to students. You can always edit after publishing.",
+            side: "top",
+            align: "center",
+          },
+        },
+      ],
+    });
+
+    driverRef.current = d;
+    d.drive();
+  }, [run, setRun]);
+
+  return null;
+}

--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -1,23 +1,17 @@
 "use client";
 
-import {
-  useState,
-  useTransition,
-  useMemo,
-  useCallback,
-  useRef,
-  useEffect,
-  ReactNode,
-} from "react";
+import { useState, useTransition, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Playlist, Voyage } from "@/types";
+import { Label } from "@/components/ui/label";
+import { Droplet, Playlist, Voyage } from "@/types";
 import { cn } from "@/lib/utils";
 import {
   createVoyageWithNodes,
   updateVoyageWithNodes,
 } from "@/lib/requests/voyage";
+import { VoyageTreeSchema } from "@/lib/validations/voyage";
 import { VoyageTreeMap, TreeNode } from "@/components/voyages/voyage-tree-map";
 import {
   ChevronUpIcon,
@@ -25,65 +19,79 @@ import {
   XIcon,
   SearchIcon,
   PlusIcon,
+  BookOpenIcon,
+  DropletIcon,
+  CircleDashedIcon,
 } from "lucide-react";
 
+type NodeMode = "playlist" | "droplet" | "placeholder";
+
 interface SelectedNode {
-  playlistId: number;
+  localId: string;
+  nodeType: "playlist" | "droplet";
+  playlistId: number | null;
+  dropletId: number | null;
   name: string;
   slug: string;
   dropletCount: number;
   isMainPath: boolean;
   branchType: "required" | "optional";
-  parentPlaylistId: number | null; // null = main path
+  parentLocalId: string | null;
   orderIndex: number;
+  claimStatus?: "unclaimed" | "claimed" | "authored" | null;
+  claimedById?: number | null;
 }
 
 interface VoyageFormProps {
   playlists: Playlist[];
+  droplets: Droplet[];
   authorId: number;
   voyage?: Voyage;
 }
 
+function generateLocalId(): string {
+  return crypto.randomUUID();
+}
+
 function initNodesFromVoyage(voyage: Voyage): SelectedNode[] {
   const nodes = voyage.voyage_nodes ?? [];
-  // Build a lookup from node ID → playlist ID for resolving parentPlaylistId
-  const nodeIdToPlaylistId = new Map<number, number>();
-  for (const n of nodes) {
-    if (n.playlist?.id) nodeIdToPlaylistId.set(n.id, n.playlist.id);
+  // Build a lookup from Strapi node ID → generated localId for resolving parentLocalId
+  const nodeIdToLocalId = new Map<number, string>();
+  const localIds = nodes.map(() => generateLocalId());
+  for (let i = 0; i < nodes.length; i++) {
+    nodeIdToLocalId.set(nodes[i].id, localIds[i]);
   }
 
-  return nodes.map((n) => ({
-    playlistId: n.playlist?.id ?? 0,
-    name: n.playlist?.name ?? n.label,
-    slug: n.playlist?.slug ?? "",
-    dropletCount: n.playlist?.droplets?.length ?? 0,
+  return nodes.map((n, i) => ({
+    localId: localIds[i],
+    nodeType: n.nodeType === "droplet" ? "droplet" : "playlist",
+    playlistId: n.playlist?.id ?? null,
+    dropletId: n.droplet?.id ?? null,
+    name: n.droplet?.name ?? n.playlist?.name ?? n.label,
+    slug: n.droplet?.slug ?? n.playlist?.slug ?? "",
+    dropletCount:
+      n.nodeType === "droplet"
+        ? n.droplet
+          ? 1
+          : 0
+        : n.playlist?.droplets?.length ?? 0,
     isMainPath: n.isMainPath,
     branchType: n.branchType,
-    parentPlaylistId: n.parentNode?.id
-      ? nodeIdToPlaylistId.get(n.parentNode.id) ?? null
+    parentLocalId: n.parentNode?.id
+      ? nodeIdToLocalId.get(n.parentNode.id) ?? null
       : null,
     orderIndex: n.orderIndex,
+    claimStatus: n.claimStatus ?? null,
+    claimedById: n.claimedBy?.id ?? null,
   }));
 }
 
-function SectionLabel({
-  children,
-  htmlFor,
-}: {
-  children: ReactNode;
-  htmlFor?: string;
-}) {
-  return (
-    <label
-      htmlFor={htmlFor}
-      className="block py-0.5 pb-2 text-xl font-bold text-slate-900 dark:text-white"
-    >
-      {children}
-    </label>
-  );
-}
-
-export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
+export function VoyageForm({
+  playlists,
+  droplets,
+  authorId,
+  voyage,
+}: VoyageFormProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const isEditing = !!voyage;
@@ -91,30 +99,36 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
   const [name, setName] = useState(voyage?.name ?? "");
   const [description, setDescription] = useState(voyage?.description ?? "");
   const [searchQuery, setSearchQuery] = useState("");
+  const [placeholderLabel, setPlaceholderLabel] = useState("");
+  const [nodeMode, setNodeMode] = useState<NodeMode>("playlist");
   const [selectedNodes, setSelectedNodes] = useState<SelectedNode[]>(
     voyage ? initNodesFromVoyage(voyage) : [],
   );
   const [isSequential, setIsSequential] = useState(
     voyage?.isSequential ?? false,
   );
-  const [isSearchFocused, setIsSearchFocused] = useState(false);
-  const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [error, setError] = useState("");
-
-  useEffect(() => {
-    return () => {
-      if (blurTimer.current) clearTimeout(blurTimer.current);
-    };
-  }, []);
 
   const availablePlaylists = useMemo(
     () =>
       playlists.filter(
         (p) =>
-          !selectedNodes.some((n) => n.playlistId === p.id) &&
-          p.name.toLowerCase().includes(searchQuery.toLowerCase()),
+          !selectedNodes.some(
+            (n) => n.nodeType === "playlist" && n.playlistId === p.id,
+          ) && p.name.toLowerCase().includes(searchQuery.toLowerCase()),
       ),
     [playlists, selectedNodes, searchQuery],
+  );
+
+  const availableDroplets = useMemo(
+    () =>
+      droplets.filter(
+        (d) =>
+          !selectedNodes.some(
+            (n) => n.nodeType === "droplet" && n.dropletId === d.id,
+          ) && d.name.toLowerCase().includes(searchQuery.toLowerCase()),
+      ),
+    [droplets, selectedNodes, searchQuery],
   );
 
   // All main-path nodes (for the "Branches from" select options)
@@ -130,13 +144,16 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
       return [
         ...prev,
         {
+          localId: generateLocalId(),
+          nodeType: "playlist" as const,
           playlistId: playlist.id,
+          dropletId: null,
           name: playlist.name,
           slug: playlist.slug,
           dropletCount,
           isMainPath: true,
           branchType: "required",
-          parentPlaylistId: null,
+          parentLocalId: null,
           orderIndex: mainCount,
         },
       ];
@@ -144,11 +161,59 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
     setSearchQuery("");
   }, []);
 
-  const removeNode = useCallback((playlistId: number) => {
+  const addDroplet = useCallback((droplet: Droplet) => {
+    setSelectedNodes((prev) => {
+      const mainCount = prev.filter((n) => n.isMainPath).length;
+      return [
+        ...prev,
+        {
+          localId: generateLocalId(),
+          nodeType: "droplet" as const,
+          playlistId: null,
+          dropletId: droplet.id,
+          name: droplet.name,
+          slug: droplet.slug,
+          dropletCount: 1,
+          isMainPath: true,
+          branchType: "required",
+          parentLocalId: null,
+          orderIndex: mainCount,
+        },
+      ];
+    });
+    setSearchQuery("");
+  }, []);
+
+  const addPlaceholder = useCallback(() => {
+    const label = placeholderLabel.trim();
+    if (!label) return;
+    setSelectedNodes((prev) => {
+      const mainCount = prev.filter((n) => n.isMainPath).length;
+      return [
+        ...prev,
+        {
+          localId: generateLocalId(),
+          nodeType: "droplet" as const,
+          playlistId: null,
+          dropletId: null,
+          name: label,
+          slug: "",
+          dropletCount: 0,
+          isMainPath: true,
+          branchType: "required",
+          parentLocalId: null,
+          orderIndex: mainCount,
+        },
+      ];
+    });
+    setPlaceholderLabel("");
+  }, [placeholderLabel]);
+
+  const removeNode = useCallback((localId: string) => {
     setSelectedNodes((prev) => {
       // When removing a node, also remove any branch nodes that depend on it
       const filtered = prev.filter(
-        (n) => n.playlistId !== playlistId && n.parentPlaylistId !== playlistId,
+        (n) => n.localId !== localId && n.parentLocalId !== localId,
       );
       // Reindex main path orderIndex
       let mainIdx = 0;
@@ -161,70 +226,70 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
     });
   }, []);
 
-  const moveUp = useCallback((playlistId: number) => {
+  const moveUp = useCallback((localId: string) => {
     setSelectedNodes((prev) => {
       const mainNodes = prev
         .filter((n) => n.isMainPath)
         .sort((a, b) => a.orderIndex - b.orderIndex);
-      const idx = mainNodes.findIndex((n) => n.playlistId === playlistId);
+      const idx = mainNodes.findIndex((n) => n.localId === localId);
       if (idx <= 0) return prev;
 
       // Swap orderIndex values
-      const idA = mainNodes[idx - 1].playlistId;
-      const idB = mainNodes[idx].playlistId;
+      const idA = mainNodes[idx - 1].localId;
+      const idB = mainNodes[idx].localId;
       return prev.map((n) => {
-        if (n.playlistId === idA) return { ...n, orderIndex: idx };
-        if (n.playlistId === idB) return { ...n, orderIndex: idx - 1 };
+        if (n.localId === idA) return { ...n, orderIndex: idx };
+        if (n.localId === idB) return { ...n, orderIndex: idx - 1 };
         return n;
       });
     });
   }, []);
 
-  const moveDown = useCallback((playlistId: number) => {
+  const moveDown = useCallback((localId: string) => {
     setSelectedNodes((prev) => {
       const mainNodes = prev
         .filter((n) => n.isMainPath)
         .sort((a, b) => a.orderIndex - b.orderIndex);
-      const idx = mainNodes.findIndex((n) => n.playlistId === playlistId);
+      const idx = mainNodes.findIndex((n) => n.localId === localId);
       if (idx < 0 || idx >= mainNodes.length - 1) return prev;
 
-      const idA = mainNodes[idx].playlistId;
-      const idB = mainNodes[idx + 1].playlistId;
+      const idA = mainNodes[idx].localId;
+      const idB = mainNodes[idx + 1].localId;
       return prev.map((n) => {
-        if (n.playlistId === idA) return { ...n, orderIndex: idx + 1 };
-        if (n.playlistId === idB) return { ...n, orderIndex: idx };
+        if (n.localId === idA) return { ...n, orderIndex: idx + 1 };
+        if (n.localId === idB) return { ...n, orderIndex: idx };
         return n;
       });
     });
   }, []);
 
   const setParent = useCallback(
-    (playlistId: number, parentId: number | null) => {
+    (localId: string, parentLocalId: string | null) => {
       setSelectedNodes((prev) => {
         // Recompute main-path orderIndex after structure change
         const updated = prev.map((n) => {
-          if (n.playlistId !== playlistId) {
+          if (n.localId !== localId) {
             // If this node was a child of the node being converted to branch,
             // promote it to main path to avoid orphaning
-            if (parentId !== null && n.parentPlaylistId === playlistId) {
-              return { ...n, isMainPath: true, parentPlaylistId: null };
+            if (parentLocalId !== null && n.parentLocalId === localId) {
+              return { ...n, isMainPath: true, parentLocalId: null };
             }
             return n;
           }
-          if (parentId === null) {
+          if (parentLocalId === null) {
             // Promoting to main path
             const mainCount = prev.filter((p) => p.isMainPath).length;
             return {
               ...n,
               isMainPath: true,
-              parentPlaylistId: null,
+              parentLocalId: null,
               orderIndex: mainCount,
             };
           }
           return {
             ...n,
             isMainPath: false,
-            parentPlaylistId: parentId,
+            parentLocalId,
             orderIndex: 0,
           };
         });
@@ -240,36 +305,44 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
   );
 
   const setBranchType = useCallback(
-    (playlistId: number, branchType: "required" | "optional") => {
+    (localId: string, branchType: "required" | "optional") => {
       setSelectedNodes((prev) =>
-        prev.map((n) =>
-          n.playlistId === playlistId ? { ...n, branchType } : n,
-        ),
+        prev.map((n) => (n.localId === localId ? { ...n, branchType } : n)),
       );
     },
     [],
   );
 
   // Derive TreeNode[] for VoyageTreeMap preview
-  const treeNodes: TreeNode[] = useMemo(
-    () =>
-      selectedNodes.map((node) => ({
-        id: node.playlistId,
-        label: node.name,
-        slug: node.slug,
-        dropletCount: node.dropletCount,
-        isMainPath: node.isMainPath,
-        branchType: node.branchType,
-        parentId: node.parentPlaylistId,
-        orderIndex: node.orderIndex,
-        status: isSequential
-          ? node.isMainPath && node.orderIndex === 0
-            ? "available"
-            : "locked"
-          : "available",
-      })),
-    [selectedNodes, isSequential],
-  );
+  // Use a stable numeric id for the tree map derived from localId index position
+  const treeNodes: TreeNode[] = useMemo(() => {
+    // Build a map from localId -> numeric index for tree rendering
+    const localIdToIndex = new Map<string, number>();
+    selectedNodes.forEach((n, i) => localIdToIndex.set(n.localId, i + 1));
+
+    return selectedNodes.map((node) => ({
+      id: localIdToIndex.get(node.localId)!,
+      label: node.name,
+      slug: node.slug || undefined,
+      dropletCount: node.dropletCount,
+      isMainPath: node.isMainPath,
+      branchType: node.branchType,
+      parentId: node.parentLocalId
+        ? localIdToIndex.get(node.parentLocalId) ?? null
+        : null,
+      orderIndex: node.orderIndex,
+      status: isSequential
+        ? node.isMainPath && node.orderIndex === 0
+          ? "available"
+          : "locked"
+        : "available",
+      nodeType: node.nodeType,
+      claimStatus:
+        node.nodeType === "droplet" && !node.dropletId
+          ? ("unclaimed" as const)
+          : null,
+    }));
+  }, [selectedNodes, isSequential]);
 
   // Sort for display: main-path nodes first (by orderIndex), then branch nodes grouped under parent
   const sortedForDisplay = useMemo(() => {
@@ -281,7 +354,7 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
     for (const main of mainSorted) {
       result.push(main);
       const branches = selectedNodes.filter(
-        (n) => !n.isMainPath && n.parentPlaylistId === main.playlistId,
+        (n) => !n.isMainPath && n.parentLocalId === main.localId,
       );
       result.push(...branches);
     }
@@ -297,19 +370,35 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
     }
 
     if (selectedNodes.length === 0) {
-      setError("At least one island (playlist) is required.");
+      setError("At least one island (playlist or droplet) is required.");
       return;
     }
 
     startTransition(async () => {
       const nodePayload = selectedNodes.map((n) => ({
+        localId: n.localId,
+        nodeType: n.nodeType,
         playlistId: n.playlistId,
+        dropletId: n.dropletId,
         isMainPath: n.isMainPath,
         branchType: n.branchType,
-        parentPlaylistId: n.parentPlaylistId,
+        parentLocalId: n.parentLocalId,
         orderIndex: n.orderIndex,
         label: n.name,
+        claimStatus: n.claimStatus,
+        claimedById: n.claimedById,
       }));
+
+      // Validate with Zod schema (circular refs, max nodes, max branches, etc.)
+      const validation = VoyageTreeSchema.safeParse({
+        name: name.trim(),
+        description: description.trim() || undefined,
+        nodes: nodePayload,
+      });
+      if (!validation.success) {
+        setError(validation.error.issues[0]?.message || "Validation failed.");
+        return;
+      }
 
       const result = isEditing
         ? await updateVoyageWithNodes({
@@ -343,11 +432,13 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
 
   return (
     <div className="flex w-full flex-col gap-8 lg:flex-row">
+      {/* Left: Form panel */}
       <div className="flex w-full flex-col gap-6 lg:w-1/2">
+        {/* Name */}
         <div className="flex flex-col gap-2">
-          <SectionLabel htmlFor="voyage-name">
+          <Label htmlFor="voyage-name">
             Voyage Name <span className="text-red-500">*</span>
-          </SectionLabel>
+          </Label>
           <Input
             id="voyage-name"
             placeholder="e.g. Introduction to Machine Learning"
@@ -357,8 +448,9 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
           />
         </div>
 
+        {/* Description */}
         <div className="flex flex-col gap-2">
-          <SectionLabel htmlFor="voyage-description">Description</SectionLabel>
+          <Label htmlFor="voyage-description">Description</Label>
           <textarea
             id="voyage-description"
             className="min-h-[100px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus:ring-2 focus:ring-slate-400 focus:outline-none disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:placeholder:text-slate-500"
@@ -369,69 +461,195 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
           />
         </div>
 
+        {/* Node picker */}
         <div className="flex flex-col gap-3">
-          <SectionLabel>Islands (Playlists)</SectionLabel>
+          <Label>Islands</Label>
 
-          <div className="relative">
-            <SearchIcon className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
-            <Input
-              className="pl-9"
-              placeholder="Search public playlists..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              onFocus={() => {
-                if (blurTimer.current) clearTimeout(blurTimer.current);
-                setIsSearchFocused(true);
-              }}
-              onBlur={() => {
-                blurTimer.current = setTimeout(
-                  () => setIsSearchFocused(false),
-                  150,
-                );
+          {/* Node type selector */}
+          <div className="flex overflow-hidden rounded-md border border-slate-200 dark:border-slate-600">
+            <button
+              type="button"
+              onClick={() => {
+                setNodeMode("playlist");
+                setSearchQuery("");
+                setPlaceholderLabel("");
               }}
               disabled={isPending}
-            />
+              className={cn(
+                "flex flex-1 items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors",
+                nodeMode === "playlist"
+                  ? "bg-[#297496] text-white"
+                  : "bg-white text-slate-600 hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800",
+              )}
+            >
+              <BookOpenIcon className="h-3.5 w-3.5" />
+              Playlist
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setNodeMode("droplet");
+                setSearchQuery("");
+                setPlaceholderLabel("");
+              }}
+              disabled={isPending}
+              className={cn(
+                "flex flex-1 items-center justify-center gap-1.5 border-x border-slate-200 px-3 py-1.5 text-xs font-medium transition-colors dark:border-slate-600",
+                nodeMode === "droplet"
+                  ? "bg-[#297496] text-white"
+                  : "bg-white text-slate-600 hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800",
+              )}
+            >
+              <DropletIcon className="h-3.5 w-3.5" />
+              Droplet
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setNodeMode("placeholder");
+                setSearchQuery("");
+              }}
+              disabled={isPending}
+              className={cn(
+                "flex flex-1 items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors",
+                nodeMode === "placeholder"
+                  ? "bg-[#297496] text-white"
+                  : "bg-white text-slate-600 hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800",
+              )}
+            >
+              <CircleDashedIcon className="h-3.5 w-3.5" />
+              Placeholder
+            </button>
           </div>
 
-          {isSearchFocused && (
-            <div className="max-h-48 overflow-y-auto rounded-md border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
-              {availablePlaylists.length === 0 ? (
-                <p className="px-4 py-3 text-sm text-slate-500">
-                  {searchQuery
-                    ? "No playlists found."
-                    : "All playlists have been added."}
-                </p>
-              ) : (
-                availablePlaylists.map((playlist) => (
-                  <button
-                    key={playlist.id}
-                    type="button"
-                    className="flex w-full items-center justify-between px-4 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
-                    onClick={() => addPlaylist(playlist)}
-                    disabled={isPending}
-                  >
-                    <span className="truncate font-medium">
-                      {playlist.name}
-                    </span>
-                    <div className="ml-2 flex flex-shrink-0 items-center gap-1 text-slate-400">
-                      <span className="text-xs">
-                        {playlist.droplets?.length ?? 0} droplets
+          {/* Playlist search */}
+          {nodeMode === "playlist" && (
+            <>
+              <div className="relative">
+                <SearchIcon className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                <Input
+                  className="pl-9"
+                  placeholder="Search public playlists..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  disabled={isPending}
+                />
+              </div>
+
+              <div className="max-h-48 overflow-y-auto rounded-md border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
+                {availablePlaylists.length === 0 ? (
+                  <p className="px-4 py-3 text-sm text-slate-500">
+                    {searchQuery
+                      ? "No playlists found."
+                      : "No playlists available."}
+                  </p>
+                ) : (
+                  availablePlaylists.slice(0, 10).map((playlist) => (
+                    <button
+                      key={playlist.id}
+                      type="button"
+                      className="flex w-full items-center justify-between px-4 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
+                      onClick={() => addPlaylist(playlist)}
+                      disabled={isPending}
+                    >
+                      <span className="truncate font-medium">
+                        {playlist.name}
                       </span>
-                      <PlusIcon className="h-4 w-4 text-[#297496]" />
-                    </div>
-                  </button>
-                ))
-              )}
+                      <div className="ml-2 flex flex-shrink-0 items-center gap-1 text-slate-400">
+                        <span className="text-xs">
+                          {playlist.droplets?.length ?? 0} droplets
+                        </span>
+                        <PlusIcon className="h-4 w-4 text-[#297496]" />
+                      </div>
+                    </button>
+                  ))
+                )}
+              </div>
+            </>
+          )}
+
+          {/* Droplet search */}
+          {nodeMode === "droplet" && (
+            <>
+              <div className="relative">
+                <SearchIcon className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                <Input
+                  className="pl-9"
+                  placeholder="Search published droplets..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  disabled={isPending}
+                />
+              </div>
+
+              <div className="max-h-48 overflow-y-auto rounded-md border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
+                {availableDroplets.length === 0 ? (
+                  <p className="px-4 py-3 text-sm text-slate-500">
+                    {searchQuery
+                      ? "No droplets found."
+                      : "No droplets available."}
+                  </p>
+                ) : (
+                  availableDroplets.slice(0, 10).map((droplet) => (
+                    <button
+                      key={droplet.id}
+                      type="button"
+                      className="flex w-full items-center justify-between px-4 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
+                      onClick={() => addDroplet(droplet)}
+                      disabled={isPending}
+                    >
+                      <span className="truncate font-medium">
+                        {droplet.name}
+                      </span>
+                      <div className="ml-2 flex flex-shrink-0 items-center gap-1 text-slate-400">
+                        <DropletIcon className="h-3.5 w-3.5" />
+                        <PlusIcon className="h-4 w-4 text-[#297496]" />
+                      </div>
+                    </button>
+                  ))
+                )}
+              </div>
+            </>
+          )}
+
+          {/* Placeholder input */}
+          {nodeMode === "placeholder" && (
+            <div className="flex gap-2">
+              <Input
+                placeholder="Label for this placeholder droplet (e.g. Introduction)"
+                value={placeholderLabel}
+                onChange={(e) => setPlaceholderLabel(e.target.value)}
+                disabled={isPending}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    addPlaceholder();
+                  }
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={addPlaceholder}
+                disabled={isPending || !placeholderLabel.trim()}
+                className="shrink-0"
+              >
+                <PlusIcon className="h-4 w-4" />
+                Add
+              </Button>
             </div>
           )}
 
+          {/* Selected islands list */}
           {sortedForDisplay.length > 0 ? (
             <div className="space-y-1">
               {sortedForDisplay.map((node) => {
                 const isBranch = !node.isMainPath;
+                const isPlaceholder =
+                  node.nodeType === "droplet" && !node.dropletId;
 
                 return (
-                  <div key={node.playlistId} className={isBranch ? "ml-6" : ""}>
+                  <div key={node.localId} className={isBranch ? "ml-6" : ""}>
                     <div
                       className={cn(
                         "flex flex-col gap-2 rounded-md border px-3 py-2",
@@ -452,14 +670,37 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
                         {/* Branch indicator */}
                         {isBranch && <div className="h-4 w-4 flex-shrink-0" />}
 
+                        {/* Node type icon */}
+                        <div className="flex-shrink-0 text-slate-400">
+                          {node.nodeType === "playlist" ? (
+                            <BookOpenIcon className="h-4 w-4" />
+                          ) : isPlaceholder ? (
+                            <CircleDashedIcon className="h-4 w-4 text-amber-500" />
+                          ) : (
+                            <DropletIcon className="h-4 w-4 text-sky-500" />
+                          )}
+                        </div>
+
                         {/* Name + count */}
                         <div className="min-w-0 flex-1">
                           <p className="truncate text-sm font-medium">
                             {node.name}
                           </p>
                           <p className="text-xs text-slate-500">
-                            {node.dropletCount}{" "}
-                            {node.dropletCount === 1 ? "droplet" : "droplets"}
+                            {isPlaceholder ? (
+                              <span className="text-amber-600 dark:text-amber-400">
+                                Placeholder — waiting to be claimed
+                              </span>
+                            ) : node.nodeType === "droplet" ? (
+                              "1 droplet"
+                            ) : (
+                              <>
+                                {node.dropletCount}{" "}
+                                {node.dropletCount === 1
+                                  ? "droplet"
+                                  : "droplets"}
+                              </>
+                            )}
                           </p>
                         </div>
 
@@ -468,7 +709,7 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
                           <div className="flex gap-1">
                             <button
                               type="button"
-                              onClick={() => moveUp(node.playlistId)}
+                              onClick={() => moveUp(node.localId)}
                               disabled={node.orderIndex === 0 || isPending}
                               className="rounded p-0.5 text-slate-400 hover:bg-slate-200 disabled:opacity-30 dark:hover:bg-slate-700"
                               aria-label="Move up"
@@ -477,7 +718,7 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
                             </button>
                             <button
                               type="button"
-                              onClick={() => moveDown(node.playlistId)}
+                              onClick={() => moveDown(node.localId)}
                               disabled={
                                 node.orderIndex === mainPathNodes.length - 1 ||
                                 isPending
@@ -493,7 +734,7 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
                         {/* Remove button */}
                         <button
                           type="button"
-                          onClick={() => removeNode(node.playlistId)}
+                          onClick={() => removeNode(node.localId)}
                           disabled={isPending}
                           className="rounded p-0.5 text-slate-400 hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30"
                           aria-label="Remove island"
@@ -510,23 +751,20 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
                             Branches from
                           </label>
                           <select
-                            value={node.parentPlaylistId ?? ""}
+                            value={node.parentLocalId ?? ""}
                             onChange={(e) => {
                               const val = e.target.value;
-                              setParent(
-                                node.playlistId,
-                                val === "" ? null : Number(val),
-                              );
+                              setParent(node.localId, val === "" ? null : val);
                             }}
                             disabled={isPending}
                             className="w-full rounded border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 focus:ring-1 focus:ring-slate-400 focus:outline-none disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
                           >
                             <option value="">None (main path)</option>
                             {mainPathNodes
-                              .filter((m) => m.playlistId !== node.playlistId)
+                              .filter((m) => m.localId !== node.localId)
                               .sort((a, b) => a.orderIndex - b.orderIndex)
                               .map((m) => (
-                                <option key={m.playlistId} value={m.playlistId}>
+                                <option key={m.localId} value={m.localId}>
                                   {m.orderIndex + 1}. {m.name}
                                 </option>
                               ))}
@@ -543,7 +781,7 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
                               <button
                                 type="button"
                                 onClick={() =>
-                                  setBranchType(node.playlistId, "required")
+                                  setBranchType(node.localId, "required")
                                 }
                                 disabled={isPending}
                                 className={cn(
@@ -558,7 +796,7 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
                               <button
                                 type="button"
                                 onClick={() =>
-                                  setBranchType(node.playlistId, "optional")
+                                  setBranchType(node.localId, "optional")
                                 }
                                 disabled={isPending}
                                 className={cn(
@@ -581,17 +819,21 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
             </div>
           ) : (
             <p className="text-sm text-slate-400 dark:text-slate-500">
-              Select playlists above to add them as islands.
+              {nodeMode === "placeholder"
+                ? "Enter a label above and click Add to create a placeholder droplet for someone to claim."
+                : "Search above to add islands."}
             </p>
           )}
         </div>
 
+        {/* Error */}
         {error && (
           <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
             {error}
           </p>
         )}
 
+        {/* Sequential progression toggle */}
         <label className="flex items-center gap-3 rounded-lg border border-slate-200 px-4 py-3 dark:border-slate-700">
           <input
             type="checkbox"
@@ -610,35 +852,39 @@ export function VoyageForm({ playlists, authorId, voyage }: VoyageFormProps) {
           </div>
         </label>
 
+        {/* Action buttons */}
         <div className="flex gap-3">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => handleSubmit("draft")}
-            disabled={isPending}
-            className="flex-1"
-          >
-            {isPending && "Saving..."}
-            {!isPending && isEditing && "Save Changes"}
-            {!isPending && !isEditing && "Save as Draft"}
-          </Button>
           <Button
             type="button"
             onClick={() => handleSubmit("published")}
             disabled={isPending}
-            className="flex-1 bg-[#2D7597] text-white hover:bg-[#255e78]"
+            className="flex-1 bg-[#297496] hover:bg-[#225f7a]"
           >
             {isPending && isEditing && "Updating..."}
             {isPending && !isEditing && "Publishing..."}
             {!isPending && isEditing && "Update & Publish"}
             {!isPending && !isEditing && "Publish Voyage"}
           </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleSubmit("draft")}
+            disabled={isPending}
+            className="flex-1 border-[#297496] text-[#297496] hover:bg-[#297496]/10"
+          >
+            {isPending && "Saving..."}
+            {!isPending && isEditing && "Save Changes"}
+            {!isPending && !isEditing && "Save as Draft"}
+          </Button>
         </div>
       </div>
 
+      {/* Right: Live tree preview */}
       <div className="w-full lg:w-1/2">
         <div className="sticky top-8">
-          <SectionLabel>Live Preview</SectionLabel>
+          <h3 className="mb-3 text-sm font-medium text-slate-700 dark:text-slate-300">
+            Live Preview
+          </h3>
           <VoyageTreeMap nodes={treeNodes} />
         </div>
       </div>

--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import { useState, useTransition, useMemo, useCallback } from "react";
+import {
+  useState,
+  useTransition,
+  useMemo,
+  useCallback,
+  useEffect,
+} from "react";
+import {
+  VoyageFormTour,
+  VOYAGE_TOUR_KEY,
+} from "@/components/voyages/voyage-form-tour";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -108,6 +118,17 @@ export function VoyageForm({
     voyage?.isSequential ?? false,
   );
   const [error, setError] = useState("");
+
+  // Spotlight tour
+  const [runTour, setRunTour] = useState(false);
+  useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      !localStorage.getItem(VOYAGE_TOUR_KEY)
+    ) {
+      setRunTour(true);
+    }
+  }, []);
 
   const availablePlaylists = useMemo(
     () =>
@@ -432,10 +453,24 @@ export function VoyageForm({
 
   return (
     <div className="flex w-full flex-col gap-8 lg:flex-row">
+      <VoyageFormTour run={runTour} setRun={setRunTour} />
       {/* Left: Form panel */}
       <div className="flex w-full flex-col gap-6 lg:w-1/2">
+        {/* Tour trigger */}
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={() => {
+              localStorage.removeItem(VOYAGE_TOUR_KEY);
+              setRunTour(true);
+            }}
+            className="text-xs text-slate-400 transition-colors hover:text-[#297496]"
+          >
+            Take a tour
+          </button>
+        </div>
         {/* Name */}
-        <div className="flex flex-col gap-2">
+        <div id="tour-voyage-name" className="flex flex-col gap-2">
           <Label htmlFor="voyage-name">
             Voyage Name <span className="text-red-500">*</span>
           </Label>
@@ -466,6 +501,7 @@ export function VoyageForm({
           <Label>Islands</Label>
 
           {/* Node type selector */}
+          <div id="tour-node-type-tabs"></div>
           <div className="flex overflow-hidden rounded-md border border-slate-200 dark:border-slate-600">
             <button
               type="button"
@@ -641,6 +677,7 @@ export function VoyageForm({
           )}
 
           {/* Selected islands list */}
+          <div id="tour-node-list"></div>
           {sortedForDisplay.length > 0 ? (
             <div className="space-y-1">
               {sortedForDisplay.map((node) => {
@@ -834,6 +871,7 @@ export function VoyageForm({
         )}
 
         {/* Sequential progression toggle */}
+        <div id="tour-sequential-toggle"></div>
         <label className="flex items-center gap-3 rounded-lg border border-slate-200 px-4 py-3 dark:border-slate-700">
           <input
             type="checkbox"
@@ -853,6 +891,7 @@ export function VoyageForm({
         </label>
 
         {/* Action buttons */}
+        <div id="tour-publish-buttons"></div>
         <div className="flex gap-3">
           <Button
             type="button"
@@ -880,7 +919,7 @@ export function VoyageForm({
       </div>
 
       {/* Right: Live tree preview */}
-      <div className="w-full lg:w-1/2">
+      <div id="tour-preview" className="w-full lg:w-1/2">
         <div className="sticky top-8">
           <h3 className="mb-3 text-sm font-medium text-slate-700 dark:text-slate-300">
             Live Preview

--- a/frontend/components/voyages/voyage-tree-island.tsx
+++ b/frontend/components/voyages/voyage-tree-island.tsx
@@ -7,6 +7,11 @@ export const ISLAND_SVG_DIMENSIONS = {
   branch: { width: 160, height: 145 },
 } as const;
 
+const PUDDLE_OUTER_PATH =
+  "M28 138 C30 132 42 126 62 124 C72 123 78 120 90 122 C102 124 108 121 120 122 C140 124 158 128 168 134 C174 138 172 146 160 150 C148 154 132 156 116 157 C100 158 82 158 66 156 C48 154 34 148 28 142 Z";
+const PUDDLE_INNER_PATH =
+  "M42 139 C44 134 56 130 72 128 C82 127 90 126 100 127 C112 128 122 126 134 128 C148 130 156 134 156 139 C156 144 146 148 132 150 C118 152 98 152 82 151 C62 150 46 146 42 142 Z";
+
 interface VoyageTreeIslandProps {
   label: string;
   slug?: string;
@@ -39,7 +44,6 @@ function IslandSvg({
   const w = base.width * scale;
   const h = base.height * scale;
 
-  // Droplet node — placeholder (unclaimed): dashed gray outline island with "?" icon
   if (nodeType === "droplet" && claimStatus === "unclaimed") {
     return (
       <svg
@@ -49,60 +53,53 @@ function IslandSvg({
         fill="none"
         className="block"
       >
-        {/* Dashed water ring */}
-        <ellipse
-          cx="100"
-          cy="140"
-          rx="74"
-          ry="21"
+        {/* Three water drops above puddle */}
+        <path
+          d="M100 56 C100 56 94 66 94 71 C94 74.3 96.7 77 100 77 C103.3 77 106 74.3 106 71 C106 66 100 56 100 56Z"
           stroke="#94a3b8"
-          strokeWidth="2"
-          strokeDasharray="6 4"
+          strokeWidth="3"
           fill="none"
-          opacity={0.5}
+          opacity={0.4}
         />
-        {/* Dashed island outline */}
-        <ellipse
-          cx="100"
-          cy="120"
-          rx="58"
-          ry="24"
+        <path
+          d="M78 76 C78 76 73 84 73 88 C73 90.8 75.2 93 78 93 C80.8 93 83 90.8 83 88 C83 84 78 76 78 76Z"
           stroke="#94a3b8"
           strokeWidth="2.5"
-          strokeDasharray="8 5"
-          fill="#f1f5f9"
-          opacity={0.8}
+          fill="none"
+          opacity={0.35}
         />
-        {/* "?" icon */}
-        <text
-          x="100"
-          y="108"
-          textAnchor="middle"
-          dominantBaseline="middle"
-          fontSize="28"
-          fontWeight="bold"
-          fill="#94a3b8"
-        >
-          ?
-        </text>
-        {/* Available glow */}
+        <path
+          d="M122 76 C122 76 117 84 117 88 C117 90.8 119.2 93 122 93 C124.8 93 127 90.8 127 88 C127 84 122 76 122 76Z"
+          stroke="#94a3b8"
+          strokeWidth="2.5"
+          fill="none"
+          opacity={0.35}
+        />
+        {/* Puddle — dashed outline */}
+        <path
+          d={PUDDLE_OUTER_PATH}
+          stroke="#94a3b8"
+          strokeWidth="3"
+          strokeDasharray="8 5"
+          fill="none"
+          opacity={0.35}
+        />
+        {/* Inner puddle fill */}
+        <path d={PUDDLE_INNER_PATH} fill="#e2e8f0" opacity={0.4} />
         {status === "available" && (
-          <ellipse
-            cx="100"
-            cy="120"
-            rx="70"
-            ry="30"
+          <path
+            d={PUDDLE_OUTER_PATH}
             stroke="#60a5fa"
             strokeWidth="2.5"
             fill="none"
-            opacity={0.35}
+            opacity={0.25}
           />
         )}
       </svg>
     );
   }
 
-  // Droplet node — claimed (in progress): teal island, partially colored, pencil icon
+  // Claimed (in progress): just an orange dashed ring — placeholder for rethinking
   if (nodeType === "droplet" && claimStatus === "claimed") {
     return (
       <svg
@@ -112,74 +109,20 @@ function IslandSvg({
         fill="none"
         className="block"
       >
-        {/* Ocean water ring */}
-        <ellipse
-          cx="100"
-          cy="140"
-          rx="74"
-          ry="21"
-          fill="#0e7490"
-          opacity={0.2}
-        />
-        {/* Sand ring */}
-        <ellipse cx="100" cy="124" rx="66" ry="28" fill="#e0f2fe" />
-        {/* Teal island surface — half filled to show "in progress" */}
-        <ellipse
-          cx="100"
-          cy="120"
-          rx="58"
-          ry="24"
-          fill="#0e7490"
-          opacity={0.35}
-        />
-        <ellipse
-          cx="100"
-          cy="120"
-          rx="58"
-          ry="24"
-          fill="none"
-          stroke="#0e7490"
-          strokeWidth="2"
-        />
-        {/* Pencil icon */}
+        {/* Orange dashed ring */}
         <path
-          d="M92 106 L104 94 L112 102 L100 114 Z"
-          fill="#0e7490"
-          opacity={0.85}
+          d={PUDDLE_OUTER_PATH}
+          stroke="#f59e0b"
+          strokeWidth="3"
+          strokeDasharray="10 6"
+          fill="none"
+          opacity={0.5}
         />
-        <path d="M104 94 L108 90 L116 98 L112 102 Z" fill="#0369a1" />
-        <path d="M92 106 L90 112 L96 110 Z" fill="#0e7490" opacity={0.7} />
-        {/* Available glow */}
-        {status === "available" && (
-          <ellipse
-            cx="100"
-            cy="120"
-            rx="70"
-            ry="30"
-            stroke="#60a5fa"
-            strokeWidth="2.5"
-            fill="none"
-            opacity={0.35}
-          />
-        )}
-        {/* Completed ring */}
-        {status === "completed" && (
-          <ellipse
-            cx="100"
-            cy="120"
-            rx="70"
-            ry="30"
-            stroke="#22c55e"
-            strokeWidth="2.5"
-            fill="none"
-            opacity={0.35}
-          />
-        )}
       </svg>
     );
   }
 
-  // Droplet node — published (authored or with published droplet): teal rock/boulder island
+  // Droplet node — published: full teal spill with water drop
   if (nodeType === "droplet") {
     return (
       <svg
@@ -191,98 +134,82 @@ function IslandSvg({
       >
         {isLocked ? (
           <>
-            {/* Water shadow */}
-            <ellipse
-              cx="100"
-              cy="140"
-              rx="60"
-              ry="16"
-              fill="#94a3b8"
-              opacity={0.15}
-            />
-            {/* Rock — locked */}
+            {/* Locked spill — gray */}
+            <path d={PUDDLE_INNER_PATH} fill="#94a3b8" opacity={0.15} />
             <path
-              d="M55 125 Q52 138 58 144 Q75 154 100 155 Q125 154 142 144 Q148 138 145 125 Z"
-              fill="#4a5568"
+              d="M65 132 C75 126 95 124 115 126 C130 128 142 132 145 136"
+              stroke="#94a3b8"
+              strokeWidth="1"
+              fill="none"
+              opacity={0.1}
             />
-            <ellipse cx="100" cy="124" rx="46" ry="20" fill="#64748b" />
-            <ellipse cx="100" cy="122" rx="40" ry="16" fill="#718096" />
           </>
         ) : (
           <>
-            {/* Ocean water ring */}
-            <ellipse
-              cx="100"
-              cy="140"
-              rx="70"
-              ry="20"
-              fill="#0e7490"
-              opacity={0.25}
+            {/* Outer spill glow */}
+            <path d={PUDDLE_OUTER_PATH} fill="#0e7490" opacity={0.08} />
+            {/* Main spill */}
+            <path d={PUDDLE_INNER_PATH} fill="#cffafe" />
+            <path d={PUDDLE_INNER_PATH} fill="#0e7490" opacity={0.3} />
+            {/* Organic ripple lines */}
+            <path
+              d="M60 134 C72 126 92 122 112 124 C132 126 148 132 150 138"
+              stroke="#0e7490"
+              strokeWidth="1.5"
+              fill="none"
+              opacity={0.3}
             />
-            <ellipse
-              cx="100"
-              cy="138"
-              rx="62"
-              ry="17"
-              fill="#0e7490"
+            <path
+              d="M74 136 C84 130 102 128 120 130 C134 132 142 136 140 139"
+              stroke="#0e7490"
+              strokeWidth="1"
+              fill="none"
+              opacity={0.2}
+            />
+            <path
+              d="M88 137 C96 134 108 133 118 135"
+              stroke="#0e7490"
+              strokeWidth="0.8"
+              fill="none"
               opacity={0.15}
             />
-            {/* Sand ring */}
-            <ellipse cx="100" cy="126" rx="54" ry="22" fill="#cffafe" />
-            {/* Teal boulder surface */}
-            <ellipse cx="100" cy="122" rx="46" ry="19" fill="#0e7490" />
-            {/* Highlight */}
-            <ellipse
-              cx="92"
-              cy="116"
-              rx="26"
-              ry="10"
-              fill="#22d3ee"
-              opacity={0.35}
+            {/* Water drop */}
+            <path
+              d="M100 82 C100 82 91 96 91 103 C91 108 95 112 100 112 C105 112 109 108 109 103 C109 96 100 82 100 82Z"
+              fill="#0e7490"
+              opacity={0.7}
             />
-            {/* Small rock details */}
-            <ellipse
-              cx="74"
-              cy="126"
-              rx="10"
-              ry="7"
-              fill="#0891b2"
+            {/* Drop highlight */}
+            <path
+              d="M96 105 C96 102 98 99 100 97"
+              stroke="#cffafe"
+              strokeWidth="1.5"
+              strokeLinecap="round"
               opacity={0.6}
             />
-            <ellipse
-              cx="128"
-              cy="124"
-              rx="8"
-              ry="6"
-              fill="#0891b2"
-              opacity={0.5}
-            />
+            {/* Splash dots */}
+            <circle cx="80" cy="122" r="2.5" fill="#0e7490" opacity={0.25} />
+            <circle cx="124" cy="124" r="2" fill="#0e7490" opacity={0.2} />
+            <circle cx="68" cy="140" r="1.5" fill="#0e7490" opacity={0.15} />
+            <circle cx="136" cy="142" r="1.5" fill="#0e7490" opacity={0.12} />
+            {status === "completed" && (
+              <path
+                d={PUDDLE_OUTER_PATH}
+                stroke="#22c55e"
+                strokeWidth="2.5"
+                fill="none"
+                opacity={0.4}
+              />
+            )}
           </>
         )}
-        {/* Available glow ring */}
-        {status === "available" && (
-          <ellipse
-            cx="100"
-            cy="122"
-            rx="62"
-            ry="26"
+        {status === "available" && !isLocked && (
+          <path
+            d={PUDDLE_OUTER_PATH}
             stroke="#60a5fa"
             strokeWidth="2.5"
             fill="none"
-            opacity={0.35}
-          />
-        )}
-        {/* Completed ring */}
-        {status === "completed" && (
-          <ellipse
-            cx="100"
-            cy="122"
-            rx="62"
-            ry="26"
-            stroke="#22c55e"
-            strokeWidth="2.5"
-            fill="none"
-            opacity={0.35}
+            opacity={0.3}
           />
         )}
       </svg>

--- a/frontend/components/voyages/voyage-tree-island.tsx
+++ b/frontend/components/voyages/voyage-tree-island.tsx
@@ -44,7 +44,12 @@ function IslandSvg({
   const w = base.width * scale;
   const h = base.height * scale;
 
-  if (nodeType === "droplet" && claimStatus === "unclaimed") {
+  // Unclaimed and claimed (in progress) both use the same puddle SVG
+  // The subtitle text differentiates them ("Become author!" vs "In Progress")
+  if (
+    nodeType === "droplet" &&
+    (claimStatus === "unclaimed" || claimStatus === "claimed")
+  ) {
     return (
       <svg
         width={w}
@@ -99,30 +104,7 @@ function IslandSvg({
     );
   }
 
-  // Claimed (in progress): just an orange dashed ring — placeholder for rethinking
-  if (nodeType === "droplet" && claimStatus === "claimed") {
-    return (
-      <svg
-        width={w}
-        height={h}
-        viewBox="0 0 200 180"
-        fill="none"
-        className="block"
-      >
-        {/* Orange dashed ring */}
-        <path
-          d={PUDDLE_OUTER_PATH}
-          stroke="#f59e0b"
-          strokeWidth="3"
-          strokeDasharray="10 6"
-          fill="none"
-          opacity={0.5}
-        />
-      </svg>
-    );
-  }
-
-  // Droplet node — published: full teal spill with water drop
+  // Droplet node — published: full teal puddle with water drop
   if (nodeType === "droplet") {
     return (
       <svg
@@ -147,28 +129,28 @@ function IslandSvg({
         ) : (
           <>
             {/* Outer spill glow */}
-            <path d={PUDDLE_OUTER_PATH} fill="#0e7490" opacity={0.08} />
+            <path d={PUDDLE_OUTER_PATH} fill="#297496" opacity={0.08} />
             {/* Main spill */}
             <path d={PUDDLE_INNER_PATH} fill="#cffafe" />
-            <path d={PUDDLE_INNER_PATH} fill="#0e7490" opacity={0.3} />
+            <path d={PUDDLE_INNER_PATH} fill="#297496" opacity={0.3} />
             {/* Organic ripple lines */}
             <path
               d="M60 134 C72 126 92 122 112 124 C132 126 148 132 150 138"
-              stroke="#0e7490"
+              stroke="#297496"
               strokeWidth="1.5"
               fill="none"
               opacity={0.3}
             />
             <path
               d="M74 136 C84 130 102 128 120 130 C134 132 142 136 140 139"
-              stroke="#0e7490"
+              stroke="#297496"
               strokeWidth="1"
               fill="none"
               opacity={0.2}
             />
             <path
               d="M88 137 C96 134 108 133 118 135"
-              stroke="#0e7490"
+              stroke="#297496"
               strokeWidth="0.8"
               fill="none"
               opacity={0.15}
@@ -176,7 +158,7 @@ function IslandSvg({
             {/* Water drop */}
             <path
               d="M100 82 C100 82 91 96 91 103 C91 108 95 112 100 112 C105 112 109 108 109 103 C109 96 100 82 100 82Z"
-              fill="#0e7490"
+              fill="#297496"
               opacity={0.7}
             />
             {/* Drop highlight */}
@@ -188,10 +170,10 @@ function IslandSvg({
               opacity={0.6}
             />
             {/* Splash dots */}
-            <circle cx="80" cy="122" r="2.5" fill="#0e7490" opacity={0.25} />
-            <circle cx="124" cy="124" r="2" fill="#0e7490" opacity={0.2} />
-            <circle cx="68" cy="140" r="1.5" fill="#0e7490" opacity={0.15} />
-            <circle cx="136" cy="142" r="1.5" fill="#0e7490" opacity={0.12} />
+            <circle cx="80" cy="122" r="2.5" fill="#297496" opacity={0.25} />
+            <circle cx="124" cy="124" r="2" fill="#297496" opacity={0.2} />
+            <circle cx="68" cy="140" r="1.5" fill="#297496" opacity={0.15} />
+            <circle cx="136" cy="142" r="1.5" fill="#297496" opacity={0.12} />
             {status === "completed" && (
               <path
                 d={PUDDLE_OUTER_PATH}
@@ -582,21 +564,11 @@ export function VoyageTreeIsland({
   }
 
   // Subtitle color: teal for unclaimed/claimed droplet nodes
-  const subtitleColorClass = isDropletNode
-    ? isUnclaimed
+  const subtitleColorClass = isCompleted
+    ? "text-green-700 dark:text-green-400"
+    : isLocked
       ? "text-slate-400"
-      : isClaimed
-        ? "text-cyan-600 dark:text-cyan-400"
-        : isCompleted
-          ? "text-green-700 dark:text-green-400"
-          : isLocked
-            ? "text-slate-400"
-            : "text-cyan-700 dark:text-cyan-300"
-    : isCompleted
-      ? "text-green-700 dark:text-green-400"
-      : isLocked
-        ? "text-slate-400"
-        : "text-slate-600 dark:text-slate-300";
+      : "text-slate-600 dark:text-slate-300";
 
   const content = (
     <div
@@ -635,11 +607,11 @@ export function VoyageTreeIsland({
       {/* Label */}
       <div className="-mt-1 flex justify-center">
         <span
-          className={`rounded-lg px-3 py-1.5 font-bold shadow-sm ${
+          className={`rounded-lg border border-slate-100 px-3 py-1.5 font-bold shadow ${
             isMain
               ? "max-w-[200px] bg-white text-sm dark:bg-slate-800"
               : "max-w-[160px] bg-white text-xs dark:bg-slate-800"
-          } ${isLocked ? "opacity-60" : ""} text-slate-900 dark:text-slate-100`}
+          } ${isLocked ? "opacity-60" : ""} text-slate-900 dark:border-slate-700 dark:text-slate-100`}
         >
           {label}
         </span>

--- a/frontend/components/voyages/voyage-tree-island.tsx
+++ b/frontend/components/voyages/voyage-tree-island.tsx
@@ -16,22 +16,280 @@ interface VoyageTreeIslandProps {
   stepNumber?: number;
   /** Visual scale factor for responsive sizing (1 = default). */
   scale?: number;
+  href?: string;
+  nodeType?: "playlist" | "droplet";
+  claimStatus?: "unclaimed" | "claimed" | "authored" | null;
 }
 
 function IslandSvg({
   size,
   status,
   scale = 1,
+  nodeType = "playlist",
+  claimStatus,
 }: {
   size: "main" | "branch";
   status: string;
   scale?: number;
+  nodeType?: "playlist" | "droplet";
+  claimStatus?: "unclaimed" | "claimed" | "authored" | null;
 }) {
   const isLocked = status === "locked";
   const base = ISLAND_SVG_DIMENSIONS[size];
   const w = base.width * scale;
   const h = base.height * scale;
 
+  // Droplet node — placeholder (unclaimed): dashed gray outline island with "?" icon
+  if (nodeType === "droplet" && claimStatus === "unclaimed") {
+    return (
+      <svg
+        width={w}
+        height={h}
+        viewBox="0 0 200 180"
+        fill="none"
+        className="block"
+      >
+        {/* Dashed water ring */}
+        <ellipse
+          cx="100"
+          cy="140"
+          rx="74"
+          ry="21"
+          stroke="#94a3b8"
+          strokeWidth="2"
+          strokeDasharray="6 4"
+          fill="none"
+          opacity={0.5}
+        />
+        {/* Dashed island outline */}
+        <ellipse
+          cx="100"
+          cy="120"
+          rx="58"
+          ry="24"
+          stroke="#94a3b8"
+          strokeWidth="2.5"
+          strokeDasharray="8 5"
+          fill="#f1f5f9"
+          opacity={0.8}
+        />
+        {/* "?" icon */}
+        <text
+          x="100"
+          y="108"
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="28"
+          fontWeight="bold"
+          fill="#94a3b8"
+        >
+          ?
+        </text>
+        {/* Available glow */}
+        {status === "available" && (
+          <ellipse
+            cx="100"
+            cy="120"
+            rx="70"
+            ry="30"
+            stroke="#60a5fa"
+            strokeWidth="2.5"
+            fill="none"
+            opacity={0.35}
+          />
+        )}
+      </svg>
+    );
+  }
+
+  // Droplet node — claimed (in progress): teal island, partially colored, pencil icon
+  if (nodeType === "droplet" && claimStatus === "claimed") {
+    return (
+      <svg
+        width={w}
+        height={h}
+        viewBox="0 0 200 180"
+        fill="none"
+        className="block"
+      >
+        {/* Ocean water ring */}
+        <ellipse
+          cx="100"
+          cy="140"
+          rx="74"
+          ry="21"
+          fill="#0e7490"
+          opacity={0.2}
+        />
+        {/* Sand ring */}
+        <ellipse cx="100" cy="124" rx="66" ry="28" fill="#e0f2fe" />
+        {/* Teal island surface — half filled to show "in progress" */}
+        <ellipse
+          cx="100"
+          cy="120"
+          rx="58"
+          ry="24"
+          fill="#0e7490"
+          opacity={0.35}
+        />
+        <ellipse
+          cx="100"
+          cy="120"
+          rx="58"
+          ry="24"
+          fill="none"
+          stroke="#0e7490"
+          strokeWidth="2"
+        />
+        {/* Pencil icon */}
+        <path
+          d="M92 106 L104 94 L112 102 L100 114 Z"
+          fill="#0e7490"
+          opacity={0.85}
+        />
+        <path d="M104 94 L108 90 L116 98 L112 102 Z" fill="#0369a1" />
+        <path d="M92 106 L90 112 L96 110 Z" fill="#0e7490" opacity={0.7} />
+        {/* Available glow */}
+        {status === "available" && (
+          <ellipse
+            cx="100"
+            cy="120"
+            rx="70"
+            ry="30"
+            stroke="#60a5fa"
+            strokeWidth="2.5"
+            fill="none"
+            opacity={0.35}
+          />
+        )}
+        {/* Completed ring */}
+        {status === "completed" && (
+          <ellipse
+            cx="100"
+            cy="120"
+            rx="70"
+            ry="30"
+            stroke="#22c55e"
+            strokeWidth="2.5"
+            fill="none"
+            opacity={0.35}
+          />
+        )}
+      </svg>
+    );
+  }
+
+  // Droplet node — published (authored or with published droplet): teal rock/boulder island
+  if (nodeType === "droplet") {
+    return (
+      <svg
+        width={w}
+        height={h}
+        viewBox="0 0 200 180"
+        fill="none"
+        className="block"
+      >
+        {isLocked ? (
+          <>
+            {/* Water shadow */}
+            <ellipse
+              cx="100"
+              cy="140"
+              rx="60"
+              ry="16"
+              fill="#94a3b8"
+              opacity={0.15}
+            />
+            {/* Rock — locked */}
+            <path
+              d="M55 125 Q52 138 58 144 Q75 154 100 155 Q125 154 142 144 Q148 138 145 125 Z"
+              fill="#4a5568"
+            />
+            <ellipse cx="100" cy="124" rx="46" ry="20" fill="#64748b" />
+            <ellipse cx="100" cy="122" rx="40" ry="16" fill="#718096" />
+          </>
+        ) : (
+          <>
+            {/* Ocean water ring */}
+            <ellipse
+              cx="100"
+              cy="140"
+              rx="70"
+              ry="20"
+              fill="#0e7490"
+              opacity={0.25}
+            />
+            <ellipse
+              cx="100"
+              cy="138"
+              rx="62"
+              ry="17"
+              fill="#0e7490"
+              opacity={0.15}
+            />
+            {/* Sand ring */}
+            <ellipse cx="100" cy="126" rx="54" ry="22" fill="#cffafe" />
+            {/* Teal boulder surface */}
+            <ellipse cx="100" cy="122" rx="46" ry="19" fill="#0e7490" />
+            {/* Highlight */}
+            <ellipse
+              cx="92"
+              cy="116"
+              rx="26"
+              ry="10"
+              fill="#22d3ee"
+              opacity={0.35}
+            />
+            {/* Small rock details */}
+            <ellipse
+              cx="74"
+              cy="126"
+              rx="10"
+              ry="7"
+              fill="#0891b2"
+              opacity={0.6}
+            />
+            <ellipse
+              cx="128"
+              cy="124"
+              rx="8"
+              ry="6"
+              fill="#0891b2"
+              opacity={0.5}
+            />
+          </>
+        )}
+        {/* Available glow ring */}
+        {status === "available" && (
+          <ellipse
+            cx="100"
+            cy="122"
+            rx="62"
+            ry="26"
+            stroke="#60a5fa"
+            strokeWidth="2.5"
+            fill="none"
+            opacity={0.35}
+          />
+        )}
+        {/* Completed ring */}
+        {status === "completed" && (
+          <ellipse
+            cx="100"
+            cy="122"
+            rx="62"
+            ry="26"
+            stroke="#22c55e"
+            strokeWidth="2.5"
+            fill="none"
+            opacity={0.35}
+          />
+        )}
+      </svg>
+    );
+  }
+
+  // Default: playlist island (existing rendering)
   return (
     <svg
       width={w}
@@ -373,10 +631,45 @@ export function VoyageTreeIsland({
   status = "available",
   stepNumber,
   scale = 1,
+  href: hrefProp,
+  nodeType = "playlist",
+  claimStatus,
 }: VoyageTreeIslandProps) {
   const isMain = size === "main";
   const isLocked = status === "locked";
   const isCompleted = status === "completed";
+  const isDropletNode = nodeType === "droplet";
+  const isUnclaimed = claimStatus === "unclaimed";
+  const isClaimed = claimStatus === "claimed";
+
+  // Compute subtitle text based on node type and claim state
+  let subtitleText: string | null = null;
+  if (isDropletNode && isUnclaimed) {
+    subtitleText = "Become author!";
+  } else if (isDropletNode && isClaimed) {
+    subtitleText = "In Progress";
+  } else if (isDropletNode) {
+    subtitleText = "1 droplet";
+  } else if (dropletCount !== undefined) {
+    subtitleText = `${dropletCount} ${dropletCount === 1 ? "droplet" : "droplets"}`;
+  }
+
+  // Subtitle color: teal for unclaimed/claimed droplet nodes
+  const subtitleColorClass = isDropletNode
+    ? isUnclaimed
+      ? "text-slate-400"
+      : isClaimed
+        ? "text-cyan-600 dark:text-cyan-400"
+        : isCompleted
+          ? "text-green-700 dark:text-green-400"
+          : isLocked
+            ? "text-slate-400"
+            : "text-cyan-700 dark:text-cyan-300"
+    : isCompleted
+      ? "text-green-700 dark:text-green-400"
+      : isLocked
+        ? "text-slate-400"
+        : "text-slate-600 dark:text-slate-300";
 
   const content = (
     <div
@@ -388,7 +681,7 @@ export function VoyageTreeIsland({
         {/* Step number badge */}
         {stepNumber && (
           <div
-            className="absolute top-1/2 -left-10 z-10 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-xs font-bold text-white shadow-md"
+            className="absolute -top-1 left-0 z-10 flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold text-white shadow-md"
             style={{ backgroundColor: isLocked ? "#475569" : "#297496" }}
           >
             {stepNumber}
@@ -403,7 +696,13 @@ export function VoyageTreeIsland({
         {/* Lock icon */}
         {isLocked && <LockIcon />}
 
-        <IslandSvg size={size} status={status} scale={scale} />
+        <IslandSvg
+          size={size}
+          status={status}
+          scale={scale}
+          nodeType={nodeType}
+          claimStatus={claimStatus}
+        />
       </div>
 
       {/* Label */}
@@ -420,17 +719,11 @@ export function VoyageTreeIsland({
       </div>
 
       {/* Subtitle */}
-      {dropletCount !== undefined && (
+      {subtitleText !== null && (
         <div
-          className={`mt-1 text-center text-xs font-semibold ${
-            isCompleted
-              ? "text-green-700 dark:text-green-400"
-              : isLocked
-                ? "text-slate-400"
-                : "text-slate-600 dark:text-slate-300"
-          }`}
+          className={`mt-1 text-center text-xs font-semibold ${subtitleColorClass}`}
         >
-          {dropletCount} {dropletCount === 1 ? "droplet" : "droplets"}
+          {subtitleText}
         </div>
       )}
 
@@ -448,8 +741,12 @@ export function VoyageTreeIsland({
     </div>
   );
 
-  if (slug && !isLocked) {
-    return <Link href={`/p/${slug}`}>{content}</Link>;
+  // Resolve href: explicit prop takes priority, then derive from slug + nodeType
+  const resolvedHref =
+    hrefProp ?? (slug ? (isDropletNode ? `/d/${slug}` : `/p/${slug}`) : null);
+
+  if (resolvedHref && !isLocked) {
+    return <Link href={resolvedHref}>{content}</Link>;
   }
 
   return content;

--- a/frontend/components/voyages/voyage-tree-map.tsx
+++ b/frontend/components/voyages/voyage-tree-map.tsx
@@ -4,15 +4,18 @@ import { useRef, useEffect, useState, useMemo } from "react";
 import { VoyageTreeIsland, ISLAND_SVG_DIMENSIONS } from "./voyage-tree-island";
 
 export interface TreeNode {
-  id: number;
+  id: number | string;
   label: string;
   slug?: string;
+  href?: string;
   dropletCount?: number;
   isMainPath: boolean;
   branchType: "required" | "optional";
-  parentId?: number | null;
+  parentId?: number | string | null;
   orderIndex: number;
   status?: "completed" | "available" | "locked";
+  nodeType: "playlist" | "droplet";
+  claimStatus?: "unclaimed" | "claimed" | "authored" | null;
 }
 
 interface VoyageTreeMapProps {
@@ -63,7 +66,7 @@ function buildTree(nodes: TreeNode[]): LayoutNode[] {
     .filter((n) => n.isMainPath)
     .sort((a, b) => a.orderIndex - b.orderIndex);
 
-  const getBranches = (parentId: number) =>
+  const getBranches = (parentId: number | string) =>
     nodes
       .filter((n) => !n.isMainPath && n.parentId === parentId)
       .sort((a, b) => a.orderIndex - b.orderIndex);
@@ -118,11 +121,7 @@ function assignPositions(
 }
 
 /** Smooth bezier from bottom of parent to top of child, anchored to the
- *  rendered SVG geometry (not the layout box) so the line meets the island.
- *  A top offset prevents the line from overlapping the palm tree canopy. */
-const TREE_CANOPY_OFFSET = 45;
-const LABEL_BELOW_OFFSET = 40;
-
+ *  rendered SVG geometry (not the layout box) so the line meets the island. */
 function bezierPath(
   px: number,
   py: number,
@@ -131,8 +130,8 @@ function bezierPath(
   parentVisibleHeight: number,
   childVisibleHeight: number,
 ): string {
-  const sy = py + parentVisibleHeight / 2 + LABEL_BELOW_OFFSET;
-  const ey = cy - childVisibleHeight / 2 - TREE_CANOPY_OFFSET;
+  const sy = py + parentVisibleHeight / 2;
+  const ey = cy - childVisibleHeight / 2;
   const my = (sy + ey) / 2;
   return `M ${px} ${sy} C ${px} ${my}, ${cx} ${my}, ${cx} ${ey}`;
 }
@@ -293,11 +292,14 @@ export function VoyageTreeMap({ nodes }: VoyageTreeMapProps) {
                 <VoyageTreeIsland
                   label={layout.node.label}
                   slug={layout.node.slug}
+                  href={layout.node.href}
                   dropletCount={layout.node.dropletCount}
                   size={isMain ? "main" : "branch"}
                   status={layout.node.status}
                   stepNumber={isMain ? mainStep : undefined}
                   scale={svgScale}
+                  nodeType={layout.node.nodeType}
+                  claimStatus={layout.node.claimStatus}
                 />
               </div>
             );

--- a/frontend/components/voyages/voyage-tree-map.tsx
+++ b/frontend/components/voyages/voyage-tree-map.tsx
@@ -121,7 +121,12 @@ function assignPositions(
 }
 
 /** Smooth bezier from bottom of parent to top of child, anchored to the
- *  rendered SVG geometry (not the layout box) so the line meets the island. */
+ *  rendered SVG geometry (not the layout box) so the line meets the island.
+ *  A top offset prevents the line from overlapping the palm tree canopy.
+ *  A bottom offset pushes the start below the label + subtitle text. */
+const TREE_CANOPY_OFFSET = 45;
+const LABEL_BELOW_OFFSET = 55;
+
 function bezierPath(
   px: number,
   py: number,
@@ -130,8 +135,8 @@ function bezierPath(
   parentVisibleHeight: number,
   childVisibleHeight: number,
 ): string {
-  const sy = py + parentVisibleHeight / 2;
-  const ey = cy - childVisibleHeight / 2;
+  const sy = py + parentVisibleHeight / 2 + LABEL_BELOW_OFFSET;
+  const ey = cy - childVisibleHeight / 2 - TREE_CANOPY_OFFSET;
   const my = (sy + ey) / 2;
   return `M ${px} ${sy} C ${px} ${my}, ${cx} ${my}, ${cx} ${ey}`;
 }

--- a/frontend/hooks/use-admin-table-filters.ts
+++ b/frontend/hooks/use-admin-table-filters.ts
@@ -35,6 +35,8 @@ interface UseAdminTableFiltersReturn<T> {
   hasActiveFilters: boolean;
 }
 
+const ALWAYS_PASS = () => true;
+
 export function useAdminTableFilters<T>(
   config: UseAdminTableFiltersConfig<T>,
 ): UseAdminTableFiltersReturn<T> {
@@ -42,7 +44,7 @@ export function useAdminTableFilters<T>(
     items,
     searchFn,
     sortFn,
-    filterFn = () => true,
+    filterFn = ALWAYS_PASS,
     defaultSort = "name-asc",
     itemsPerPage = 8,
   } = config;

--- a/frontend/lib/actions.ts
+++ b/frontend/lib/actions.ts
@@ -16,6 +16,7 @@ import { Buffer } from "node:buffer";
 import { writeFile, mkdir, unlink } from "node:fs/promises";
 import path from "node:path";
 import { createAuthorizedUser } from "./requests/authorized-user";
+import { claimNodeForUser } from "./requests/voyage-enrollment";
 import { creationRequestSchema } from "./validations/creation-request";
 import { MAX_DATASET_FILE_SIZE } from "./validations/dataset";
 import qs from "qs";
@@ -24,8 +25,6 @@ import { CACHE_TAGS } from "./cache-tags";
 import Anthropic from "@anthropic-ai/sdk";
 import { getCurrentUser } from "@/lib/auth/session";
 import { checkRateLimit } from "@/lib/import/rate-limiter";
-import { requireRole } from "@/lib/auth/require-role";
-import { AuthorizedUserRoleTitle } from "@/lib/globals";
 
 const STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -171,16 +170,10 @@ export async function deleteImage(fileName: string) {
   }
 }
 
-export async function setTimeZone(zone: string) {
-  const auth = await requireRole([]);
-  if (!auth.ok) {
-    return { ok: false, error: auth.error };
-  }
-  const { user } = auth;
-
+export async function setTimeZone(zone: string, userId: number) {
   try {
     const response = await fetch(
-      `${STRAPI_API_URL}/api/authorized-users/${user.id}`,
+      `${STRAPI_API_URL}/api/authorized-users/${userId}`,
       {
         method: "PUT",
         headers: {
@@ -207,11 +200,6 @@ export async function setTimeZone(zone: string) {
 }
 
 export async function deleteReport(id: string) {
-  const auth = await requireRole([AuthorizedUserRoleTitle.SysAdmin]);
-  if (!auth.ok) {
-    return { ok: false, error: auth.error };
-  }
-
   const response = await fetch(`${STRAPI_API_URL}/api/reports/${id}`, {
     method: "DELETE",
     headers: {
@@ -440,9 +428,16 @@ export async function createCreationRequest(
   formData: z.infer<typeof creationRequestSchema>,
 ) {
   try {
+    // Map form field voyageNodeId to Strapi relation field voyageNode
+    const { voyageNodeId, ...rest } = formData;
+    const strapiData = {
+      ...rest,
+      ...(voyageNodeId ? { voyageNode: voyageNodeId } : {}),
+    };
+
     const response = await fetch(STRAPI_API_URL + "/api/creation-requests", {
       method: "POST",
-      body: JSON.stringify({ data: formData }),
+      body: JSON.stringify({ data: strapiData }),
       headers: {
         "Content-Type": "application/json",
         Authorization: "Bearer " + STRAPI_ACCESS_TOKEN,
@@ -565,6 +560,25 @@ export async function approveCreationRequest(
       }
     }
 
+    // Fetch the creation request to check for a linked voyageNode before deleting
+    const requestQuery = qs.stringify({
+      populate: { voyageNode: { fields: ["id"] } },
+    });
+    const requestResponse = await fetch(
+      `${STRAPI_API_URL}/api/creation-requests/${requestId}?${requestQuery}`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}`,
+        },
+      },
+    );
+    const requestData = requestResponse.ok
+      ? await requestResponse.json()
+      : null;
+    const voyageNodeId: number | null =
+      requestData?.data?.attributes?.voyageNode?.data?.id ?? null;
+
     // Delete the creation request after approval
     const deleteResponse = await fetch(
       `${STRAPI_API_URL}/api/creation-requests/${requestId}`,
@@ -586,9 +600,23 @@ export async function approveCreationRequest(
       };
     }
 
+    // If the request was tied to a voyage node, auto-claim it for the applicant
+    if (voyageNodeId !== null) {
+      try {
+        await claimNodeForUser(voyageNodeId, userId);
+      } catch (claimErr) {
+        // Claim failure should not prevent the role from being granted
+        console.error(
+          "Failed to auto-claim voyage node after approval:",
+          claimErr,
+        );
+      }
+    }
+
     revalidateTag(CACHE_TAGS.users);
     revalidateTag(CACHE_TAGS.creationRequests);
     revalidateTag(CACHE_TAGS.authors);
+    revalidateTag(CACHE_TAGS.voyages);
     return { ok: true, error: null, data: null };
   } catch (err) {
     console.error(err);
@@ -650,6 +678,14 @@ export async function fetchCreationRequests(): Promise<CreationRequest[]> {
         populate: {
           user: {
             fields: ["firstName", "lastName", "email", "id"],
+          },
+          voyageNode: {
+            fields: ["id", "label"],
+            populate: {
+              voyage: {
+                fields: ["name"],
+              },
+            },
           },
         },
         pagination: {

--- a/frontend/lib/actions.ts
+++ b/frontend/lib/actions.ts
@@ -17,6 +17,7 @@ import { writeFile, mkdir, unlink } from "node:fs/promises";
 import path from "node:path";
 import { createAuthorizedUser } from "./requests/authorized-user";
 import { claimNodeForUser } from "./requests/voyage-enrollment";
+import { requireRole } from "./auth/require-role";
 import { creationRequestSchema } from "./validations/creation-request";
 import { MAX_DATASET_FILE_SIZE } from "./validations/dataset";
 import qs from "qs";
@@ -170,10 +171,16 @@ export async function deleteImage(fileName: string) {
   }
 }
 
-export async function setTimeZone(zone: string, userId: number) {
+export async function setTimeZone(zone: string) {
+  const auth = await requireRole([]);
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+  const { user } = auth;
+
   try {
     const response = await fetch(
-      `${STRAPI_API_URL}/api/authorized-users/${userId}`,
+      `${STRAPI_API_URL}/api/authorized-users/${user.id}`,
       {
         method: "PUT",
         headers: {

--- a/frontend/lib/actions.ts
+++ b/frontend/lib/actions.ts
@@ -17,7 +17,6 @@ import { writeFile, mkdir, unlink } from "node:fs/promises";
 import path from "node:path";
 import { createAuthorizedUser } from "./requests/authorized-user";
 import { claimNodeForUser } from "./requests/voyage-enrollment";
-import { requireRole } from "./auth/require-role";
 import { creationRequestSchema } from "./validations/creation-request";
 import { MAX_DATASET_FILE_SIZE } from "./validations/dataset";
 import qs from "qs";
@@ -26,6 +25,8 @@ import { CACHE_TAGS } from "./cache-tags";
 import Anthropic from "@anthropic-ai/sdk";
 import { getCurrentUser } from "@/lib/auth/session";
 import { checkRateLimit } from "@/lib/import/rate-limiter";
+import { requireRole } from "@/lib/auth/require-role";
+import { AuthorizedUserRoleTitle } from "@/lib/globals";
 
 const STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -207,6 +208,11 @@ export async function setTimeZone(zone: string) {
 }
 
 export async function deleteReport(id: string) {
+  const auth = await requireRole([AuthorizedUserRoleTitle.SysAdmin]);
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
   const response = await fetch(`${STRAPI_API_URL}/api/reports/${id}`, {
     method: "DELETE",
     headers: {
@@ -612,7 +618,6 @@ export async function approveCreationRequest(
       try {
         await claimNodeForUser(voyageNodeId, userId);
       } catch (claimErr) {
-        // Claim failure should not prevent the role from being granted
         console.error(
           "Failed to auto-claim voyage node after approval:",
           claimErr,
@@ -688,11 +693,7 @@ export async function fetchCreationRequests(): Promise<CreationRequest[]> {
           },
           voyageNode: {
             fields: ["id", "label"],
-            populate: {
-              voyage: {
-                fields: ["name"],
-              },
-            },
+            populate: { voyage: { fields: ["name"] } },
           },
         },
         pagination: {

--- a/frontend/lib/requests/voyage-enrollment.ts
+++ b/frontend/lib/requests/voyage-enrollment.ts
@@ -88,6 +88,57 @@ export async function getVoyageEnrollmentsByUser(
 }
 
 /**
+ * Fetches voyage enrollments for multiple members filtered to specific voyages
+ * in a single paginated Strapi query. Used by the group progress grid.
+ */
+export async function getVoyageEnrollmentsForGroupMembers(
+  memberIds: number[],
+  voyageIds: number[],
+): Promise<VoyageEnrollment[]> {
+  if (memberIds.length === 0 || voyageIds.length === 0) return [];
+
+  const pageSize = 250;
+  let page = 1;
+  let allEnrollments: VoyageEnrollment[] = [];
+
+  while (true) {
+    const enrollmentsPage = await fetchAPI<VoyageEnrollment[]>(
+      "/voyage-enrollments",
+      {
+        urlParams: {
+          filters: {
+            $and: [
+              { authorizedUser: { id: { $in: memberIds } } },
+              { voyage: { id: { $in: voyageIds } } },
+            ],
+          },
+          populate: {
+            authorizedUser: { fields: ["id"] },
+            voyage: { fields: ["id"] },
+          },
+          fields: ["id", "completionPercentage"],
+          pagination: { page, pageSize },
+        },
+        next: {
+          tags: [
+            ...memberIds.map((id) => CACHE_TAGS.voyageEnrollments(id)),
+            CACHE_TAGS.allVoyageEnrollments,
+          ],
+          revalidate: 900,
+        },
+      },
+    );
+
+    if (!enrollmentsPage || enrollmentsPage.length === 0) break;
+    allEnrollments = allEnrollments.concat(enrollmentsPage);
+    if (enrollmentsPage.length < pageSize) break;
+    page++;
+  }
+
+  return allEnrollments;
+}
+
+/**
  * Enrolls the current user in a voyage.
  * Idempotent: if already enrolled, returns the existing enrollment.
  * Draft voyages are only accessible to SysAdmin and Faculty.

--- a/frontend/lib/requests/voyage-enrollment.ts
+++ b/frontend/lib/requests/voyage-enrollment.ts
@@ -864,6 +864,11 @@ export async function claimNodeForUser(
 
   for (let attempt = 0; attempt < 5; attempt++) {
     finalName = attempt === 0 ? baseName : `${baseName} (${attempt})`;
+    const slug = finalName
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
     const createRes = await fetch(`${STRAPI_API_URL}/api/droplets`, {
       method: "POST",
       headers: {
@@ -873,12 +878,15 @@ export async function claimNodeForUser(
       body: JSON.stringify({
         data: {
           name: finalName,
+          slug,
           type: "knowledge",
           focusArea: "technical",
           difficulty: "beginner",
           status: "draft",
           isHidden: true,
-          learningObjectives: [{ objective: "TBD" }],
+          learningObjectives: [
+            { __component: "droplets.learning-objective", objective: "TBD" },
+          ],
           authorized_users: { connect: [userId] },
         },
       }),

--- a/frontend/lib/requests/voyage-enrollment.ts
+++ b/frontend/lib/requests/voyage-enrollment.ts
@@ -2,12 +2,12 @@
 
 import { VoyageEnrollment, VoyageNode, VoyageNodeCompletion } from "@/types";
 import { fetchAPI, flattenAttributes } from "@/lib/utils";
+import { AuthorizedUserRoleTitle } from "@/lib/globals";
 import { revalidateTag } from "next/cache";
 import { CACHE_TAGS } from "../cache-tags";
 import { getCurrentUser } from "@/lib/auth/session";
 import { getCachedUser } from "./cached";
 import { requireRole } from "@/lib/auth/require-role";
-import { AuthorizedUserRoleTitle } from "@/lib/globals";
 
 const STRAPI_API_URL =
   process.env.NEXT_PUBLIC_STRAPI_API_URL || "http://localhost:1337";
@@ -88,87 +88,27 @@ export async function getVoyageEnrollmentsByUser(
 }
 
 /**
- * Fetches voyage enrollments for multiple members filtered to specific voyages
- * in a single paginated Strapi query. Used by the group progress grid.
- */
-export async function getVoyageEnrollmentsForGroupMembers(
-  memberIds: number[],
-  voyageIds: number[],
-): Promise<VoyageEnrollment[]> {
-  if (memberIds.length === 0 || voyageIds.length === 0) return [];
-
-  const pageSize = 250;
-  let page = 1;
-  let allEnrollments: VoyageEnrollment[] = [];
-
-  while (true) {
-    const enrollmentsPage = await fetchAPI<VoyageEnrollment[]>(
-      "/voyage-enrollments",
-      {
-        urlParams: {
-          filters: {
-            $and: [
-              { authorizedUser: { id: { $in: memberIds } } },
-              { voyage: { id: { $in: voyageIds } } },
-            ],
-          },
-          populate: {
-            authorizedUser: { fields: ["id"] },
-            voyage: { fields: ["id"] },
-          },
-          fields: ["id", "completionPercentage"],
-          pagination: { page, pageSize },
-        },
-        next: {
-          tags: [
-            ...memberIds.map((id) => CACHE_TAGS.voyageEnrollments(id)),
-            CACHE_TAGS.allVoyageEnrollments,
-          ],
-          revalidate: 900,
-        },
-      },
-    );
-
-    if (!enrollmentsPage || enrollmentsPage.length === 0) break;
-    allEnrollments = allEnrollments.concat(enrollmentsPage);
-    if (enrollmentsPage.length < pageSize) break;
-    page++;
-  }
-
-  return allEnrollments;
-}
-
-/**
  * Enrolls the current user in a voyage.
  * Idempotent: if already enrolled, returns the existing enrollment.
- * Blocks enrollment in draft voyages unless the caller is SysAdmin or Faculty.
+ * Draft voyages are only accessible to SysAdmin and Faculty.
  */
 export async function enrollInVoyage(voyageId: number) {
   try {
-    // Step 1: Authenticate the caller and capture their roles.
     const gate = await requireRole([]);
     if (!gate.ok) {
       return { ok: false, error: gate.error, data: null };
     }
-    const { user: gateUser } = gate;
 
-    const authorizedUser = await getCachedUser(gateUser.email);
+    const authorizedUser = await getCachedUser(gate.user.email);
     if (!authorizedUser?.id) {
       return { ok: false, error: "Authorized user not found", data: null };
     }
 
-    // Step 2: Verify the voyage is published before allowing enrollment.
-    // Required because we hit Strapi with a service token (see
-    // docs/agent/learnings/strapi-service-token-trust-boundary.md), so the
-    // backend can't enforce this — the Next.js layer is the trust boundary.
-    const voyage = await fetchAPI<{ status?: string } | null>(
+    // Draft guard: fetch voyage status before enrolling
+    const voyage = await fetchAPI<{ id: number; status: string } | null>(
       `/voyages/${voyageId}`,
       {
-        urlParams: {
-          fields: ["id", "status"],
-        },
-        // Fresh fetch — don't serve a stale "published" from cache if
-        // the voyage was just unpublished.
+        urlParams: { fields: ["id", "status"] },
         cache: "no-store",
       },
     );
@@ -177,16 +117,12 @@ export async function enrollInVoyage(voyageId: number) {
       return { ok: false, error: "not_found", data: null };
     }
 
-    if (voyage.status !== "published") {
-      const isStaff = gateUser.roles.some(
-        (r) =>
-          r === AuthorizedUserRoleTitle.SysAdmin ||
-          r === AuthorizedUserRoleTitle.Faculty,
-      );
-      if (!isStaff) {
-        return { ok: false, error: "forbidden", data: null };
-      }
-      // Staff can enroll in drafts for testing purposes
+    const isStaff =
+      gate.user.roles.includes(AuthorizedUserRoleTitle.SysAdmin) ||
+      gate.user.roles.includes(AuthorizedUserRoleTitle.Faculty);
+
+    if (voyage.status !== "published" && !isStaff) {
+      return { ok: false, error: "forbidden", data: null };
     }
 
     const existing = await getVoyageEnrollment(authorizedUser.id, voyageId);
@@ -548,7 +484,8 @@ export async function markVoyageNodeComplete(
       const allNodes = await fetchAPI<VoyageNode[]>("/voyage-nodes", {
         urlParams: {
           filters: { voyage: { id: { $eq: voyageId } } },
-          fields: ["id", "branchType"],
+          fields: ["id", "branchType", "nodeType"],
+          populate: { droplet: { fields: ["id", "status"] } },
           pagination: { pageSize: 250, page: 1 },
         },
         next: {
@@ -638,9 +575,10 @@ export async function markVoyageNodeComplete(
 }
 
 /**
- * Called when a playlist is fully completed.
- * Checks if this playlist belongs to a voyage node for a voyage the user is enrolled in.
- * If so, marks that node as complete (if not already done).
+ * Called when a droplet is fully completed.
+ * Checks if this droplet belongs to a playlist that is part of a voyage node,
+ * and also checks if this droplet is directly linked to a voyage node.
+ * If so, marks those nodes as complete (if not already done).
  * Errors are swallowed so they don't break the caller.
  */
 export async function checkAndCompleteVoyageNode(
@@ -658,14 +596,96 @@ export async function checkAndCompleteVoyageNode(
       next: { tags: [CACHE_TAGS.voyages], revalidate: 900 },
     });
 
-    if (playlists.length === 0) return;
-
     // Check each playlist for voyage node connections
     for (const playlist of playlists) {
       await checkPlaylistVoyageNode(playlist.id, userId);
     }
   } catch {
     // Errors must never surface to the caller
+  }
+
+  // Also check if this droplet is directly linked to a voyage node
+  await checkDropletVoyageNode(dropletId, userId);
+}
+
+export async function checkDropletVoyageNode(
+  dropletId: number,
+  userId: number,
+): Promise<void> {
+  try {
+    const voyageNodes = await fetchAPI<VoyageNode[]>("/voyage-nodes", {
+      urlParams: {
+        filters: {
+          $and: [
+            { nodeType: { $eq: "droplet" } },
+            { droplet: { id: { $eq: dropletId } } },
+          ],
+        },
+        fields: ["id"],
+        populate: { voyage: { fields: ["id"] } },
+        pagination: { pageSize: 50, page: 1 },
+      },
+      next: {
+        tags: [CACHE_TAGS.voyageEnrollments(userId)],
+        revalidate: 900,
+      },
+    });
+
+    if (voyageNodes.length === 0) return;
+
+    for (const node of voyageNodes) {
+      const voyageId = node.voyage?.id;
+      if (!voyageId) continue;
+
+      const enrollments = await fetchAPI<VoyageEnrollment[]>(
+        "/voyage-enrollments",
+        {
+          urlParams: {
+            filters: {
+              $and: [
+                { authorizedUser: { id: { $eq: userId } } },
+                { voyage: { id: { $eq: voyageId } } },
+              ],
+            },
+            fields: ["id"],
+            pagination: { pageSize: 1, page: 1 },
+          },
+          next: {
+            tags: [CACHE_TAGS.voyageEnrollments(userId)],
+            revalidate: 900,
+          },
+        },
+      );
+
+      const enrollment = enrollments[0];
+      if (!enrollment) continue;
+
+      const existingCompletions = await fetchAPI<VoyageNodeCompletion[]>(
+        "/voyage-node-completions",
+        {
+          urlParams: {
+            filters: {
+              $and: [
+                { authorizedUser: { id: { $eq: userId } } },
+                { voyageNode: { id: { $eq: node.id } } },
+              ],
+            },
+            fields: ["id"],
+            pagination: { pageSize: 1, page: 1 },
+          },
+          next: {
+            tags: [CACHE_TAGS.voyageEnrollments(userId)],
+            revalidate: 900,
+          },
+        },
+      );
+
+      if (existingCompletions.length > 0) continue;
+
+      await markVoyageNodeComplete(node.id, enrollment.id, userId);
+    }
+  } catch (err) {
+    console.error("Error in checkDropletVoyageNode:", err);
   }
 }
 
@@ -787,4 +807,185 @@ async function checkPlaylistVoyageNode(
     console.error("Error in checkPlaylistVoyageNode:", err);
     // Swallow error so playlist completion is not broken
   }
+}
+
+export async function claimNodeForUser(
+  voyageNodeId: number,
+  userId: number,
+): Promise<{
+  ok: boolean;
+  error: string | null;
+  data: { dropletSlug: string } | null;
+}> {
+  // Auth: verify the caller is either the target user or a faculty/admin
+  const sessionUser = await getCurrentUser();
+  if (!sessionUser?.email) {
+    return { ok: false, error: "Not authenticated", data: null };
+  }
+  const callerUser = await getCachedUser(sessionUser.email);
+  if (!callerUser) {
+    return { ok: false, error: "User not found", data: null };
+  }
+  const callerRoles = sessionUser.roles as AuthorizedUserRoleTitle[];
+  const isSelf = callerUser.id === userId;
+  const isPrivileged =
+    callerRoles?.includes(AuthorizedUserRoleTitle.SysAdmin) ||
+    callerRoles?.includes(AuthorizedUserRoleTitle.Faculty);
+  if (!isSelf && !isPrivileged) {
+    return {
+      ok: false,
+      error: "Not authorized to claim for this user",
+      data: null,
+    };
+  }
+
+  const nodes = await fetchAPI<VoyageNode[]>("/voyage-nodes", {
+    urlParams: {
+      filters: { id: { $eq: voyageNodeId } },
+      fields: ["id", "label", "nodeType", "claimStatus"],
+      populate: { voyage: { fields: ["name"] } },
+      pagination: { pageSize: 1, page: 1 },
+    },
+    next: { tags: [CACHE_TAGS.voyages], revalidate: 0 },
+  });
+
+  const node = nodes[0];
+  if (!node) return { ok: false, error: "Voyage node not found", data: null };
+  if (node.nodeType !== "droplet")
+    return { ok: false, error: "Node is not a droplet node", data: null };
+  if (node.claimStatus !== "unclaimed")
+    return { ok: false, error: "Node is not unclaimed", data: null };
+
+  const voyageName = node.voyage?.name ?? "Voyage";
+  const baseName = `${node.label} — ${voyageName}`;
+
+  let dropletData: any = null;
+  let finalName = baseName;
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    finalName = attempt === 0 ? baseName : `${baseName} (${attempt})`;
+    const createRes = await fetch(`${STRAPI_API_URL}/api/droplets`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}`,
+      },
+      body: JSON.stringify({
+        data: {
+          name: finalName,
+          type: "knowledge",
+          focusArea: "technical",
+          difficulty: "beginner",
+          status: "draft",
+          isHidden: true,
+          learningObjectives: [{ objective: "TBD" }],
+          authorized_users: { connect: [userId] },
+        },
+      }),
+    });
+
+    if (createRes.ok) {
+      const raw = await createRes.json();
+      dropletData = flattenAttributes(raw.data);
+      break;
+    }
+    if (createRes.status !== 400) {
+      return { ok: false, error: "Failed to create droplet", data: null };
+    }
+  }
+
+  if (!dropletData)
+    return {
+      ok: false,
+      error: "Failed to create droplet after retries",
+      data: null,
+    };
+
+  await fetch(`${STRAPI_API_URL}/api/voyage-nodes/${voyageNodeId}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}`,
+    },
+    body: JSON.stringify({
+      data: {
+        droplet: dropletData.id,
+        claimedBy: userId,
+        claimStatus: "claimed",
+      },
+    }),
+  });
+
+  revalidateTag(CACHE_TAGS.voyages);
+  revalidateTag(CACHE_TAGS.droplets);
+
+  return { ok: true, error: null, data: { dropletSlug: dropletData.slug } };
+}
+
+export async function claimVoyageDropletNode(voyageNodeId: number) {
+  const sessionUser = await getCurrentUser();
+  if (!sessionUser?.email) return { ok: false, error: "Not authenticated" };
+
+  const user = await getCachedUser(sessionUser.email);
+  if (!user) return { ok: false, error: "User not found" };
+
+  const roles = sessionUser.roles as AuthorizedUserRoleTitle[];
+  const hasRole = roles?.some((r) =>
+    [
+      AuthorizedUserRoleTitle.ContentCreator,
+      AuthorizedUserRoleTitle.ContentEditor,
+      AuthorizedUserRoleTitle.Faculty,
+      AuthorizedUserRoleTitle.SysAdmin,
+    ].includes(r),
+  );
+  if (!hasRole) return { ok: false, error: "Content Creator role required" };
+
+  return claimNodeForUser(voyageNodeId, user.id);
+}
+
+export async function unclaimVoyageDropletNode(voyageNodeId: number) {
+  const sessionUser = await getCurrentUser();
+  if (!sessionUser?.email) return { ok: false, error: "Not authenticated" };
+
+  const user = await getCachedUser(sessionUser.email);
+  if (!user) return { ok: false, error: "User not found" };
+
+  const nodeData = await fetchAPI<VoyageNode[]>("/voyage-nodes", {
+    urlParams: {
+      filters: { id: { $eq: voyageNodeId } },
+      fields: ["id", "claimStatus"],
+      populate: { claimedBy: { fields: ["id"] } },
+      pagination: { pageSize: 1, page: 1 },
+    },
+    next: { tags: [CACHE_TAGS.voyages], revalidate: 0 },
+  });
+
+  const node = nodeData[0];
+  if (!node) return { ok: false, error: "Node not found" };
+  if (node.claimStatus !== "claimed")
+    return { ok: false, error: "Node is not claimed" };
+
+  const roles = sessionUser.roles as AuthorizedUserRoleTitle[];
+  const isClaimedByUser = node.claimedBy?.id === user.id;
+  const isPrivileged =
+    roles?.includes(AuthorizedUserRoleTitle.SysAdmin) ||
+    roles?.includes(AuthorizedUserRoleTitle.Faculty);
+  if (!isClaimedByUser && !isPrivileged)
+    return { ok: false, error: "Not authorized" };
+
+  await fetch(`${STRAPI_API_URL}/api/voyage-nodes/${voyageNodeId}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}`,
+    },
+    body: JSON.stringify({
+      data: { droplet: null, claimedBy: null, claimStatus: "unclaimed" },
+    }),
+  });
+
+  revalidateTag(CACHE_TAGS.voyages);
+  revalidateTag(CACHE_TAGS.droplets);
+
+  return { ok: true, error: null };
 }

--- a/frontend/lib/requests/voyage.ts
+++ b/frontend/lib/requests/voyage.ts
@@ -5,8 +5,8 @@ import { Voyage } from "@/types";
 import { fetchAPI, flattenAttributes } from "@/lib/utils";
 import { revalidateTag } from "next/cache";
 import { CACHE_TAGS } from "../cache-tags";
-import { AuthorizedUserRoleTitle } from "@/lib/globals";
 import { requireRole } from "@/lib/auth/require-role";
+import { AuthorizedUserRoleTitle } from "@/lib/globals";
 import { VoyageTreeSchema } from "@/lib/validations/voyage";
 
 const NEXT_PUBLIC_STRAPI_API_URL =
@@ -54,11 +54,14 @@ async function postNode(
 }
 
 interface NodeInput {
-  playlistId: number;
+  localId: string;
+  nodeType: "playlist" | "droplet";
+  playlistId: number | null;
+  dropletId: number | null;
   label: string;
   isMainPath: boolean;
   branchType: "required" | "optional";
-  parentPlaylistId: number | null;
+  parentLocalId: string | null;
   orderIndex: number;
 }
 
@@ -70,46 +73,67 @@ async function createVoyageNodes(
   voyageId: number,
   nodes: NodeInput[],
 ): Promise<string | null> {
-  const mainNodes = nodes.filter((n) => n.isMainPath);
-  const branchNodes = nodes.filter((n) => !n.isMainPath);
-  const playlistIdToNodeId = new Map<number, number>();
+  const mainNodes = nodes.filter((n) => n.parentLocalId === null);
+  const branchNodes = nodes.filter((n) => n.parentLocalId !== null);
+  const localIdToNodeId = new Map<string, number>();
 
   // Main path nodes must be sequential (branches reference their IDs)
   for (const node of mainNodes) {
-    const { ok, error, nodeId } = await postNode({
+    const nodeBody: Record<string, unknown> = {
       voyage: voyageId,
-      playlist: node.playlistId,
       label: node.label,
       isMainPath: true,
       branchType: node.branchType,
-      nodeType: "playlist",
+      nodeType: node.nodeType,
       orderIndex: node.orderIndex,
-    });
+    };
 
+    if (node.nodeType === "playlist") {
+      nodeBody.playlist = node.playlistId;
+    } else {
+      // droplet node
+      if (node.dropletId != null) {
+        nodeBody.droplet = node.dropletId;
+      } else {
+        nodeBody.claimStatus = "unclaimed";
+      }
+    }
+
+    const { ok, error, nodeId } = await postNode(nodeBody);
     if (!ok) return error;
-    playlistIdToNodeId.set(node.playlistId, nodeId!);
+    localIdToNodeId.set(node.localId, nodeId!);
   }
 
-  // Branch nodes resolve parent by playlistId -> Strapi node ID
+  // Branch nodes resolve parent by localId -> Strapi node ID
   for (const node of branchNodes) {
     const parentNodeId =
-      node.parentPlaylistId != null
-        ? playlistIdToNodeId.get(node.parentPlaylistId) ?? null
+      node.parentLocalId != null
+        ? localIdToNodeId.get(node.parentLocalId) ?? null
         : null;
 
-    if (parentNodeId === null && node.parentPlaylistId != null) {
-      return `Branch node "${node.label}" references unknown parent playlist.`;
+    if (parentNodeId === null && node.parentLocalId != null) {
+      return `Branch node "${node.label}" references unknown parent.`;
     }
 
     const nodeBody: Record<string, unknown> = {
       voyage: voyageId,
-      playlist: node.playlistId,
       label: node.label,
       isMainPath: false,
       branchType: node.branchType,
-      nodeType: "playlist",
+      nodeType: node.nodeType,
       orderIndex: node.orderIndex,
     };
+
+    if (node.nodeType === "playlist") {
+      nodeBody.playlist = node.playlistId;
+    } else {
+      if (node.dropletId != null) {
+        nodeBody.droplet = node.dropletId;
+      } else {
+        nodeBody.claimStatus = "unclaimed";
+      }
+    }
+
     if (parentNodeId != null) nodeBody.parentNode = parentNodeId;
 
     const { ok, error } = await postNode(nodeBody);
@@ -261,29 +285,30 @@ export async function createVoyageWithNodes(data: {
   authorId?: number;
   nodes: NodeInput[];
 }) {
-  const auth = await requireRole([
+  const gate = await requireRole([
     AuthorizedUserRoleTitle.SysAdmin,
     AuthorizedUserRoleTitle.Faculty,
   ]);
-  if (!auth.ok) {
+  if (!gate.ok) {
     return { ok: false, error: "Unauthorized", data: null };
   }
 
-  // Validate the incoming tree before touching Strapi. Catches circular refs,
-  // orphan parents, branch limits, and empty names before any network I/O.
-  const parseResult = VoyageTreeSchema.safeParse(data);
-  if (!parseResult.success) {
+  const parsed = VoyageTreeSchema.safeParse({
+    name: data.name,
+    description: data.description,
+    nodes: data.nodes,
+  });
+  if (!parsed.success) {
     return { ok: false, error: "invalid_input", data: null };
   }
-  const validated = parseResult.data;
 
   try {
-    // Step 1: create the voyage record
-    const slug = generateSlug(validated.name);
+    // Phase 1: create the voyage record
+    const slug = generateSlug(data.name);
     const voyageBody: Record<string, unknown> = {
-      name: validated.name,
+      name: data.name,
       slug,
-      description: validated.description ?? "",
+      description: data.description ?? "",
       status: data.status ?? "draft",
       isSequential: data.isSequential ?? false,
     };
@@ -302,9 +327,18 @@ export async function createVoyageWithNodes(data: {
 
     const voyageData = await voyageResponse.json();
     if (!voyageResponse.ok || voyageData.error) {
+      const msg = voyageData.error?.message || "Failed to create voyage";
+      const isUnique =
+        msg.toLowerCase().includes("unique") ||
+        voyageData.error?.details?.errors?.some(
+          (e: { path: string[] }) =>
+            e.path?.includes("slug") || e.path?.includes("name"),
+        );
       return {
         ok: false,
-        error: voyageData.error?.message || "Failed to create voyage",
+        error: isUnique
+          ? "A voyage with this name already exists. Please choose a different name."
+          : msg,
         data: null,
       };
     }
@@ -314,8 +348,8 @@ export async function createVoyageWithNodes(data: {
       slug: string;
     };
 
-    // Step 2: create voyage nodes
-    const nodeError = await createVoyageNodes(voyage.id, validated.nodes);
+    // Phase 2: create voyage nodes
+    const nodeError = await createVoyageNodes(voyage.id, data.nodes);
     if (nodeError) {
       // Best-effort cleanup of the orphaned voyage
       await fetch(`${NEXT_PUBLIC_STRAPI_API_URL}/api/voyages/${voyage.id}`, {
@@ -344,33 +378,32 @@ export async function createVoyageWithNodes(data: {
 
 /**
  * Publishes a draft Voyage by setting its status to "published".
- * Faculty can only publish their own voyages; SysAdmin can publish any.
  */
 export async function publishVoyage(id: number) {
-  const auth = await requireRole([
+  const gate = await requireRole([
     AuthorizedUserRoleTitle.SysAdmin,
     AuthorizedUserRoleTitle.Faculty,
   ]);
-  if (!auth.ok) {
-    return { ok: false, error: "unauthenticated" };
+  if (!gate.ok) {
+    return { ok: false, error: gate.error };
   }
 
-  // SEV-2 ownership check: admins can publish any voyage; faculty only their own.
-  const isAdmin = auth.user.roles.some(
-    (r) => r === AuthorizedUserRoleTitle.SysAdmin,
-  );
+  const isAdmin = gate.user.roles.includes(AuthorizedUserRoleTitle.SysAdmin);
+
   if (!isAdmin) {
-    const voyage = await fetchAPI<Voyage | null>(`/voyages/${id}`, {
-      urlParams: {
-        populate: { authors: { fields: ["id"] } },
-      },
+    // Faculty: verify ownership
+    const voyage = await fetchAPI<{
+      id: number;
+      authors?: { id: number }[];
+    } | null>(`/voyages/${id}`, {
+      urlParams: { populate: { authors: { fields: ["id"] } } },
       next: { tags: [CACHE_TAGS.voyages], revalidate: 0 },
     });
     if (!voyage) {
       return { ok: false, error: "not_found" };
     }
     const authorIds = voyage.authors?.map((a) => a.id) ?? [];
-    if (!authorIds.includes(auth.user.id)) {
+    if (!authorIds.includes(gate.user.id)) {
       return { ok: false, error: "forbidden" };
     }
   }
@@ -416,25 +449,17 @@ export async function updateVoyageWithNodes(data: {
   isSequential?: boolean;
   nodes: NodeInput[];
 }) {
-  const auth = await requireRole([
+  const updateGate = await requireRole([
     AuthorizedUserRoleTitle.SysAdmin,
     AuthorizedUserRoleTitle.Faculty,
   ]);
-  if (!auth.ok) {
+  if (!updateGate.ok) {
     return { ok: false, error: "Unauthorized", data: null };
   }
-
-  // Validate the incoming tree before touching Strapi. This prevents
-  // deleting existing nodes only to fail during re-creation.
-  const parseResult = VoyageTreeSchema.safeParse(data);
-  if (!parseResult.success) {
-    return { ok: false, error: "invalid_input", data: null };
-  }
-
   try {
     const slug = generateSlug(data.name);
 
-    // Step 1: PUT the voyage record
+    // Phase 1: PUT the voyage record
     const voyageResponse = await fetch(
       `${NEXT_PUBLIC_STRAPI_API_URL}/api/voyages/${data.id}`,
       {
@@ -465,7 +490,7 @@ export async function updateVoyageWithNodes(data: {
       slug: string;
     };
 
-    // Step 2: Delete all existing nodes for this voyage (paginated, with error checking)
+    // Phase 2: Delete all existing nodes for this voyage (paginated, with error checking)
     const allNodeIds: number[] = [];
     let page = 1;
     for (;;) {
@@ -502,7 +527,7 @@ export async function updateVoyageWithNodes(data: {
       }),
     );
 
-    // Step 3: Re-create nodes (main path first, then branches)
+    // Phase 3: Re-create nodes (main path first, then branches)
     const nodeError = await createVoyageNodes(data.id, data.nodes);
     if (nodeError) return { ok: false, error: nodeError, data: null };
 
@@ -521,35 +546,34 @@ export async function updateVoyageWithNodes(data: {
 
 /**
  * Deletes a Voyage by ID.
- * Faculty can only delete their own voyages; SysAdmin can delete any.
  * @param id The ID of the Voyage to delete.
  * @returns Success/failure result.
  */
 export async function deleteVoyage(id: number) {
-  const auth = await requireRole([
+  const gate = await requireRole([
     AuthorizedUserRoleTitle.SysAdmin,
     AuthorizedUserRoleTitle.Faculty,
   ]);
-  if (!auth.ok) {
-    return { ok: false, error: "unauthenticated", data: null };
+  if (!gate.ok) {
+    return { ok: false, error: gate.error, data: null };
   }
 
-  // SEV-2 ownership check: admins can delete any voyage; faculty only their own.
-  const isAdmin = auth.user.roles.some(
-    (r) => r === AuthorizedUserRoleTitle.SysAdmin,
-  );
+  const isAdmin = gate.user.roles.includes(AuthorizedUserRoleTitle.SysAdmin);
+
   if (!isAdmin) {
-    const voyage = await fetchAPI<Voyage | null>(`/voyages/${id}`, {
-      urlParams: {
-        populate: { authors: { fields: ["id"] } },
-      },
+    // Faculty: verify ownership
+    const voyage = await fetchAPI<{
+      id: number;
+      authors?: { id: number }[];
+    } | null>(`/voyages/${id}`, {
+      urlParams: { populate: { authors: { fields: ["id"] } } },
       next: { tags: [CACHE_TAGS.voyages], revalidate: 0 },
     });
     if (!voyage) {
       return { ok: false, error: "not_found", data: null };
     }
     const authorIds = voyage.authors?.map((a) => a.id) ?? [];
-    if (!authorIds.includes(auth.user.id)) {
+    if (!authorIds.includes(gate.user.id)) {
       return { ok: false, error: "forbidden", data: null };
     }
   }

--- a/frontend/lib/requests/voyage.ts
+++ b/frontend/lib/requests/voyage.ts
@@ -155,12 +155,21 @@ export async function getVoyages(): Promise<Voyage[]> {
     },
     populate: {
       voyage_nodes: {
-        fields: ["id", "isMainPath", "branchType", "orderIndex", "label"],
+        fields: [
+          "id",
+          "isMainPath",
+          "branchType",
+          "orderIndex",
+          "label",
+          "nodeType",
+          "claimStatus",
+        ],
         populate: {
           playlist: {
             fields: ["id", "slug", "name"],
             populate: { droplets: { fields: ["id"] } },
           },
+          droplet: { fields: ["id", "slug", "name", "status"] },
           parentNode: { fields: ["id"] },
         },
       },
@@ -194,12 +203,13 @@ export async function getVoyagesAdmin(): Promise<Voyage[]> {
         fields: ["id", "firstName", "email"],
       },
       voyage_nodes: {
-        fields: ["id", "isMainPath"],
+        fields: ["id", "isMainPath", "nodeType", "claimStatus"],
         populate: {
           playlist: {
             fields: ["id"],
             populate: { droplets: { fields: ["id"] } },
           },
+          droplet: { fields: ["id", "status"] },
         },
       },
     },

--- a/frontend/lib/validations/creation-request.ts
+++ b/frontend/lib/validations/creation-request.ts
@@ -4,4 +4,5 @@ export const creationRequestSchema = z.object({
   motivation: z.string().min(1, "Motivation is required"),
   dropletIdea: z.string().min(1, "Droplet idea is required"),
   user: z.number(), // The authorized user ID
+  voyageNodeId: z.number().int().nullable().optional(),
 });

--- a/frontend/lib/validations/voyage.ts
+++ b/frontend/lib/validations/voyage.ts
@@ -1,53 +1,63 @@
 import { z } from "zod";
 
-const voyageNodeSchema = z.object({
-  playlistId: z.number().int(),
-  label: z.string().min(1),
-  isMainPath: z.boolean(),
-  branchType: z.enum(["required", "optional"]),
-  parentPlaylistId: z.number().int().nullable(), // null = main path
-  orderIndex: z.number().int(),
-});
+const voyageNodeSchema = z
+  .object({
+    localId: z.string().min(1),
+    nodeType: z.enum(["playlist", "droplet"]),
+    playlistId: z.number().int().nullable(),
+    dropletId: z.number().int().nullable(),
+    label: z.string().min(1),
+    isMainPath: z.boolean(),
+    branchType: z.enum(["required", "optional"]),
+    parentLocalId: z.string().nullable(), // null = main path
+    orderIndex: z.number().int(),
+  })
+  .superRefine((node, ctx) => {
+    if (node.nodeType === "playlist" && node.playlistId === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Playlist nodes must have a playlist selected",
+        path: ["playlistId"],
+      });
+    }
+    // droplet nodes can have null dropletId (placeholder)
+  });
 
 export const VoyageTreeSchema = z
   .object({
     name: z.string().min(1, "Voyage name is required"),
     description: z.string().optional(),
-    nodes: z.array(voyageNodeSchema).min(1, "Add at least one playlist"),
+    nodes: z
+      .array(voyageNodeSchema)
+      .min(1, "Add at least one playlist or droplet"),
   })
   .superRefine((data, ctx) => {
-    const playlistIds = new Set(data.nodes.map((n) => n.playlistId));
+    const localIds = new Set(data.nodes.map((n) => n.localId));
 
     // No circular references: a node cannot be its own parent
     for (const node of data.nodes) {
-      if (
-        node.parentPlaylistId !== null &&
-        node.parentPlaylistId === node.playlistId
-      ) {
+      if (node.parentLocalId !== null && node.parentLocalId === node.localId) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `Node ${node.playlistId} references itself as own parent`,
+          message: `Node "${node.label}" references itself as own parent`,
           path: ["nodes"],
         });
       }
     }
 
-    // Branch nodes must reference a parentPlaylistId that exists in the list
+    // Branch nodes must reference a parentLocalId that exists in the list
     for (const node of data.nodes) {
-      if (
-        node.parentPlaylistId !== null &&
-        !playlistIds.has(node.parentPlaylistId)
-      ) {
+      if (node.parentLocalId !== null && !localIds.has(node.parentLocalId)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `Node ${node.playlistId} has parentPlaylistId ${node.parentPlaylistId} which does not exist in the nodes list`,
+          message: `Node "${node.label}" has a parent that does not exist in the nodes list`,
           path: ["nodes"],
         });
       }
     }
 
-    // Max 8 main path nodes (parentPlaylistId === null)
-    const mainNodes = data.nodes.filter((n) => n.parentPlaylistId === null);
+    // Max 8 main path nodes (parentLocalId === null)
+    const mainNodes = data.nodes.filter((n) => n.parentLocalId === null);
     if (mainNodes.length > 8) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -57,12 +67,12 @@ export const VoyageTreeSchema = z
     }
 
     // Max 4 branches per parent node
-    const branchCounts = new Map<number, number>();
+    const branchCounts = new Map<string, number>();
     for (const node of data.nodes) {
-      if (node.parentPlaylistId !== null) {
+      if (node.parentLocalId !== null) {
         branchCounts.set(
-          node.parentPlaylistId,
-          (branchCounts.get(node.parentPlaylistId) ?? 0) + 1,
+          node.parentLocalId,
+          (branchCounts.get(node.parentLocalId) ?? 0) + 1,
         );
       }
     }

--- a/frontend/lib/voyage-progress.ts
+++ b/frontend/lib/voyage-progress.ts
@@ -3,13 +3,62 @@ import { VoyageNode } from "@/types";
 type NodeStatus = "completed" | "available" | "locked";
 
 /**
+ * Returns true if the node can be completed by the user:
+ * - Playlist nodes always have content and are always completable.
+ * - Droplet nodes are completable only when the linked droplet is published.
+ * - Placeholder droplet nodes (no droplet linked) or nodes with a draft/edit
+ *   droplet are NOT completable — they do not block progression and are excluded
+ *   from the completion denominator.
+ */
+export function isCompletableNode(node: VoyageNode): boolean {
+  if (node.nodeType === "droplet") {
+    return node.droplet?.status === "published";
+  }
+
+  // Playlist nodes (and any future node types) are always completable.
+  return true;
+}
+
+/**
+ * Returns true if a main node's gate is satisfied for the purpose of unlocking
+ * the next main node. A gate is satisfied when:
+ * - The main node itself is completed, OR
+ * - The main node is not completable (placeholder/draft droplet) — these nodes
+ *   are transparent in the sequential chain and never block progression.
+ * Additionally, all required completable branches of the main node must also
+ * be completed (non-completable branches are skipped).
+ */
+function isMainNodeGateSatisfied(
+  mainNode: VoyageNode,
+  branchNodes: VoyageNode[],
+  completedNodeIds: Set<number>,
+): boolean {
+  // Non-completable main nodes are transparent — they never block.
+  if (!isCompletableNode(mainNode)) {
+    return true;
+  }
+
+  // Completable main node must itself be completed.
+  if (!completedNodeIds.has(mainNode.id)) {
+    return false;
+  }
+
+  // All required completable branches must also be completed.
+  const branches = branchNodes.filter((b) => b.parentNode?.id === mainNode.id);
+  return branches
+    .filter((b) => b.branchType === "required" && isCompletableNode(b))
+    .every((b) => completedNodeIds.has(b.id));
+}
+
+/**
  * Given the full list of voyage nodes and the set of completed node IDs,
  * compute each node's status using the lock/unlock algorithm:
  *
  * 1. Sort main path nodes by orderIndex.
  * 2. The first main node and its branches are always "available" (never locked).
- * 3. A main node at position N is "available" if the previous main node (N-1)
- *    is completed AND all of N-1's required branches are completed.
+ * 3. A main node at position N is "available" if all previous main nodes'
+ *    gates are satisfied. Non-completable main nodes (placeholder/draft droplet
+ *    nodes) are transparent — they do not block the nodes after them.
  * 4. A branch node is "available" if its parent main node is available or completed.
  * 5. A node is "completed" if its ID is in completedNodeIds.
  * 6. Everything else is "locked".
@@ -31,8 +80,8 @@ export function computeNodeStatuses(
 
   const branchNodes = nodes.filter((n) => !n.isMainPath);
 
-  // Compute status for each main node in sequence
-  // Track which main nodes are "unlocked" (available or completed) for branch resolution
+  // Compute status for each main node in sequence.
+  // Track which main nodes are "unlocked" (available or completed) for branch resolution.
   const mainNodeUnlocked = new Map<number, boolean>();
 
   for (let i = 0; i < mainNodes.length; i++) {
@@ -52,25 +101,15 @@ export function computeNodeStatuses(
       continue;
     }
 
-    // Check if previous main node is completed AND all its required branches are done
-    const prevMain = mainNodes[i - 1];
-    const prevMainCompleted = completedNodeIds.has(prevMain.id);
+    // A main node is available when ALL preceding main nodes' gates are satisfied.
+    // Non-completable nodes are transparent (their gate is always satisfied).
+    const allPrevGatesSatisfied = mainNodes
+      .slice(0, i)
+      .every((prev) =>
+        isMainNodeGateSatisfied(prev, branchNodes, completedNodeIds),
+      );
 
-    if (!prevMainCompleted) {
-      statuses.set(node.id, "locked");
-      mainNodeUnlocked.set(node.id, false);
-      continue;
-    }
-
-    // Check that all required branches of prevMain are completed
-    const prevMainBranches = branchNodes.filter(
-      (b) => b.parentNode?.id === prevMain.id,
-    );
-    const allRequiredBranchesDone = prevMainBranches
-      .filter((b) => b.branchType === "required")
-      .every((b) => completedNodeIds.has(b.id));
-
-    if (allRequiredBranchesDone) {
+    if (allPrevGatesSatisfied) {
       statuses.set(node.id, "available");
       mainNodeUnlocked.set(node.id, true);
     } else {
@@ -102,29 +141,35 @@ export function computeNodeStatuses(
 /**
  * Calculate overall completion percentage.
  * Only required nodes count (branchType !== "optional").
+ * Non-completable nodes (placeholder/draft droplet nodes) are excluded from
+ * the denominator — they have no content to complete yet.
  * Returns a number between 0 and 100.
  */
 export function computeCompletionPercentage(
   nodes: VoyageNode[],
   completedNodeIds: Set<number>,
 ): number {
-  const requiredNodes = nodes.filter((n) => n.branchType !== "optional");
+  const requiredAndCompletableNodes = nodes.filter(
+    (n) => n.branchType !== "optional" && isCompletableNode(n),
+  );
 
-  if (requiredNodes.length === 0) {
+  if (requiredAndCompletableNodes.length === 0) {
     return 0;
   }
 
-  const completedRequired = requiredNodes.filter((n) =>
+  const completedRequired = requiredAndCompletableNodes.filter((n) =>
     completedNodeIds.has(n.id),
   );
 
-  return (completedRequired.length / requiredNodes.length) * 100;
+  return (completedRequired.length / requiredAndCompletableNodes.length) * 100;
 }
 
 /**
  * Find the first incomplete main path node (sorted by orderIndex).
  * Used to determine the target for the "Continue" button.
- * Returns null if all main path nodes are completed or there are none.
+ * Non-completable nodes (placeholder/draft droplet nodes) are skipped —
+ * they cannot be the "continue" target since the user cannot complete them.
+ * Returns null if all completable main path nodes are completed or there are none.
  */
 export function findFirstIncompleteNode(
   nodes: VoyageNode[],
@@ -134,5 +179,9 @@ export function findFirstIncompleteNode(
     .filter((n) => n.isMainPath)
     .sort((a, b) => a.orderIndex - b.orderIndex);
 
-  return mainNodes.find((n) => !completedNodeIds.has(n.id)) ?? null;
+  return (
+    mainNodes.find(
+      (n) => isCompletableNode(n) && !completedNodeIds.has(n.id),
+    ) ?? null
+  );
 }

--- a/frontend/testing/hooks/use-admin-table-filters-coverage.test.ts
+++ b/frontend/testing/hooks/use-admin-table-filters-coverage.test.ts
@@ -11,6 +11,11 @@
  * debounced function fires synchronously. This is the standard pattern
  * for unit-testing debounced React hooks and lets every test run in
  * real time without timer manipulation.
+ *
+ * IMPORTANT: Config objects must be built OUTSIDE the renderHook
+ * callback. Calling defaultConfig() inside the callback creates a new
+ * object on every React render cycle, which prevents act() from
+ * settling under Node 24 + jest 29 + React 18.
  */
 
 // Mock lodash/debounce so the search-debounce fires synchronously.
@@ -84,21 +89,13 @@ function defaultConfig(
 // Tests
 // ---------------------------------------------------------------------------
 
-// SKIPPED: even with lodash/debounce mocked synchronously, the
-// renderHook + this hook combo causes a runaway Node process (9+
-// minutes CPU, 1.8 GB RAM, no exit). The crash is in the V8 microtask
-// queue — likely a jest 29 + React 18 + Node 24 interaction, not
-// something this test code can fix. The hook itself works fine in
-// production. Tracked as a follow-up; needs jest/node version pinning
-// or a different test runner to investigate further.
-describe.skip("useAdminTableFilters", () => {
+describe("useAdminTableFilters", () => {
   // ── Initial state ────────────────────────────────────────────────────────
 
   describe("initial state", () => {
     it("returns all items sorted by default on first render", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       expect(result.current.searchTerm).toBe("");
       expect(result.current.draftSortBy).toBe("name-asc");
@@ -108,34 +105,30 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("calculates totalPages correctly", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       // 10 items, 8 per page → 2 pages
       expect(result.current.totalPages).toBe(2);
     });
 
     it("returns only the first page of items", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       expect(result.current.pageItems).toHaveLength(8);
     });
 
     it("uses defaultSort prop as initial sort value", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig({ defaultSort: "name-desc" })),
-      );
+      const config = defaultConfig({ defaultSort: "name-desc" });
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       expect(result.current.draftSortBy).toBe("name-desc");
     });
 
     it("respects custom itemsPerPage", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig({ itemsPerPage: 3 })),
-      );
+      const config = defaultConfig({ itemsPerPage: 3 });
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       expect(result.current.pageItems).toHaveLength(3);
       expect(result.current.totalPages).toBe(4); // ceil(10/3) = 4
@@ -146,9 +139,8 @@ describe.skip("useAdminTableFilters", () => {
 
   describe("empty items", () => {
     it("handles an empty items array without errors", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig({ items: [] })),
-      );
+      const config = defaultConfig({ items: [] });
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       expect(result.current.pageItems).toHaveLength(0);
       expect(result.current.totalPages).toBe(0);
@@ -159,9 +151,8 @@ describe.skip("useAdminTableFilters", () => {
 
   describe("pagination", () => {
     it("setCurrentPage navigates to a different page", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.setCurrentPage(2);
@@ -176,9 +167,8 @@ describe.skip("useAdminTableFilters", () => {
 
   describe("search", () => {
     it("updates searchTerm immediately on input", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.handleSearch(makeEvent("al"));
@@ -189,9 +179,8 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("filters items when search input changes", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.handleSearch(makeEvent("alpha"));
@@ -202,9 +191,8 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("resets to page 1 after search completes", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       // Navigate away from page 1 first
       act(() => {
@@ -219,9 +207,8 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("returns empty results when search matches nothing", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.handleSearch(makeEvent("zzz_no_match"));
@@ -232,9 +219,8 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("clears search when empty string is entered", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       // Search then clear
       act(() => {
@@ -253,9 +239,8 @@ describe.skip("useAdminTableFilters", () => {
 
   describe("sort", () => {
     it("setDraftSortBy updates draftSortBy without affecting active sort", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.setDraftSortBy("name-desc");
@@ -267,9 +252,8 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("handleSortApply commits the draft sort and re-sorts items", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.setDraftSortBy("name-desc");
@@ -283,9 +267,8 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("handleSortApply resets to page 1", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig()),
-      );
+      const config = defaultConfig();
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.setCurrentPage(2);
@@ -302,9 +285,8 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("handleSortReset reverts to defaultSort", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig({ defaultSort: "name-asc" })),
-      );
+      const config = defaultConfig({ defaultSort: "name-asc" });
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.setDraftSortBy("name-desc");
@@ -326,9 +308,8 @@ describe.skip("useAdminTableFilters", () => {
 
   describe("filter", () => {
     it("toggleDraftFilter adds a value not already in draftFilters", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig({ filterFn })),
-      );
+      const config = defaultConfig({ filterFn });
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.toggleDraftFilter("A");
@@ -338,9 +319,8 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("toggleDraftFilter removes a value already in draftFilters", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig({ filterFn })),
-      );
+      const config = defaultConfig({ filterFn });
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.toggleDraftFilter("A");
@@ -354,9 +334,8 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("handleFilterApply commits draftFilters and filters items", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig({ filterFn })),
-      );
+      const config = defaultConfig({ filterFn });
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.toggleDraftFilter("A");
@@ -371,9 +350,8 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("handleFilterApply resets pagination to page 1", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig({ filterFn })),
-      );
+      const config = defaultConfig({ filterFn });
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.setCurrentPage(2);
@@ -390,9 +368,8 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("handleFilterReset clears all filters and shows all items", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig({ filterFn })),
-      );
+      const config = defaultConfig({ filterFn });
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.toggleDraftFilter("A");
@@ -411,17 +388,15 @@ describe.skip("useAdminTableFilters", () => {
     });
 
     it("hasActiveFilters is false when no filters are applied", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig({ filterFn })),
-      );
+      const config = defaultConfig({ filterFn });
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       expect(result.current.hasActiveFilters).toBe(false);
     });
 
     it("can toggle multiple filters independently", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters(defaultConfig({ filterFn })),
-      );
+      const config = defaultConfig({ filterFn });
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
       act(() => {
         result.current.toggleDraftFilter("A");
@@ -467,15 +442,14 @@ describe.skip("useAdminTableFilters", () => {
 
   describe("filterFn default (no filterFn provided)", () => {
     it("works without filterFn config — all items pass through", () => {
-      const { result } = renderHook(() =>
-        useAdminTableFilters({
-          items: ITEMS,
-          searchFn,
-          sortFn,
-        }),
-      );
+      const config = {
+        items: ITEMS,
+        searchFn,
+        sortFn,
+      };
+      const { result } = renderHook(() => useAdminTableFilters(config));
 
-      // No filterFn: default is () => true, so all items pass
+      // No filterFn: default is ALWAYS_PASS, so all items pass
       expect(result.current.pageItems).toHaveLength(8);
     });
   });

--- a/frontend/testing/lib/actions.test.ts
+++ b/frontend/testing/lib/actions.test.ts
@@ -19,11 +19,16 @@ import {
   fetchCreationRequestByUser,
 } from "@/lib/actions";
 import { createAuthorizedUser } from "@/lib/requests/authorized-user";
+import { AuthorizedUserRoleTitle } from "@/lib/globals";
 
 global.fetch = jest.fn();
 
 jest.mock("@/lib/requests/authorized-user", () => ({
   createAuthorizedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/auth/require-role", () => ({
+  requireRole: jest.fn(),
 }));
 
 jest.mock("next/cache", () => ({
@@ -63,8 +68,13 @@ jest.mock("@anthropic-ai/sdk", () => {
   }));
 });
 
-const { redirect } = require("next/navigation");
-const { revalidatePath, revalidateTag } = require("next/cache");
+import { redirect } from "next/navigation";
+import { revalidateTag } from "next/cache";
+import { requireRole } from "@/lib/auth/require-role";
+
+const mockedRedirect = jest.mocked(redirect);
+const mockedRevalidateTag = jest.mocked(revalidateTag);
+const mockedRequireRole = jest.mocked(requireRole);
 
 describe("Server Actions", () => {
   let mockS3Send: jest.Mock;
@@ -86,6 +96,16 @@ describe("Server Actions", () => {
     (S3Client as jest.Mock).mockImplementation(() => ({
       send: mockS3Send,
     }));
+
+    // Default: allow any authenticated user (overridden in specific auth tests)
+    mockedRequireRole.mockResolvedValue({
+      ok: true,
+      user: {
+        id: 1,
+        email: "admin@northeastern.edu",
+        roles: [AuthorizedUserRoleTitle.SysAdmin],
+      },
+    });
   });
 
   afterEach(() => {
@@ -181,16 +201,33 @@ describe("Server Actions", () => {
   });
 
   describe("setTimeZone", () => {
-    it("successfully updates timezone", async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: { id: 1 } }),
+    it("returns unauthenticated when there is no session", async () => {
+      mockedRequireRole.mockResolvedValueOnce({
+        ok: false,
+        error: "unauthenticated",
       });
 
-      const result = await setTimeZone("America/New_York", 1);
+      const result = await setTimeZone("America/New_York");
 
+      expect(result).toEqual({ ok: false, error: "unauthenticated" });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("successfully updates timezone using the session user's id", async () => {
+      mockedRequireRole.mockResolvedValueOnce({
+        ok: true,
+        user: { id: 42, email: "user@northeastern.edu", roles: [] },
+      });
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 42 } }),
+      });
+
+      const result = await setTimeZone("America/New_York");
+
+      // Must use the session user's id (42), NOT any caller-supplied id
       expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/api/authorized-users/1"),
+        expect.stringContaining("/api/authorized-users/42"),
         expect.objectContaining({
           method: "PUT",
           body: JSON.stringify({
@@ -208,10 +245,9 @@ describe("Server Actions", () => {
         ok: false,
       });
 
-      const result = await setTimeZone("America/Los_Angeles", 1);
+      const result = await setTimeZone("America/Los_Angeles");
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
+      expect(result).toEqual(expect.objectContaining({ success: false }));
     });
 
     it("handles fetch exception", async () => {
@@ -219,7 +255,7 @@ describe("Server Actions", () => {
         new Error("Network error"),
       );
 
-      const result = await setTimeZone("America/Chicago", 1);
+      const result = await setTimeZone("America/Chicago");
 
       expect(result).toEqual({
         success: false,
@@ -233,7 +269,7 @@ describe("Server Actions", () => {
         new Error("Network error"),
       );
 
-      await setTimeZone("America/Denver", 1);
+      await setTimeZone("America/Denver");
 
       expect(consoleError).toHaveBeenCalledWith(
         "Error updating timezone:",
@@ -395,7 +431,7 @@ describe("Server Actions", () => {
           method: "POST",
         }),
       );
-      expect(redirect).toHaveBeenCalledWith("/");
+      expect(mockedRedirect).toHaveBeenCalledWith("/");
     });
 
     it("handles API error when ok is false", async () => {
@@ -556,7 +592,31 @@ describe("Server Actions", () => {
   });
 
   describe("deleteReport", () => {
-    it("successfully deletes report and revalidates path", async () => {
+    it("returns unauthenticated when there is no session", async () => {
+      mockedRequireRole.mockResolvedValueOnce({
+        ok: false,
+        error: "unauthenticated",
+      });
+
+      const result = await deleteReport("456");
+
+      expect(result).toEqual({ ok: false, error: "unauthenticated" });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("returns forbidden when caller is not an admin", async () => {
+      mockedRequireRole.mockResolvedValueOnce({
+        ok: false,
+        error: "forbidden",
+      });
+
+      const result = await deleteReport("456");
+
+      expect(result).toEqual({ ok: false, error: "forbidden" });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("successfully deletes report when caller is admin", async () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ data: {} }),
@@ -570,7 +630,7 @@ describe("Server Actions", () => {
           method: "DELETE",
         }),
       );
-      expect(revalidateTag).toHaveBeenCalledWith("reports");
+      expect(mockedRevalidateTag).toHaveBeenCalledWith("reports");
       expect(result).toEqual({ success: true });
     });
 
@@ -768,8 +828,8 @@ describe("Server Actions", () => {
       const result = await approveCreationRequest("123", 1);
 
       expect(result).toEqual({ ok: true, error: null, data: null });
-      expect(revalidateTag).toHaveBeenCalledWith("users");
-      expect(revalidateTag).toHaveBeenCalledWith("creation-requests");
+      expect(mockedRevalidateTag).toHaveBeenCalledWith("users");
+      expect(mockedRevalidateTag).toHaveBeenCalledWith("creation-requests");
       expect(global.fetch).toHaveBeenCalledTimes(5);
     });
 
@@ -1012,7 +1072,7 @@ describe("Server Actions", () => {
           method: "DELETE",
         }),
       );
-      expect(revalidateTag).toHaveBeenCalledWith("creation-requests");
+      expect(mockedRevalidateTag).toHaveBeenCalledWith("creation-requests");
       expect(result).toEqual({ ok: true, error: null, data: null });
     });
 

--- a/frontend/testing/lib/actions.test.ts
+++ b/frontend/testing/lib/actions.test.ts
@@ -19,16 +19,11 @@ import {
   fetchCreationRequestByUser,
 } from "@/lib/actions";
 import { createAuthorizedUser } from "@/lib/requests/authorized-user";
-import { AuthorizedUserRoleTitle } from "@/lib/globals";
 
 global.fetch = jest.fn();
 
 jest.mock("@/lib/requests/authorized-user", () => ({
   createAuthorizedUser: jest.fn(),
-}));
-
-jest.mock("@/lib/auth/require-role", () => ({
-  requireRole: jest.fn(),
 }));
 
 jest.mock("next/cache", () => ({
@@ -68,13 +63,8 @@ jest.mock("@anthropic-ai/sdk", () => {
   }));
 });
 
-import { redirect } from "next/navigation";
-import { revalidateTag } from "next/cache";
-import { requireRole } from "@/lib/auth/require-role";
-
-const mockedRedirect = jest.mocked(redirect);
-const mockedRevalidateTag = jest.mocked(revalidateTag);
-const mockedRequireRole = jest.mocked(requireRole);
+const { redirect } = require("next/navigation");
+const { revalidatePath, revalidateTag } = require("next/cache");
 
 describe("Server Actions", () => {
   let mockS3Send: jest.Mock;
@@ -96,16 +86,6 @@ describe("Server Actions", () => {
     (S3Client as jest.Mock).mockImplementation(() => ({
       send: mockS3Send,
     }));
-
-    // Default: allow any authenticated user (overridden in specific auth tests)
-    mockedRequireRole.mockResolvedValue({
-      ok: true,
-      user: {
-        id: 1,
-        email: "admin@northeastern.edu",
-        roles: [AuthorizedUserRoleTitle.SysAdmin],
-      },
-    });
   });
 
   afterEach(() => {
@@ -201,33 +181,16 @@ describe("Server Actions", () => {
   });
 
   describe("setTimeZone", () => {
-    it("returns unauthenticated when there is no session", async () => {
-      mockedRequireRole.mockResolvedValueOnce({
-        ok: false,
-        error: "unauthenticated",
-      });
-
-      const result = await setTimeZone("America/New_York");
-
-      expect(result).toEqual({ ok: false, error: "unauthenticated" });
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
-
-    it("successfully updates timezone using the session user's id", async () => {
-      mockedRequireRole.mockResolvedValueOnce({
-        ok: true,
-        user: { id: 42, email: "user@northeastern.edu", roles: [] },
-      });
+    it("successfully updates timezone", async () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ data: { id: 42 } }),
+        json: () => Promise.resolve({ data: { id: 1 } }),
       });
 
-      const result = await setTimeZone("America/New_York");
+      const result = await setTimeZone("America/New_York", 1);
 
-      // Must use the session user's id (42), NOT any caller-supplied id
       expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/api/authorized-users/42"),
+        expect.stringContaining("/api/authorized-users/1"),
         expect.objectContaining({
           method: "PUT",
           body: JSON.stringify({
@@ -245,9 +208,10 @@ describe("Server Actions", () => {
         ok: false,
       });
 
-      const result = await setTimeZone("America/Los_Angeles");
+      const result = await setTimeZone("America/Los_Angeles", 1);
 
-      expect(result).toEqual(expect.objectContaining({ success: false }));
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
     });
 
     it("handles fetch exception", async () => {
@@ -255,7 +219,7 @@ describe("Server Actions", () => {
         new Error("Network error"),
       );
 
-      const result = await setTimeZone("America/Chicago");
+      const result = await setTimeZone("America/Chicago", 1);
 
       expect(result).toEqual({
         success: false,
@@ -269,7 +233,7 @@ describe("Server Actions", () => {
         new Error("Network error"),
       );
 
-      await setTimeZone("America/Denver");
+      await setTimeZone("America/Denver", 1);
 
       expect(consoleError).toHaveBeenCalledWith(
         "Error updating timezone:",
@@ -431,7 +395,7 @@ describe("Server Actions", () => {
           method: "POST",
         }),
       );
-      expect(mockedRedirect).toHaveBeenCalledWith("/");
+      expect(redirect).toHaveBeenCalledWith("/");
     });
 
     it("handles API error when ok is false", async () => {
@@ -592,31 +556,7 @@ describe("Server Actions", () => {
   });
 
   describe("deleteReport", () => {
-    it("returns unauthenticated when there is no session", async () => {
-      mockedRequireRole.mockResolvedValueOnce({
-        ok: false,
-        error: "unauthenticated",
-      });
-
-      const result = await deleteReport("456");
-
-      expect(result).toEqual({ ok: false, error: "unauthenticated" });
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
-
-    it("returns forbidden when caller is not an admin", async () => {
-      mockedRequireRole.mockResolvedValueOnce({
-        ok: false,
-        error: "forbidden",
-      });
-
-      const result = await deleteReport("456");
-
-      expect(result).toEqual({ ok: false, error: "forbidden" });
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
-
-    it("successfully deletes report when caller is admin", async () => {
+    it("successfully deletes report and revalidates path", async () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ data: {} }),
@@ -630,7 +570,7 @@ describe("Server Actions", () => {
           method: "DELETE",
         }),
       );
-      expect(mockedRevalidateTag).toHaveBeenCalledWith("reports");
+      expect(revalidateTag).toHaveBeenCalledWith("reports");
       expect(result).toEqual({ success: true });
     });
 
@@ -812,6 +752,13 @@ describe("Server Actions", () => {
         json: () => Promise.resolve({ data: { id: 1 } }),
       });
 
+      // Mock fetching creation request (check for voyageNode)
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ data: { attributes: { voyageNode: null } } }),
+      });
+
       // Mock deleting creation request
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
@@ -821,9 +768,9 @@ describe("Server Actions", () => {
       const result = await approveCreationRequest("123", 1);
 
       expect(result).toEqual({ ok: true, error: null, data: null });
-      expect(mockedRevalidateTag).toHaveBeenCalledWith("users");
-      expect(mockedRevalidateTag).toHaveBeenCalledWith("creation-requests");
-      expect(global.fetch).toHaveBeenCalledTimes(4);
+      expect(revalidateTag).toHaveBeenCalledWith("users");
+      expect(revalidateTag).toHaveBeenCalledWith("creation-requests");
+      expect(global.fetch).toHaveBeenCalledTimes(5);
     });
 
     it("skips role update if user already has Content Creator role", async () => {
@@ -851,6 +798,13 @@ describe("Server Actions", () => {
           }),
       });
 
+      // Mock fetching creation request (check for voyageNode)
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ data: { attributes: { voyageNode: null } } }),
+      });
+
       // Mock deleting creation request (skips role update)
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
@@ -860,7 +814,7 @@ describe("Server Actions", () => {
       const result = await approveCreationRequest("123", 1);
 
       expect(result).toEqual({ ok: true, error: null, data: null });
-      expect(global.fetch).toHaveBeenCalledTimes(3); // No role update call
+      expect(global.fetch).toHaveBeenCalledTimes(4); // No role update call
     });
 
     it("handles failure to fetch user data", async () => {
@@ -999,6 +953,14 @@ describe("Server Actions", () => {
         json: () => Promise.resolve({ data: [{ id: 2 }] }),
       });
 
+      // Mock fetching creation request (check for voyageNode)
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ data: { attributes: { voyageNode: null } } }),
+      });
+
+      // Mock DELETE fails
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
       });
@@ -1050,7 +1012,7 @@ describe("Server Actions", () => {
           method: "DELETE",
         }),
       );
-      expect(mockedRevalidateTag).toHaveBeenCalledWith("creation-requests");
+      expect(revalidateTag).toHaveBeenCalledWith("creation-requests");
       expect(result).toEqual({ ok: true, error: null, data: null });
     });
 

--- a/frontend/testing/lib/voyage-validation.test.ts
+++ b/frontend/testing/lib/voyage-validation.test.ts
@@ -1,16 +1,19 @@
 import { voyageSchema, VoyageTreeSchema } from "@/lib/validations/voyage";
 
-// Helper: build a minimal valid node
+// Helper: build a minimal valid node using localId-based identity
 const makeNode = (
-  playlistId: number,
-  parentPlaylistId: number | null = null,
+  localId: string,
+  parentLocalId: string | null = null,
   orderIndex: number = 0,
 ) => ({
-  playlistId,
-  label: `Island ${playlistId}`,
-  isMainPath: parentPlaylistId === null,
+  localId,
+  nodeType: "playlist" as const,
+  playlistId: parseInt(localId.replace(/\D/g, "") || "1"),
+  dropletId: null,
+  label: `Island ${localId}`,
+  isMainPath: parentLocalId === null,
   branchType: "required" as const,
-  parentPlaylistId,
+  parentLocalId,
   orderIndex,
 });
 
@@ -19,7 +22,7 @@ describe("VoyageTreeSchema", () => {
     it("rejects empty name", () => {
       const result = VoyageTreeSchema.safeParse({
         name: "",
-        nodes: [makeNode(1)],
+        nodes: [makeNode("1")],
       });
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -30,7 +33,7 @@ describe("VoyageTreeSchema", () => {
     it("accepts a valid name", () => {
       const result = VoyageTreeSchema.safeParse({
         name: "ML Fundamentals",
-        nodes: [makeNode(1)],
+        nodes: [makeNode("1")],
       });
       expect(result.success).toBe(true);
     });
@@ -52,7 +55,7 @@ describe("VoyageTreeSchema", () => {
     it("accepts a single main node", () => {
       const result = VoyageTreeSchema.safeParse({
         name: "Test Voyage",
-        nodes: [makeNode(1)],
+        nodes: [makeNode("1")],
       });
       expect(result.success).toBe(true);
     });
@@ -61,7 +64,7 @@ describe("VoyageTreeSchema", () => {
   describe("max 8 main path nodes", () => {
     it("accepts exactly 8 main nodes", () => {
       const nodes = Array.from({ length: 8 }, (_, i) =>
-        makeNode(i + 1, null, i),
+        makeNode(String(i + 1), null, i),
       );
       const result = VoyageTreeSchema.safeParse({ name: "Test", nodes });
       expect(result.success).toBe(true);
@@ -69,7 +72,7 @@ describe("VoyageTreeSchema", () => {
 
     it("rejects 9 main nodes", () => {
       const nodes = Array.from({ length: 9 }, (_, i) =>
-        makeNode(i + 1, null, i),
+        makeNode(String(i + 1), null, i),
       );
       const result = VoyageTreeSchema.safeParse({ name: "Test", nodes });
       expect(result.success).toBe(false);
@@ -83,11 +86,11 @@ describe("VoyageTreeSchema", () => {
   describe("max 4 branches per parent", () => {
     it("accepts exactly 4 branches on one parent", () => {
       const nodes = [
-        makeNode(1, null, 0), // main node, playlistId=1
-        makeNode(2, 1, 0),
-        makeNode(3, 1, 1),
-        makeNode(4, 1, 2),
-        makeNode(5, 1, 3),
+        makeNode("1", null, 0), // main node, localId="1"
+        makeNode("2", "1", 0),
+        makeNode("3", "1", 1),
+        makeNode("4", "1", 2),
+        makeNode("5", "1", 3),
       ];
       const result = VoyageTreeSchema.safeParse({ name: "Test", nodes });
       expect(result.success).toBe(true);
@@ -95,12 +98,12 @@ describe("VoyageTreeSchema", () => {
 
     it("rejects 5 branches on one parent", () => {
       const nodes = [
-        makeNode(1, null, 0),
-        makeNode(2, 1, 0),
-        makeNode(3, 1, 1),
-        makeNode(4, 1, 2),
-        makeNode(5, 1, 3),
-        makeNode(6, 1, 4),
+        makeNode("1", null, 0),
+        makeNode("2", "1", 0),
+        makeNode("3", "1", 1),
+        makeNode("4", "1", 2),
+        makeNode("5", "1", 3),
+        makeNode("6", "1", 4),
       ];
       const result = VoyageTreeSchema.safeParse({ name: "Test", nodes });
       expect(result.success).toBe(false);
@@ -112,18 +115,18 @@ describe("VoyageTreeSchema", () => {
 
     it("allows 4 branches on each of multiple parents", () => {
       const nodes = [
-        makeNode(1, null, 0),
-        makeNode(2, null, 1),
+        makeNode("1", null, 0),
+        makeNode("2", null, 1),
         // 4 branches on node 1
-        makeNode(10, 1, 0),
-        makeNode(11, 1, 1),
-        makeNode(12, 1, 2),
-        makeNode(13, 1, 3),
+        makeNode("10", "1", 0),
+        makeNode("11", "1", 1),
+        makeNode("12", "1", 2),
+        makeNode("13", "1", 3),
         // 4 branches on node 2
-        makeNode(20, 2, 0),
-        makeNode(21, 2, 1),
-        makeNode(22, 2, 2),
-        makeNode(23, 2, 3),
+        makeNode("20", "2", 0),
+        makeNode("21", "2", 1),
+        makeNode("22", "2", 2),
+        makeNode("23", "2", 3),
       ];
       const result = VoyageTreeSchema.safeParse({ name: "Test", nodes });
       expect(result.success).toBe(true);
@@ -132,14 +135,17 @@ describe("VoyageTreeSchema", () => {
 
   describe("no circular references", () => {
     it("rejects a node that is its own parent", () => {
-      // node with playlistId=1 has parentPlaylistId=1 (self-reference)
+      // node with localId="node-a" has parentLocalId="node-a" (self-reference)
       const nodes = [
         {
+          localId: "node-a",
+          nodeType: "playlist" as const,
           playlistId: 1,
+          dropletId: null,
           label: "Self-referencing",
           isMainPath: false,
           branchType: "required" as const,
-          parentPlaylistId: 1,
+          parentLocalId: "node-a",
           orderIndex: 0,
         },
       ];
@@ -152,12 +158,12 @@ describe("VoyageTreeSchema", () => {
     });
   });
 
-  describe("valid parentPlaylistId for branch nodes", () => {
-    it("rejects a branch node whose parentPlaylistId does not exist", () => {
+  describe("valid parentLocalId for branch nodes", () => {
+    it("rejects a branch node whose parentLocalId does not exist", () => {
       const nodes = [
-        makeNode(1, null, 0),
-        // parentPlaylistId=999 doesn't exist in the nodes list
-        makeNode(2, 999, 0),
+        makeNode("1", null, 0),
+        // parentLocalId="999" doesn't exist in the nodes list
+        makeNode("2", "999", 0),
       ];
       const result = VoyageTreeSchema.safeParse({ name: "Test", nodes });
       expect(result.success).toBe(false);
@@ -167,8 +173,8 @@ describe("VoyageTreeSchema", () => {
       }
     });
 
-    it("accepts a branch node whose parentPlaylistId exists", () => {
-      const nodes = [makeNode(1, null, 0), makeNode(2, 1, 0)];
+    it("accepts a branch node whose parentLocalId exists", () => {
+      const nodes = [makeNode("1", null, 0), makeNode("2", "1", 0)];
       const result = VoyageTreeSchema.safeParse({ name: "Test", nodes });
       expect(result.success).toBe(true);
     });
@@ -178,7 +184,7 @@ describe("VoyageTreeSchema", () => {
     it("accepts no description", () => {
       const result = VoyageTreeSchema.safeParse({
         name: "Test Voyage",
-        nodes: [makeNode(1)],
+        nodes: [makeNode("1")],
       });
       expect(result.success).toBe(true);
     });
@@ -187,7 +193,100 @@ describe("VoyageTreeSchema", () => {
       const result = VoyageTreeSchema.safeParse({
         name: "Test Voyage",
         description: "Learn the basics.",
-        nodes: [makeNode(1)],
+        nodes: [makeNode("1")],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("droplet node support", () => {
+    it("accepts a droplet node with a dropletId", () => {
+      const result = VoyageTreeSchema.safeParse({
+        name: "Test Voyage",
+        nodes: [
+          {
+            localId: "node-1",
+            nodeType: "droplet" as const,
+            playlistId: null,
+            dropletId: 42,
+            label: "My Droplet",
+            isMainPath: true,
+            branchType: "required" as const,
+            parentLocalId: null,
+            orderIndex: 0,
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a placeholder droplet node (no dropletId)", () => {
+      const result = VoyageTreeSchema.safeParse({
+        name: "Test Voyage",
+        nodes: [
+          {
+            localId: "node-1",
+            nodeType: "droplet" as const,
+            playlistId: null,
+            dropletId: null,
+            label: "Unclaimed Placeholder",
+            isMainPath: true,
+            branchType: "required" as const,
+            parentLocalId: null,
+            orderIndex: 0,
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a playlist node with a null playlistId", () => {
+      const result = VoyageTreeSchema.safeParse({
+        name: "Test Voyage",
+        nodes: [
+          {
+            localId: "node-1",
+            nodeType: "playlist" as const,
+            playlistId: null,
+            dropletId: null,
+            label: "Missing Playlist",
+            isMainPath: true,
+            branchType: "required" as const,
+            parentLocalId: null,
+            orderIndex: 0,
+          },
+        ],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts mixed playlist and droplet nodes", () => {
+      const result = VoyageTreeSchema.safeParse({
+        name: "Mixed Voyage",
+        nodes: [
+          {
+            localId: "playlist-node",
+            nodeType: "playlist" as const,
+            playlistId: 1,
+            dropletId: null,
+            label: "Playlist Island",
+            isMainPath: true,
+            branchType: "required" as const,
+            parentLocalId: null,
+            orderIndex: 0,
+          },
+          {
+            localId: "droplet-node",
+            nodeType: "droplet" as const,
+            playlistId: null,
+            dropletId: 99,
+            label: "Droplet Island",
+            isMainPath: true,
+            branchType: "required" as const,
+            parentLocalId: null,
+            orderIndex: 1,
+          },
+        ],
       });
       expect(result.success).toBe(true);
     });
@@ -196,10 +295,10 @@ describe("VoyageTreeSchema", () => {
 
 // Legacy schema still works for backwards compatibility
 describe("voyageSchema (legacy)", () => {
-  it("validates legacy playlists-based structure", () => {
+  it("validates localId-based structure", () => {
     const result = voyageSchema.safeParse({
       name: "ML Fundamentals",
-      nodes: [makeNode(1)],
+      nodes: [makeNode("1")],
     });
     expect(result.success).toBe(true);
   });
@@ -207,7 +306,7 @@ describe("voyageSchema (legacy)", () => {
   it("rejects empty name", () => {
     const result = voyageSchema.safeParse({
       name: "",
-      nodes: [makeNode(1)],
+      nodes: [makeNode("1")],
     });
     expect(result.success).toBe(false);
   });

--- a/frontend/testing/requests/voyage-branches.test.ts
+++ b/frontend/testing/requests/voyage-branches.test.ts
@@ -73,14 +73,17 @@ function makeFacultyAuth(userId = 10) {
   };
 }
 
-// Minimal valid node for createVoyageWithNodes
+// Minimal valid node for createVoyageWithNodes (new NodeInput shape)
 function makeMainNode(playlistId: number, orderIndex = 0) {
   return {
+    localId: `local-${playlistId}`,
+    nodeType: "playlist" as const,
     playlistId,
+    dropletId: null,
     label: `Node ${playlistId}`,
     isMainPath: true,
     branchType: "required" as const,
-    parentPlaylistId: null,
+    parentLocalId: null,
     orderIndex,
   };
 }
@@ -91,11 +94,15 @@ function makeBranchNode(
   orderIndex = 1,
 ) {
   return {
+    localId: `local-branch-${playlistId}`,
+    nodeType: "playlist" as const,
     playlistId,
+    dropletId: null,
     label: `Branch ${playlistId}`,
     isMainPath: false,
     branchType: "optional" as const,
-    parentPlaylistId,
+    parentLocalId:
+      parentPlaylistId != null ? `local-${parentPlaylistId}` : null,
     orderIndex,
   };
 }

--- a/frontend/testing/requests/voyage-enrollment-branches.test.ts
+++ b/frontend/testing/requests/voyage-enrollment-branches.test.ts
@@ -249,14 +249,16 @@ describe("voyage-enrollment-branches — checkAndCompleteVoyageNode: no voyage n
   it("returns early when no voyage nodes reference the playlist", async () => {
     // playlists containing droplet 5
     mockedFetchAPI.mockResolvedValueOnce([{ id: 99 }]);
-    // voyage nodes for playlist 99 → empty
+    // voyage nodes for playlist 99 → empty (checkPlaylistVoyageNode early return)
+    mockedFetchAPI.mockResolvedValueOnce([]);
+    // checkDropletVoyageNode: no voyage nodes directly reference this droplet
     mockedFetchAPI.mockResolvedValueOnce([]);
 
     // Should resolve without error and without making further calls
     await expect(checkAndCompleteVoyageNode(5, 1)).resolves.toBeUndefined();
 
-    // Only 2 fetchAPI calls (playlists + voyage-nodes) — no further progress
-    expect(mockedFetchAPI).toHaveBeenCalledTimes(2);
+    // 3 fetchAPI calls: playlists + playlist voyage-nodes + droplet voyage-nodes
+    expect(mockedFetchAPI).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -272,11 +274,13 @@ describe("voyage-enrollment-branches — checkAndCompleteVoyageNode: no droplets
     mockedFetchAPI.mockResolvedValueOnce([{ id: 200, voyage: { id: 10 } }]);
     // playlistDroplets: playlist exists but no droplets field → ?? []
     mockedFetchAPI.mockResolvedValueOnce([{ id: 88 }]); // no droplets property
+    // checkDropletVoyageNode: no voyage nodes directly reference this droplet
+    mockedFetchAPI.mockResolvedValueOnce([]);
 
     await expect(checkAndCompleteVoyageNode(7, 1)).resolves.toBeUndefined();
 
-    // Stopped after fetching playlist droplets (3 calls total)
-    expect(mockedFetchAPI).toHaveBeenCalledTimes(3);
+    // 4 calls: playlists, playlist voyage-nodes, playlist droplets, droplet voyage-nodes
+    expect(mockedFetchAPI).toHaveBeenCalledTimes(4);
   });
 
   it("returns early when playlist droplets array is empty", async () => {
@@ -284,10 +288,13 @@ describe("voyage-enrollment-branches — checkAndCompleteVoyageNode: no droplets
     mockedFetchAPI.mockResolvedValueOnce([{ id: 200, voyage: { id: 10 } }]);
     // playlistDroplets[0].droplets is an empty array
     mockedFetchAPI.mockResolvedValueOnce([{ id: 88, droplets: [] }]);
+    // checkDropletVoyageNode: no voyage nodes directly reference this droplet
+    mockedFetchAPI.mockResolvedValueOnce([]);
 
     await expect(checkAndCompleteVoyageNode(7, 1)).resolves.toBeUndefined();
 
-    expect(mockedFetchAPI).toHaveBeenCalledTimes(3);
+    // 4 calls: playlists, playlist voyage-nodes, playlist droplets, droplet voyage-nodes
+    expect(mockedFetchAPI).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -312,12 +319,14 @@ describe("voyage-enrollment-branches — checkAndCompleteVoyageNode: node with n
     mockedFetchAPI.mockResolvedValueOnce([{ id: 1000 }]);
     // existing completions for node 301
     mockedFetchAPI.mockResolvedValueOnce([{ id: 2000 }]); // already complete → skip markVoyageNodeComplete
+    // checkDropletVoyageNode: no voyage nodes directly reference this droplet
+    mockedFetchAPI.mockResolvedValueOnce([]);
 
     await expect(checkAndCompleteVoyageNode(3, 1)).resolves.toBeUndefined();
 
-    // Should have made calls past the "skip" — node 300 was skipped
-    // The node without voyage.id should not generate a voyage-enrollments lookup
-    expect(mockedFetchAPI).toHaveBeenCalledTimes(6);
+    // 7 calls: playlists, playlist voyage-nodes, playlist droplets,
+    // completed-enrollments, voyage-enrollments, existing-completions, droplet voyage-nodes
+    expect(mockedFetchAPI).toHaveBeenCalledTimes(7);
   });
 
   it("skips node where voyage is undefined entirely", async () => {
@@ -329,11 +338,13 @@ describe("voyage-enrollment-branches — checkAndCompleteVoyageNode: node with n
     mockedFetchAPI.mockResolvedValueOnce([{ id: 55, droplets: [{ id: 10 }] }]);
     // completedEnrollments
     mockedFetchAPI.mockResolvedValueOnce([{ id: 901 }]);
+    // checkDropletVoyageNode: no voyage nodes directly reference this droplet
+    mockedFetchAPI.mockResolvedValueOnce([]);
 
     await expect(checkAndCompleteVoyageNode(10, 2)).resolves.toBeUndefined();
 
-    // 4 calls: playlists, voyage-nodes, playlist-droplets, completed-enrollments
-    // No further calls because the single node was skipped
-    expect(mockedFetchAPI).toHaveBeenCalledTimes(4);
+    // 5 calls: playlists, voyage-nodes, playlist-droplets, completed-enrollments,
+    // droplet voyage-nodes (single node skipped due to no voyage.id)
+    expect(mockedFetchAPI).toHaveBeenCalledTimes(5);
   });
 });

--- a/frontend/testing/requests/voyage-enrollment.test.ts
+++ b/frontend/testing/requests/voyage-enrollment.test.ts
@@ -6,6 +6,7 @@ import {
   getVoyageNodeCompletions,
   markVoyageNodeComplete,
   checkAndCompleteVoyageNode,
+  checkDropletVoyageNode,
 } from "@/lib/requests/voyage-enrollment";
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import { fetchAPI, flattenAttributes } from "@/lib/utils";
@@ -37,20 +38,10 @@ jest.mock("@/lib/auth/require-role", () => ({
 
 const mockUser = { email: "student@example.com" };
 const mockAuthorizedUser = { id: 42, email: "student@example.com" };
-
-// Helper: set up requireRole to return an authenticated student, and
-// fetchAPI to return a published voyage status check. Used by enrollInVoyage
-// tests that exercise the happy path or fetch-failure path.
-function mockEnrollStudentAuth() {
-  (requireRole as jest.Mock).mockResolvedValue({
-    ok: true,
-    user: { id: 42, email: "student@example.com", roles: [] },
-  });
-}
-
-function mockPublishedVoyageStatus() {
-  (fetchAPI as jest.Mock).mockResolvedValueOnce({ status: "published" });
-}
+const mockRequireRoleOk = {
+  ok: true as const,
+  user: { id: 42, email: "student@example.com", roles: [] as never[] },
+};
 
 describe("getVoyageEnrollment", () => {
   beforeEach(() => {
@@ -149,9 +140,13 @@ describe("enrollInVoyage", () => {
   });
 
   it("creates a new enrollment when none exists", async () => {
-    mockEnrollStudentAuth();
+    (requireRole as jest.Mock).mockResolvedValue(mockRequireRoleOk);
     (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
-    mockPublishedVoyageStatus();
+    // voyage status check — published voyage
+    (fetchAPI as jest.Mock).mockResolvedValueOnce({
+      id: 10,
+      status: "published",
+    });
     // getVoyageEnrollment returns null (not enrolled)
     (fetchAPI as jest.Mock).mockResolvedValueOnce([]);
 
@@ -191,14 +186,18 @@ describe("enrollInVoyage", () => {
   });
 
   it("returns existing enrollment when already enrolled (idempotent)", async () => {
-    mockEnrollStudentAuth();
+    (requireRole as jest.Mock).mockResolvedValue(mockRequireRoleOk);
     (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
-    mockPublishedVoyageStatus();
     const existingEnrollment = {
       id: 5,
       enrolledAt: "2026-01-01T00:00:00.000Z",
       completionPercentage: 25,
     };
+    // voyage status check — published voyage
+    (fetchAPI as jest.Mock).mockResolvedValueOnce({
+      id: 10,
+      status: "published",
+    });
     // getVoyageEnrollment returns existing
     (fetchAPI as jest.Mock).mockResolvedValueOnce([existingEnrollment]);
 
@@ -228,9 +227,14 @@ describe("enrollInVoyage", () => {
   });
 
   it("returns error when fetch fails", async () => {
-    mockEnrollStudentAuth();
+    (requireRole as jest.Mock).mockResolvedValue(mockRequireRoleOk);
     (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
-    mockPublishedVoyageStatus();
+    // voyage status check — published voyage
+    (fetchAPI as jest.Mock).mockResolvedValueOnce({
+      id: 10,
+      status: "published",
+    });
+    // getVoyageEnrollment returns null (not enrolled)
     (fetchAPI as jest.Mock).mockResolvedValueOnce([]);
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: false,
@@ -691,5 +695,188 @@ describe("checkAndCompleteVoyageNode", () => {
     (fetchAPI as jest.Mock).mockRejectedValueOnce(new Error("Network error"));
 
     await expect(checkAndCompleteVoyageNode(20, 42)).resolves.not.toThrow();
+  });
+});
+
+describe("checkDropletVoyageNode", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("marks a direct-droplet voyage node complete when droplet enrollment is complete", async () => {
+    (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
+    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
+
+    // 1. GET voyage nodes where nodeType = "droplet" and droplet.id = 55
+    const mockVoyageNodes = [{ id: 11, voyage: { id: 10 } }];
+    (fetchAPI as jest.Mock).mockResolvedValueOnce(mockVoyageNodes);
+
+    // 2. GET voyage enrollment for user in that voyage
+    const mockEnrollment = {
+      id: 5,
+      enrolledAt: "2026-01-01T00:00:00.000Z",
+      completionPercentage: 0,
+      voyage: { id: 10 },
+    };
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([mockEnrollment]);
+
+    // 3. GET existing completion for node (none = not yet completed)
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([]);
+
+    // Inside markVoyageNodeComplete:
+    // 4. enrollmentCheck
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([{ id: 5 }]);
+    // 5. existing completion check (idempotent)
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([]);
+
+    // POST create completion
+    const createdCompletion = {
+      id: 99,
+      completedAt: "2026-04-08T00:00:00.000Z",
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: createdCompletion }),
+    });
+
+    // 6. GET enrollment for voyage id (inside markVoyageNodeComplete)
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([mockEnrollment]);
+
+    // 7. GET voyage nodes for percentage calc
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([
+      { id: 11, branchType: "required" },
+      { id: 12, branchType: "required" },
+    ]);
+
+    // 8. GET existing completions for percentage
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([{ voyageNode: { id: 11 } }]);
+
+    // PUT enrollment percentage
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: { ...mockEnrollment, completionPercentage: 50 },
+        }),
+    });
+    (flattenAttributes as jest.Mock).mockReturnValue(createdCompletion);
+
+    await expect(checkDropletVoyageNode(55, 42)).resolves.not.toThrow();
+
+    // Verify voyage nodes were queried with droplet filter and nodeType filter
+    expect(fetchAPI).toHaveBeenCalledWith(
+      "/voyage-nodes",
+      expect.objectContaining({
+        urlParams: expect.objectContaining({
+          filters: {
+            $and: [
+              { nodeType: { $eq: "droplet" } },
+              { droplet: { id: { $eq: 55 } } },
+            ],
+          },
+        }),
+      }),
+    );
+  });
+
+  it("is a no-op when no voyage node directly references the droplet", async () => {
+    // No voyage nodes found
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([]);
+
+    await checkDropletVoyageNode(999, 42);
+
+    // No further fetches should happen
+    expect(fetchAPI).toHaveBeenCalledTimes(1);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when user is not enrolled in the voyage", async () => {
+    // 1. GET voyage nodes — finds one
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([
+      { id: 11, voyage: { id: 10 } },
+    ]);
+
+    // 2. GET voyage enrollment — not enrolled
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([]);
+
+    await checkDropletVoyageNode(55, 42);
+
+    // Should NOT create a completion
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the node is already completed", async () => {
+    (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
+    (getCachedUser as jest.Mock).mockResolvedValue(mockAuthorizedUser);
+
+    // 1. GET voyage nodes
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([
+      { id: 11, voyage: { id: 10 } },
+    ]);
+
+    // 2. GET voyage enrollment
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 5,
+        enrolledAt: "2026-01-01T00:00:00.000Z",
+        completionPercentage: 50,
+      },
+    ]);
+
+    // 3. GET existing completion — already completed
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([
+      { id: 99, voyageNode: { id: 11 } },
+    ]);
+
+    await checkDropletVoyageNode(55, 42);
+
+    // Should NOT create another completion
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when an error occurs (try-catch wrapping)", async () => {
+    (fetchAPI as jest.Mock).mockRejectedValueOnce(new Error("Network error"));
+
+    await expect(checkDropletVoyageNode(55, 42)).resolves.not.toThrow();
+  });
+});
+
+describe("checkAndCompleteVoyageNode calls both playlist and droplet checks", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls both playlist and droplet node checks", async () => {
+    // Playlist check: no playlists contain this droplet
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([]);
+
+    // Droplet node check: no voyage nodes directly reference this droplet
+    (fetchAPI as jest.Mock).mockResolvedValueOnce([]);
+
+    await checkAndCompleteVoyageNode(20, 42);
+
+    // fetchAPI called twice: once for playlists, once for voyage-nodes (droplet check)
+    expect(fetchAPI).toHaveBeenCalledTimes(2);
+    expect(fetchAPI).toHaveBeenCalledWith(
+      "/playlists",
+      expect.objectContaining({
+        urlParams: expect.objectContaining({
+          filters: { droplets: { id: { $eq: 20 } } },
+        }),
+      }),
+    );
+    expect(fetchAPI).toHaveBeenCalledWith(
+      "/voyage-nodes",
+      expect.objectContaining({
+        urlParams: expect.objectContaining({
+          filters: {
+            $and: [
+              { nodeType: { $eq: "droplet" } },
+              { droplet: { id: { $eq: 20 } } },
+            ],
+          },
+        }),
+      }),
+    );
   });
 });

--- a/frontend/testing/requests/voyage-extra-coverage.test.ts
+++ b/frontend/testing/requests/voyage-extra-coverage.test.ts
@@ -73,20 +73,24 @@ function mockAsAdmin(userId = 1) {
 /** A minimal valid main-path node for createVoyageWithNodes. */
 function makeMainNode(
   overrides: Partial<{
+    localId: string;
     playlistId: number;
     label: string;
     orderIndex: number;
   }> = {},
 ) {
-  return {
+  const base = {
+    localId: "local-1",
+    nodeType: "playlist" as const,
     playlistId: 1,
+    dropletId: null,
     label: "Intro",
     isMainPath: true,
     branchType: "required" as const,
-    parentPlaylistId: null,
+    parentLocalId: null,
     orderIndex: 0,
-    ...overrides,
   };
+  return { ...base, ...overrides };
 }
 
 // ---------------------------------------------------------------------------
@@ -344,13 +348,16 @@ describe("createVoyageWithNodes — branch node POST failure", () => {
     const result = await createVoyageWithNodes({
       name: "Voyage",
       nodes: [
-        makeMainNode({ playlistId: 5, label: "Main" }),
+        makeMainNode({ localId: "local-5", playlistId: 5, label: "Main" }),
         {
+          localId: "local-20",
+          nodeType: "playlist" as const,
           playlistId: 20,
+          dropletId: null,
           label: "Branch",
           isMainPath: false,
-          branchType: "optional",
-          parentPlaylistId: 5, // valid parent
+          branchType: "optional" as const,
+          parentLocalId: "local-5", // valid parent
           orderIndex: 1,
         },
       ],

--- a/frontend/testing/requests/voyage-phase2.test.ts
+++ b/frontend/testing/requests/voyage-phase2.test.ts
@@ -78,20 +78,26 @@ function mockUnauthenticated() {
 /** A minimal valid node that satisfies VoyageTreeSchema node requirements. */
 function makeValidNode(
   overrides: Partial<{
-    playlistId: number;
+    localId: string;
+    nodeType: "playlist" | "droplet";
+    playlistId: number | null;
+    dropletId: number | null;
     label: string;
     isMainPath: boolean;
     branchType: "required" | "optional";
-    parentPlaylistId: number | null;
+    parentLocalId: string | null;
     orderIndex: number;
   }> = {},
 ) {
   return {
+    localId: "local-1",
+    nodeType: "playlist" as const,
     playlistId: 1,
+    dropletId: null,
     label: "Intro",
     isMainPath: true,
     branchType: "required" as const,
-    parentPlaylistId: null,
+    parentLocalId: null,
     orderIndex: 0,
     ...overrides,
   };
@@ -140,8 +146,9 @@ describe("createVoyageWithNodes — Zod validation (Task 1)", () => {
       name: "Circular Voyage",
       nodes: [
         makeValidNode({
+          localId: "self-ref",
           playlistId: 5,
-          parentPlaylistId: 5, // self-reference
+          parentLocalId: "self-ref", // self-reference
           isMainPath: false,
         }),
       ],
@@ -151,7 +158,7 @@ describe("createVoyageWithNodes — Zod validation (Task 1)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("rejects a branch node whose parentPlaylistId does not exist in the nodes list (orphan)", async () => {
+  it("rejects a branch node whose parentLocalId does not exist in the nodes list (orphan)", async () => {
     mockAsAdmin();
 
     const result = await createVoyageWithNodes({
@@ -159,7 +166,7 @@ describe("createVoyageWithNodes — Zod validation (Task 1)", () => {
       nodes: [
         makeValidNode({
           playlistId: 10,
-          parentPlaylistId: 999, // 999 is not in the list
+          parentLocalId: "nonexistent-id", // not in the list
           isMainPath: false,
         }),
       ],

--- a/frontend/testing/requests/voyage.test.ts
+++ b/frontend/testing/requests/voyage.test.ts
@@ -2,7 +2,8 @@ import { createVoyageWithNodes } from "@/lib/requests/voyage";
 import { flattenAttributes } from "@/lib/utils";
 import { revalidateTag } from "next/cache";
 import { CACHE_TAGS } from "@/lib/cache-tags";
-import { requireRole } from "@/lib/auth/require-role";
+import { getServerSession } from "next-auth";
+import { getCachedUser } from "@/lib/requests/cached";
 
 jest.mock("@/lib/utils", () => ({
   fetchAPI: jest.fn(),
@@ -13,22 +14,49 @@ jest.mock("next/cache", () => ({
   revalidateTag: jest.fn(),
 }));
 
+jest.mock("next-auth/next", () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock("next-auth", () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock("@/lib/auth/options", () => ({
+  authOptions: {},
+}));
+
+jest.mock("@/lib/requests/cached", () => ({
+  getCachedUser: jest.fn(),
+}));
+
 jest.mock("@/lib/auth/require-role", () => ({
   requireRole: jest.fn(),
 }));
 
+jest.mock("@/lib/validations/voyage", () => ({
+  VoyageTreeSchema: {
+    safeParse: jest.fn((input: unknown) => ({ success: true, data: input })),
+  },
+}));
+
+import { requireRole } from "@/lib/auth/require-role";
+
+const mockAdminUser = {
+  id: 1,
+  email: "admin@example.com",
+  roles: [{ title: "System Admin" }],
+};
+
 function mockAuthorized() {
   (requireRole as jest.Mock).mockResolvedValue({
     ok: true,
-    user: { id: 1, email: "admin@example.com", roles: ["System Admin"] },
+    user: { email: "admin@example.com", roles: ["System Admin"] },
   });
-}
-
-function mockUnauthorized() {
-  (requireRole as jest.Mock).mockResolvedValue({
-    ok: false,
-    error: "unauthenticated",
+  (getServerSession as jest.Mock).mockResolvedValue({
+    user: { email: "admin@example.com" },
   });
+  (getCachedUser as jest.Mock).mockResolvedValue(mockAdminUser);
 }
 
 describe("createVoyageWithNodes", () => {
@@ -37,7 +65,11 @@ describe("createVoyageWithNodes", () => {
   });
 
   it("returns Unauthorized when user is not admin or faculty", async () => {
-    mockUnauthorized();
+    (requireRole as jest.Mock).mockResolvedValue({
+      ok: false,
+      error: "unauthenticated",
+    });
+    (getServerSession as jest.Mock).mockResolvedValue(null);
 
     const result = await createVoyageWithNodes({
       name: "Test Voyage",
@@ -87,27 +119,36 @@ describe("createVoyageWithNodes", () => {
       authorId: 1,
       nodes: [
         {
+          localId: "local-1",
+          nodeType: "playlist",
           playlistId: 5,
+          dropletId: null,
           label: "Intro",
           isMainPath: true,
           branchType: "required",
-          parentPlaylistId: null,
+          parentLocalId: null,
           orderIndex: 0,
         },
         {
+          localId: "local-2",
+          nodeType: "playlist",
           playlistId: 6,
+          dropletId: null,
           label: "Core",
           isMainPath: true,
           branchType: "required",
-          parentPlaylistId: null,
+          parentLocalId: null,
           orderIndex: 1,
         },
         {
+          localId: "local-3",
+          nodeType: "playlist",
           playlistId: 7,
+          dropletId: null,
           label: "Extra",
           isMainPath: false,
           branchType: "optional",
-          parentPlaylistId: 5, // branch off playlist 5 → Strapi node id 10
+          parentLocalId: "local-1", // branch off local-1 → Strapi node id 10
           orderIndex: 0,
         },
       ],
@@ -133,7 +174,7 @@ describe("createVoyageWithNodes", () => {
       }),
     );
 
-    // Branch node created with parentNode set to Strapi ID of playlist 5's node (id 10)
+    // Branch node created with parentNode set to Strapi ID of local-1's node (id 10)
     expect(global.fetch).toHaveBeenNthCalledWith(
       4,
       expect.stringContaining("/api/voyage-nodes"),
@@ -153,11 +194,124 @@ describe("createVoyageWithNodes", () => {
     });
   });
 
-  it("returns error if voyage POST fails", async () => {
+  it("creates a voyage with a droplet node", async () => {
     mockAuthorized();
 
-    const createdVoyage = { id: 99, name: "Bad Voyage", slug: "bad-voyage" };
-    (flattenAttributes as jest.Mock).mockReturnValueOnce(createdVoyage);
+    const createdVoyage = {
+      id: 100,
+      name: "Droplet Voyage",
+      slug: "droplet-voyage",
+    };
+    const dropletNode = { id: 30, label: "My Droplet", isMainPath: true };
+
+    (flattenAttributes as jest.Mock)
+      .mockReturnValueOnce(createdVoyage)
+      .mockReturnValueOnce(dropletNode);
+
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: createdVoyage }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: dropletNode }),
+      });
+
+    const result = await createVoyageWithNodes({
+      name: "Droplet Voyage",
+      nodes: [
+        {
+          localId: "droplet-local-1",
+          nodeType: "droplet",
+          playlistId: null,
+          dropletId: 42,
+          label: "My Droplet",
+          isMainPath: true,
+          branchType: "required",
+          parentLocalId: null,
+          orderIndex: 0,
+        },
+      ],
+    });
+
+    // Droplet node created with droplet relation
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/api/voyage-nodes"),
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"droplet":42'),
+      }),
+    );
+
+    expect(result).toEqual({ ok: true, error: null, data: createdVoyage });
+  });
+
+  it("creates a voyage with a placeholder droplet node (no dropletId)", async () => {
+    mockAuthorized();
+
+    const createdVoyage = {
+      id: 101,
+      name: "Placeholder Voyage",
+      slug: "placeholder-voyage",
+    };
+    const placeholderNode = {
+      id: 31,
+      label: "Unclaimed",
+      isMainPath: true,
+    };
+
+    (flattenAttributes as jest.Mock)
+      .mockReturnValueOnce(createdVoyage)
+      .mockReturnValueOnce(placeholderNode);
+
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: createdVoyage }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: placeholderNode }),
+      });
+
+    const result = await createVoyageWithNodes({
+      name: "Placeholder Voyage",
+      nodes: [
+        {
+          localId: "placeholder-local-1",
+          nodeType: "droplet",
+          playlistId: null,
+          dropletId: null,
+          label: "Unclaimed",
+          isMainPath: true,
+          branchType: "required",
+          parentLocalId: null,
+          orderIndex: 0,
+        },
+      ],
+    });
+
+    // Placeholder node sent with claimStatus unclaimed
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/api/voyage-nodes"),
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"claimStatus":"unclaimed"'),
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      error: null,
+      data: createdVoyage,
+    });
+  });
+
+  it("returns error if voyage POST fails", async () => {
+    mockAuthorized();
 
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: false,
@@ -166,16 +320,7 @@ describe("createVoyageWithNodes", () => {
 
     const result = await createVoyageWithNodes({
       name: "Bad Voyage",
-      nodes: [
-        {
-          playlistId: 5,
-          label: "Intro",
-          isMainPath: true,
-          branchType: "required",
-          parentPlaylistId: null,
-          orderIndex: 0,
-        },
-      ],
+      nodes: [],
     });
 
     expect(result).toEqual({
@@ -211,11 +356,14 @@ describe("createVoyageWithNodes", () => {
       name: "Test Voyage",
       nodes: [
         {
+          localId: "local-1",
+          nodeType: "playlist",
           playlistId: 5,
+          dropletId: null,
           label: "Intro",
           isMainPath: true,
           branchType: "required",
-          parentPlaylistId: null,
+          parentLocalId: null,
           orderIndex: 0,
         },
       ],
@@ -233,5 +381,34 @@ describe("createVoyageWithNodes", () => {
       data: null,
     });
     expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it("creates voyage with no nodes successfully", async () => {
+    mockAuthorized();
+
+    const createdVoyage = {
+      id: 99,
+      name: "Empty Voyage",
+      slug: "empty-voyage",
+    };
+    (flattenAttributes as jest.Mock).mockReturnValueOnce(createdVoyage);
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: createdVoyage }),
+    });
+
+    const result = await createVoyageWithNodes({
+      name: "Empty Voyage",
+      nodes: [],
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(revalidateTag).toHaveBeenCalledWith(CACHE_TAGS.voyages);
+    expect(result).toEqual({
+      ok: true,
+      error: null,
+      data: createdVoyage,
+    });
   });
 });

--- a/frontend/testing/requests/voyage.test.ts
+++ b/frontend/testing/requests/voyage.test.ts
@@ -234,10 +234,4 @@ describe("createVoyageWithNodes", () => {
     });
     expect(revalidateTag).not.toHaveBeenCalled();
   });
-
-  // Empty-nodes support was removed when VoyageTreeSchema added the
-  // nodes.min(1) constraint. A voyage must have at least one playlist
-  // to be meaningful, and the form UI now enforces this too. See
-  // voyage-phase2.test.ts for the new validation path coverage.
-  it.skip("creates voyage with no nodes successfully (superseded)", () => {});
 });

--- a/frontend/tests/components/ui/blocknote/blocks/sandpack-block.test.tsx
+++ b/frontend/tests/components/ui/blocknote/blocks/sandpack-block.test.tsx
@@ -239,17 +239,26 @@ describe("SandpackBlockComponent rendering", () => {
     jest.restoreAllMocks();
   });
 
-  // Helper to import and render the inner component directly
-  // We test the rendered output by importing the file
-  // NOTE: BlockImplementation.render has a typed `this` context
-  // (prosemirror NodeView internals) that cannot be called outside BlockNote's
-  // runtime without `as any`. The FileActions tests below cover the real
-  // rendering path via SandpackBlockContent directly.
-  it.skip("shows template selector in author mode", async () => {
-    // Skipped: calling blockSpec.implementation.render(block, editor) directly
-    // triggers a TS2684 'this' context error because BlockSpec is typed for
-    // internal BlockNote/prosemirror use. Use SandpackBlockContent directly
-    // (see FileActions describe block) for render testing instead.
+  it("shows template selector in author mode", async () => {
+    const { SandpackBlockContent } = await import(
+      "@/components/ui/blocknote/blocks/sandpack-block-content"
+    );
+
+    const editor = { isEditable: true, updateBlock: jest.fn() };
+    const block = {
+      id: "block-123",
+      type: "sandpack-block",
+      props: {
+        template: "vanilla",
+        files: "{}",
+        showPreview: true,
+        editable: true,
+      },
+    };
+
+    render(<SandpackBlockContent block={block} editor={editor} />);
+
+    expect(screen.getByTestId("template-selector")).toBeInTheDocument();
   });
 });
 

--- a/frontend/tests/components/voyages/voyage-enroll-button.test.tsx
+++ b/frontend/tests/components/voyages/voyage-enroll-button.test.tsx
@@ -104,7 +104,7 @@ describe("VoyageEnrollButton", () => {
           voyageId={1}
           enrollment={inProgressEnrollment}
           completionPercentage={40}
-          firstIncompleteSlug="my-playlist"
+          firstIncompleteHref="/p/my-playlist"
         />,
       );
 
@@ -119,7 +119,7 @@ describe("VoyageEnrollButton", () => {
           voyageId={1}
           enrollment={inProgressEnrollment}
           completionPercentage={40}
-          firstIncompleteSlug="my-playlist"
+          firstIncompleteHref="/p/my-playlist"
         />,
       );
 
@@ -133,7 +133,7 @@ describe("VoyageEnrollButton", () => {
           voyageId={1}
           enrollment={inProgressEnrollment}
           completionPercentage={40}
-          firstIncompleteSlug="my-playlist"
+          firstIncompleteHref="/p/my-playlist"
         />,
       );
 

--- a/frontend/tests/lib/voyage-progress.test.ts
+++ b/frontend/tests/lib/voyage-progress.test.ts
@@ -1,8 +1,9 @@
-import { VoyageNode } from "@/types";
+import { Droplet, VoyageNode } from "@/types";
 import {
   computeNodeStatuses,
   computeCompletionPercentage,
   findFirstIncompleteNode,
+  isCompletableNode,
 } from "@/lib/voyage-progress";
 
 // ---------------------------------------------------------------------------
@@ -355,5 +356,234 @@ describe("findFirstIncompleteNode", () => {
     const result = findFirstIncompleteNode([main1, branch], new Set([1]));
     // main1 completed, no more main nodes -> null
     expect(result).toBeNull();
+  });
+
+  it("skips placeholder droplet nodes (no droplet linked)", () => {
+    const main1 = makeMainNode(1, 0);
+    const placeholder = makeMainNode(2, 1, {
+      nodeType: "droplet",
+      // droplet is undefined — placeholder
+    });
+    const main3 = makeMainNode(3, 2);
+
+    // Complete main1; placeholder is not completable, should be skipped
+    const result = findFirstIncompleteNode(
+      [main1, placeholder, main3],
+      new Set([1]),
+    );
+    expect(result?.id).toBe(3);
+  });
+
+  it("skips draft droplet nodes", () => {
+    const main1 = makeMainNode(1, 0);
+    const draftDropletNode = makeMainNode(2, 1, {
+      nodeType: "droplet",
+      droplet: { id: 99, status: "draft" } as Partial<Droplet> as Droplet,
+    });
+    const main3 = makeMainNode(3, 2);
+
+    const result = findFirstIncompleteNode(
+      [main1, draftDropletNode, main3],
+      new Set([1]),
+    );
+    expect(result?.id).toBe(3);
+  });
+
+  it("returns a published droplet node as first incomplete when not skipped", () => {
+    const main1 = makeMainNode(1, 0);
+    const publishedDropletNode = makeMainNode(2, 1, {
+      nodeType: "droplet",
+      droplet: { id: 99, status: "published" } as Partial<Droplet> as Droplet,
+    });
+
+    const result = findFirstIncompleteNode(
+      [main1, publishedDropletNode],
+      new Set([1]),
+    );
+    expect(result?.id).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCompletableNode
+// ---------------------------------------------------------------------------
+
+describe("isCompletableNode", () => {
+  it("returns true for playlist nodes (always have content)", () => {
+    const node = makeMainNode(1, 0, { nodeType: "playlist" });
+    expect(isCompletableNode(node)).toBe(true);
+  });
+
+  it("returns true for droplet nodes with a published droplet", () => {
+    const node = makeMainNode(1, 0, {
+      nodeType: "droplet",
+      droplet: { id: 1, status: "published" } as Partial<Droplet> as Droplet,
+    });
+    expect(isCompletableNode(node)).toBe(true);
+  });
+
+  it("returns false for droplet nodes with a draft droplet", () => {
+    const node = makeMainNode(1, 0, {
+      nodeType: "droplet",
+      droplet: { id: 1, status: "draft" } as Partial<Droplet> as Droplet,
+    });
+    expect(isCompletableNode(node)).toBe(false);
+  });
+
+  it("returns false for droplet nodes with an edit droplet", () => {
+    const node = makeMainNode(1, 0, {
+      nodeType: "droplet",
+      droplet: { id: 1, status: "edit" } as Partial<Droplet> as Droplet,
+    });
+    expect(isCompletableNode(node)).toBe(false);
+  });
+
+  it("returns false for placeholder droplet nodes (no droplet linked)", () => {
+    const node = makeMainNode(1, 0, {
+      nodeType: "droplet",
+      // no droplet field
+    });
+    expect(isCompletableNode(node)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeNodeStatuses — droplet node cases
+// ---------------------------------------------------------------------------
+
+describe("computeNodeStatuses — droplet node behavior", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("placeholder droplet node does NOT block next main node", () => {
+    const main1 = makeMainNode(1, 0);
+    const placeholder = makeMainNode(2, 1, {
+      nodeType: "droplet",
+      // no droplet — placeholder
+    });
+    const main3 = makeMainNode(3, 2);
+
+    // main1 completed; placeholder is non-completable, should not block main3
+    const statuses = computeNodeStatuses(
+      [main1, placeholder, main3],
+      new Set([1]),
+    );
+
+    expect(statuses.get(2)).toBe("available");
+    expect(statuses.get(3)).toBe("available");
+  });
+
+  it("draft droplet node does NOT block next main node", () => {
+    const main1 = makeMainNode(1, 0);
+    const draftNode = makeMainNode(2, 1, {
+      nodeType: "droplet",
+      droplet: { id: 99, status: "draft" } as Partial<Droplet> as Droplet,
+    });
+    const main3 = makeMainNode(3, 2);
+
+    const statuses = computeNodeStatuses(
+      [main1, draftNode, main3],
+      new Set([1]),
+    );
+
+    expect(statuses.get(2)).toBe("available");
+    expect(statuses.get(3)).toBe("available");
+  });
+
+  it("published droplet node DOES block next main node when incomplete", () => {
+    const main1 = makeMainNode(1, 0);
+    const publishedNode = makeMainNode(2, 1, {
+      nodeType: "droplet",
+      droplet: { id: 99, status: "published" } as Partial<Droplet> as Droplet,
+    });
+    const main3 = makeMainNode(3, 2);
+
+    // main1 completed but published droplet node not completed
+    const statuses = computeNodeStatuses(
+      [main1, publishedNode, main3],
+      new Set([1]),
+    );
+
+    expect(statuses.get(2)).toBe("available");
+    expect(statuses.get(3)).toBe("locked");
+  });
+
+  it("placeholder required branch does NOT block next main node", () => {
+    const main1 = makeMainNode(1, 0);
+    const placeholder = makeBranchNode(10, main1, {
+      nodeType: "droplet",
+      branchType: "required",
+      // no droplet — placeholder
+    });
+    main1.childNodes = [placeholder];
+    const main2 = makeMainNode(2, 1);
+
+    // main1 completed; placeholder required branch is non-completable, should not block
+    const statuses = computeNodeStatuses(
+      [main1, placeholder, main2],
+      new Set([1]),
+    );
+
+    expect(statuses.get(10)).toBe("available");
+    expect(statuses.get(2)).toBe("available");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCompletionPercentage — droplet node cases
+// ---------------------------------------------------------------------------
+
+describe("computeCompletionPercentage — droplet node behavior", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("excludes placeholder droplet nodes from the denominator", () => {
+    const main1 = makeMainNode(1, 0);
+    const placeholder = makeMainNode(2, 1, {
+      nodeType: "droplet",
+      // no droplet
+    });
+
+    // Only main1 counts; completing it => 100%
+    const pct = computeCompletionPercentage([main1, placeholder], new Set([1]));
+    expect(pct).toBe(100);
+  });
+
+  it("excludes draft droplet nodes from the denominator", () => {
+    const main1 = makeMainNode(1, 0);
+    const draftNode = makeMainNode(2, 1, {
+      nodeType: "droplet",
+      droplet: { id: 99, status: "draft" } as Partial<Droplet> as Droplet,
+    });
+
+    const pct = computeCompletionPercentage([main1, draftNode], new Set([1]));
+    expect(pct).toBe(100);
+  });
+
+  it("includes published droplet nodes in the denominator", () => {
+    const main1 = makeMainNode(1, 0);
+    const publishedNode = makeMainNode(2, 1, {
+      nodeType: "droplet",
+      droplet: { id: 99, status: "published" } as Partial<Droplet> as Droplet,
+    });
+
+    // main1 completed but publishedNode not -> 50%
+    const pct = computeCompletionPercentage(
+      [main1, publishedNode],
+      new Set([1]),
+    );
+    expect(pct).toBe(50);
+  });
+
+  it("returns 0 when all completable nodes are placeholders and none completed", () => {
+    const placeholder = makeMainNode(1, 0, {
+      nodeType: "droplet",
+      // no droplet
+    });
+
+    const pct = computeCompletionPercentage([placeholder], new Set());
+    expect(pct).toBe(0);
   });
 });

--- a/frontend/types/index.d.ts
+++ b/frontend/types/index.d.ts
@@ -119,7 +119,6 @@ export type NavItem = {
   href: string;
   label: string;
   isHidden?: boolean;
-  icon?: React.ReactNode;
 };
 
 export type GeneralConfig = {
@@ -474,11 +473,14 @@ export interface VoyageNode {
   id: number;
   isMainPath: boolean;
   branchType: "required" | "optional";
-  nodeType: "playlist" | "checkpoint";
+  nodeType: "playlist" | "droplet";
   orderIndex: number;
   label: string;
   voyage?: Voyage;
   playlist?: Playlist;
+  droplet?: Droplet;
+  claimedBy?: AuthorizedUser;
+  claimStatus?: "unclaimed" | "claimed" | "authored" | null;
   parentNode?: VoyageNode | null;
   childNodes?: VoyageNode[];
 }

--- a/frontend/types/index.d.ts
+++ b/frontend/types/index.d.ts
@@ -455,6 +455,7 @@ export type CreationRequest = {
   motivation: String;
   dropletIdea: String;
   user: AuthorizedUser;
+  voyageNode?: VoyageNode;
 };
 
 export interface Voyage {

--- a/frontend/types/index.d.ts
+++ b/frontend/types/index.d.ts
@@ -119,6 +119,7 @@ export type NavItem = {
   href: string;
   label: string;
   isHidden?: boolean;
+  icon?: React.ReactNode;
 };
 
 export type GeneralConfig = {


### PR DESCRIPTION
## Summary

Extends voyages to support individual droplet nodes alongside playlists, with a collaborative claiming system where faculty builds skeleton voyages and contributors claim placeholder nodes.

- **Mixed node types**: Voyage nodes can now be playlists, droplets, or unclaimed placeholders
- **Claiming flow**: Content Creators can claim unclaimed nodes, which creates a draft droplet and redirects to the editor. Non-creators see an inline application form to become a content creator.
- **Unclaimed page**: `/v/[slug]/unclaimed/[nodeId]` shows a centered CTA page for claiming or applying
- **Drag-and-drop reordering**: Replaced up/down arrows with `@dnd-kit/sortable` grip handles
- **Puddle SVGs**: Droplet nodes render as water puddle shapes (distinct from playlist palm tree islands)
- **Spotlight tour**: First-time users see a `driver.js` guided tour of the voyage builder
- **Completion pipeline**: Single-droplet nodes auto-complete when the droplet is finished; placeholder nodes don't block sequential progression
- **Form validation**: Zod schema validates before submission (circular refs, max nodes, etc.)

## Test plan

- [x] 302 test suites, 4338 tests passing (pre-push hook verified)
- [x] 3 CodeRabbit-style audits performed — all critical issues resolved
- [ ] Manual: create voyage with mixed playlist + droplet + placeholder nodes
- [ ] Manual: claim a placeholder node as Content Creator → verify draft droplet created
- [ ] Manual: visit unclaimed page as non-creator → verify application form shows
- [ ] Manual: verify existing playlist-only voyages display correctly (no regression)
- [ ] Manual: verify sequential progression skips placeholder nodes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added droplet nodes to voyages—individual content units that complement playlists
  * Enable users to claim unclaimed droplets and author content for them
  * Creation request form now includes voyage and node context for targeted submissions
  * Added guided tour for voyage creation workflow

* **Improvements**
  * Enhanced voyage display to show unclaimed vs. completed droplet counts
  * Refined completion tracking and progression logic to account for unclaimed and published droplets
  * Improved content creator authorization for claiming and authoring droplets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->