### PR TITLE
feat: presentation toggle + dark mode fixes

### DIFF
--- a/backend/src/api/droplet/content-types/droplet/schema.json
+++ b/backend/src/api/droplet/content-types/droplet/schema.json
@@ -177,6 +177,10 @@
       "relation": "oneToMany",
       "target": "api::dataset.dataset",
       "mappedBy": "droplet"
+    },
+    "presentationEnabled": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -969,6 +969,7 @@ export interface ApiDropletDroplet extends Schema.CollectionType {
       'manyToMany',
       'api::droplet.droplet'
     >;
+    presentationEnabled: Attribute.Boolean & Attribute.DefaultTo<false>;
     publishedAt: Attribute.DateTime;
     reviewDroplet: Attribute.Relation<
       'api::droplet.droplet',

--- a/frontend/app/(droplets)/d/[slug]/page.tsx
+++ b/frontend/app/(droplets)/d/[slug]/page.tsx
@@ -137,7 +137,7 @@ export default async function DropletRoute({ params }: Props) {
 
               <div className="mt-4 w-full rounded-lg border border-[#D0D5DD] bg-[#fcfcfd] p-8 dark:border-slate-500 dark:bg-slate-800">
                 <div
-                  className="prose prose-sky prose-code:text-inherit prose-strong:text-inherit prose-headings:text-inherit dark:text-slate-300"
+                  className="prose prose-sky prose-code:text-inherit prose-strong:text-inherit prose-headings:text-inherit max-w-none dark:text-slate-300"
                   dangerouslySetInnerHTML={{
                     __html: createDOMPurifier.sanitize(droplet.overview),
                   }}

--- a/frontend/app/(editing)/draft/d/[slug]/page.tsx
+++ b/frontend/app/(editing)/draft/d/[slug]/page.tsx
@@ -165,7 +165,9 @@ export default async function Droplet({ params }: Props) {
           ) : null}
 
           {droplet.status === "published" && (
-            <div className="p-2">This droplet is currently live</div>
+            <div className="p-2 dark:text-slate-200">
+              This droplet is currently live
+            </div>
           )}
           <div
             className={`pt-4 pb-4 ${droplet.status === "draft" && !droplet.inReview && isContentCreator(user.roles) ? "visibility: visible" : "visibility: hidden"} text-red-500 dark:text-red-300`}

--- a/frontend/app/(presentation)/d/[slug]/present/page.tsx
+++ b/frontend/app/(presentation)/d/[slug]/present/page.tsx
@@ -50,6 +50,16 @@ export default async function PresentationPage({ params }: Props) {
 
   if (!isAdmin && !isAuthor && !isEnrolled) return notFound();
 
+  // Block presentation if not enabled by the creator
+  if (!droplet.presentationEnabled) {
+    return (
+      <NoPresentationWarning
+        dropletSlug={slug}
+        isAuthorOrAdmin={isAdmin || isAuthor}
+      />
+    );
+  }
+
   const tags = [
     uppercaseFirstChar(droplet.focusArea),
     uppercaseFirstChar(droplet.type),
@@ -98,6 +108,7 @@ export default async function PresentationPage({ params }: Props) {
         tags={tags}
         sortedLessons={sortedLessons}
         lessonNames={lessonNames}
+        isAuthorOrAdmin={isAdmin || isAuthor}
       />
     </Suspense>
   );
@@ -110,6 +121,7 @@ async function LessonContentLoader({
   tags,
   sortedLessons,
   lessonNames,
+  isAuthorOrAdmin,
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   droplet: any;
@@ -117,6 +129,7 @@ async function LessonContentLoader({
   tags: string[];
   sortedLessons: { slug: string; name: string }[];
   lessonNames: string[];
+  isAuthorOrAdmin: boolean;
 }) {
   const lessonContents: Lesson[] = await Promise.all(
     sortedLessons.map((l) => getCachedLessonBySlug(l.slug)),
@@ -133,7 +146,12 @@ async function LessonContentLoader({
     .map((l) => l.name);
 
   if (nonEmptySlides.length === 0) {
-    return <NoPresentationWarning dropletSlug={slug} />;
+    return (
+      <NoPresentationWarning
+        dropletSlug={slug}
+        isAuthorOrAdmin={isAuthorOrAdmin}
+      />
+    );
   }
 
   return (

--- a/frontend/app/(presentation)/d/[slug]/present/page.tsx
+++ b/frontend/app/(presentation)/d/[slug]/present/page.tsx
@@ -52,12 +52,7 @@ export default async function PresentationPage({ params }: Props) {
 
   // Block presentation if not enabled by the creator
   if (!droplet.presentationEnabled) {
-    return (
-      <NoPresentationWarning
-        dropletSlug={slug}
-        isAuthorOrAdmin={isAdmin || isAuthor}
-      />
-    );
+    return <NoPresentationWarning dropletSlug={slug} reason="disabled" />;
   }
 
   const tags = [
@@ -108,7 +103,6 @@ export default async function PresentationPage({ params }: Props) {
         tags={tags}
         sortedLessons={sortedLessons}
         lessonNames={lessonNames}
-        isAuthorOrAdmin={isAdmin || isAuthor}
       />
     </Suspense>
   );
@@ -121,7 +115,6 @@ async function LessonContentLoader({
   tags,
   sortedLessons,
   lessonNames,
-  isAuthorOrAdmin,
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   droplet: any;
@@ -129,7 +122,6 @@ async function LessonContentLoader({
   tags: string[];
   sortedLessons: { slug: string; name: string }[];
   lessonNames: string[];
-  isAuthorOrAdmin: boolean;
 }) {
   const lessonContents: Lesson[] = await Promise.all(
     sortedLessons.map((l) => getCachedLessonBySlug(l.slug)),
@@ -146,12 +138,7 @@ async function LessonContentLoader({
     .map((l) => l.name);
 
   if (nonEmptySlides.length === 0) {
-    return (
-      <NoPresentationWarning
-        dropletSlug={slug}
-        isAuthorOrAdmin={isAuthorOrAdmin}
-      />
-    );
+    return <NoPresentationWarning dropletSlug={slug} reason="no-slides" />;
   }
 
   return (

--- a/frontend/components/draft/draft-layout-shell.tsx
+++ b/frontend/components/draft/draft-layout-shell.tsx
@@ -23,6 +23,7 @@ interface DraftLayoutShellProps {
     | "type"
     | "originalDropletId"
     | "difficulty"
+    | "presentationEnabled"
   >;
   availableDroplets: Pick<Droplet, "id" | "name" | "slug" | "lessons">[];
   children: React.ReactNode;

--- a/frontend/components/draft/metadata/learning-objectives/learning-objectives.tsx
+++ b/frontend/components/draft/metadata/learning-objectives/learning-objectives.tsx
@@ -104,7 +104,7 @@ export function LearningObjectives({
                   handleDraftChange(e.target.value);
                 }}
                 placeholder="New Learning Objective..."
-                className="placeholder:text-[#121216]"
+                className="placeholder:text-[#121216] dark:placeholder:text-slate-400"
                 autoComplete="off"
               />
               <AddButton />

--- a/frontend/components/draft/metadata/next-steps/next-steps.tsx
+++ b/frontend/components/draft/metadata/next-steps/next-steps.tsx
@@ -95,7 +95,7 @@ export function NextSteps({
                   setUrl(e.target.value);
                 }}
                 placeholder="URL"
-                className="placeholder:text-[#121216]"
+                className="placeholder:text-[#121216] dark:placeholder:text-slate-400"
                 autoComplete="off"
               />
               <Input
@@ -105,7 +105,7 @@ export function NextSteps({
                   setLabel(e.target.value);
                 }}
                 placeholder="Label"
-                className="placeholder:text-[#121216]"
+                className="placeholder:text-[#121216] dark:placeholder:text-slate-400"
                 autoComplete="off"
               />
               <AddButton />

--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -689,7 +689,10 @@ export function Sidebar({
                 role="switch"
                 aria-checked={presentationEnabled}
                 aria-label="Toggle presentation mode for viewers"
-                disabled={!hasSlideBreaks || isTogglingPresentation}
+                disabled={
+                  isTogglingPresentation ||
+                  (!hasSlideBreaks && !presentationEnabled)
+                }
                 onClick={handleTogglePresentation}
                 className={cn(
                   "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",

--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -71,6 +71,7 @@ import { SortableLesson } from "@/components/draft/sortable-lesson";
 import { useLessonOrder } from "./metadata/hooks/useLessonOrder";
 import { Button } from "../ui/button";
 import { createDropletAnnouncement } from "@/lib/requests/feed";
+import { togglePresentationEnabled } from "@/lib/requests/droplet";
 
 import { MantineProvider } from "@mantine/core";
 
@@ -98,6 +99,7 @@ export function Sidebar({
     | "type"
     | "originalDropletId"
     | "difficulty"
+    | "presentationEnabled"
   >;
   availableDroplets: Pick<Droplet, "id" | "name" | "slug" | "lessons">[];
   expanded: boolean;
@@ -123,6 +125,10 @@ export function Sidebar({
     return localStorage.getItem(`auto-formatted-${droplet.id}`) === "true";
   });
   const [showAutoFormatConfirm, setShowAutoFormatConfirm] = useState(false);
+  const [presentationEnabled, setPresentationEnabled] = useState(
+    () => droplet.presentationEnabled ?? false,
+  );
+  const [isTogglingPresentation, setIsTogglingPresentation] = useState(false);
   const lessons = (dropletLessons || [])
     .slice()
     .sort((a, b) => a.orderIndex - b.orderIndex);
@@ -284,6 +290,30 @@ export function Sidebar({
       toast.error("Failed to auto-format slides");
     } finally {
       setIsAutoFormatting(false);
+    }
+  };
+
+  const handleTogglePresentation = async () => {
+    const newValue = !presentationEnabled;
+    setIsTogglingPresentation(true);
+    setPresentationEnabled(newValue);
+    try {
+      const result = await togglePresentationEnabled(droplet.id, newValue);
+      if (!result.ok) {
+        setPresentationEnabled(!newValue);
+        toast.error("Failed to update presentation setting");
+      } else {
+        toast.success(
+          newValue
+            ? "Presentation enabled for viewers"
+            : "Presentation disabled for viewers",
+        );
+      }
+    } catch {
+      setPresentationEnabled(!newValue);
+      toast.error("Failed to update presentation setting");
+    } finally {
+      setIsTogglingPresentation(false);
     }
   };
 
@@ -478,8 +508,8 @@ export function Sidebar({
                     </TooltipTrigger>
                     <TooltipContent side="bottom">
                       {hasSlideBreaks
-                        ? "Present as slides"
-                        : "Add slide breaks to enable presentation mode"}
+                        ? "Preview presentation"
+                        : "Add slide breaks to preview presentation"}
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -636,6 +666,46 @@ export function Sidebar({
             id="tour-bottom-actions"
             className="border-t border-slate-200 p-3 dark:border-slate-700"
           >
+            <div className="mb-3 flex items-center justify-between px-1">
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <label className="flex items-center gap-2 text-xs font-medium text-slate-600 dark:text-slate-400">
+                      <IconPresentation className="h-3.5 w-3.5" />
+                      Presentation
+                    </label>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    {!hasSlideBreaks
+                      ? "Add slide breaks first to enable presentation for viewers"
+                      : presentationEnabled
+                        ? "Viewers can access presentation mode"
+                        : "Viewers cannot access presentation mode"}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={presentationEnabled}
+                aria-label="Toggle presentation mode for viewers"
+                disabled={!hasSlideBreaks || isTogglingPresentation}
+                onClick={handleTogglePresentation}
+                className={cn(
+                  "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+                  presentationEnabled
+                    ? "bg-indigo-500"
+                    : "bg-slate-200 dark:bg-slate-700",
+                )}
+              >
+                <span
+                  className={cn(
+                    "pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-lg ring-0 transition-transform",
+                    presentationEnabled ? "translate-x-4" : "translate-x-0",
+                  )}
+                />
+              </button>
+            </div>
             <div className="flex gap-2 [&>*]:flex-1 [&>a]:flex-1 [&>button]:flex-1">
               <Link
                 href={

--- a/frontend/components/droplets/droplet-layout-shell.tsx
+++ b/frontend/components/droplets/droplet-layout-shell.tsx
@@ -8,7 +8,10 @@ import { Droplet, User } from "@/types";
 interface DropletLayoutShellProps {
   user: User | null;
   author: boolean;
-  droplet: Pick<Droplet, "name" | "slug" | "lessons" | "status" | "id">;
+  droplet: Pick<
+    Droplet,
+    "name" | "slug" | "lessons" | "status" | "id" | "presentationEnabled"
+  >;
   completedLessonIds: number[];
   enrollmentId?: string;
   children: React.ReactNode;

--- a/frontend/components/droplets/sidebar.tsx
+++ b/frontend/components/droplets/sidebar.tsx
@@ -48,7 +48,10 @@ export default function Sidebar({
 }: {
   user?: User | null;
   author: boolean;
-  droplet: Pick<Droplet, "name" | "slug" | "lessons" | "status" | "id">;
+  droplet: Pick<
+    Droplet,
+    "name" | "slug" | "lessons" | "status" | "id" | "presentationEnabled"
+  >;
   completedLessonIds: number[];
   enrollmentId?: string | undefined;
   expanded: boolean;
@@ -63,7 +66,10 @@ export default function Sidebar({
   const isAdmin = user && isAuthorizedUserAdmin(user.roles);
 
   const isEnrolled = !!enrollmentId || author || isAdmin;
-  const canPresent = isEnrolled && (droplet.lessons?.length ?? 0) > 0;
+  const canPresent =
+    isEnrolled &&
+    (droplet.lessons?.length ?? 0) > 0 &&
+    droplet.presentationEnabled;
 
   const activeLinkClasses =
     "flex w-full items-center gap-3 rounded-xl px-3 py-2.5 transition-colors bg-[#287697]/10 text-[#287697] dark:bg-[#287697]/20 dark:text-[#4AABCF]";
@@ -263,13 +269,15 @@ export default function Sidebar({
                         <button
                           aria-disabled="true"
                           onClick={(e) => e.preventDefault()}
-                          className="cursor-not-allowed p-2 text-slate-400 dark:text-slate-600"
+                          className="cursor-not-allowed p-2 text-slate-300 dark:text-slate-700"
                         >
                           <IconPresentation className="h-5 w-5" />
                         </button>
                       )}
                     </TooltipTrigger>
-                    <TooltipContent side="bottom">Present</TooltipContent>
+                    <TooltipContent side="bottom">
+                      {canPresent ? "Present" : "Presentation not available"}
+                    </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
                 <button

--- a/frontend/components/new/learning-objectives-input.tsx
+++ b/frontend/components/new/learning-objectives-input.tsx
@@ -88,7 +88,7 @@ export function LearningObjectivesInput({
                   }
                 }}
                 placeholder="New Learning Objective..."
-                className="placeholder:text-[#121216]"
+                className="placeholder:text-[#121216] dark:placeholder:text-slate-400"
                 autoComplete="off"
               />
               <button

--- a/frontend/components/new/multi-select.tsx
+++ b/frontend/components/new/multi-select.tsx
@@ -92,7 +92,7 @@ export function MultiSelect({
                     <Badge
                       variant="outline"
                       key={option.id}
-                      className="flex items-center gap-1 rounded-full bg-white px-2 py-0.5 font-normal text-slate-800"
+                      className="flex items-center gap-1 rounded-full bg-white px-2 py-0.5 font-normal text-slate-800 dark:bg-slate-700 dark:text-slate-200"
                     >
                       {option.name}
                       <span

--- a/frontend/components/presentation/no-presentation-warning.tsx
+++ b/frontend/components/presentation/no-presentation-warning.tsx
@@ -2,26 +2,27 @@ import Link from "next/link";
 
 export function NoPresentationWarning({
   dropletSlug,
+  isAuthorOrAdmin = false,
 }: {
   dropletSlug: string;
+  isAuthorOrAdmin?: boolean;
 }) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-900">
       <div className="mx-auto max-w-md space-y-4 rounded-lg border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-700 dark:bg-slate-800">
-        <div className="text-4xl">No Presentation Found</div>
+        <h1 className="text-4xl">Presentation Not Available</h1>
         <p className="text-slate-600 dark:text-slate-400">
-          This droplet doesn&apos;t have any presentation slides yet. Add slide
-          breaks in the lesson editor using the{" "}
-          <kbd className="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-sm dark:bg-slate-700">
-            /
-          </kbd>{" "}
-          slash menu to create slides.
+          {isAuthorOrAdmin
+            ? "Presentation mode is not enabled for this droplet. Turn on the Presentation toggle in the editor sidebar to make it available."
+            : "Presentation mode is not available for this droplet yet."}
         </p>
         <Link
-          href={`/draft/d/${dropletSlug}`}
+          href={
+            isAuthorOrAdmin ? `/draft/d/${dropletSlug}` : `/d/${dropletSlug}`
+          }
           className="inline-block rounded-full bg-indigo-500 px-6 py-2 text-white hover:bg-indigo-600"
         >
-          Back to Editor
+          {isAuthorOrAdmin ? "Back to Editor" : "Back to Droplet"}
         </Link>
       </div>
     </div>

--- a/frontend/components/presentation/no-presentation-warning.tsx
+++ b/frontend/components/presentation/no-presentation-warning.tsx
@@ -2,27 +2,29 @@ import Link from "next/link";
 
 export function NoPresentationWarning({
   dropletSlug,
-  isAuthorOrAdmin = false,
+  reason = "disabled",
 }: {
   dropletSlug: string;
-  isAuthorOrAdmin?: boolean;
+  reason?: "disabled" | "no-slides";
 }) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-900">
       <div className="mx-auto max-w-md space-y-4 rounded-lg border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-700 dark:bg-slate-800">
-        <h1 className="text-4xl">Presentation Not Available</h1>
+        <h1 className="text-4xl">
+          {reason === "disabled"
+            ? "Presentation Not Available"
+            : "No Presentation Found"}
+        </h1>
         <p className="text-slate-600 dark:text-slate-400">
-          {isAuthorOrAdmin
+          {reason === "disabled"
             ? "Presentation mode is not enabled for this droplet. Turn on the Presentation toggle in the editor sidebar to make it available."
-            : "Presentation mode is not available for this droplet yet."}
+            : "This droplet doesn't have any presentation slides yet. Add slide breaks in the lesson editor to create slides."}
         </p>
         <Link
-          href={
-            isAuthorOrAdmin ? `/draft/d/${dropletSlug}` : `/d/${dropletSlug}`
-          }
+          href={`/draft/d/${dropletSlug}`}
           className="inline-block rounded-full bg-indigo-500 px-6 py-2 text-white hover:bg-indigo-600"
         >
-          {isAuthorOrAdmin ? "Back to Editor" : "Back to Droplet"}
+          Back to Editor
         </Link>
       </div>
     </div>

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-400 focus:border-slate-400 focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400",
+        "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-400 focus:border-slate-400 focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:ring-offset-slate-950 dark:placeholder:text-slate-500",
         className,
       )}
       ref={ref}

--- a/frontend/components/ui/label.tsx
+++ b/frontend/components/ui/label.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+  "text-sm font-medium leading-none text-slate-900 peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-slate-200",
 );
 
 const Label = React.forwardRef<

--- a/frontend/components/ui/tiptap/droplet-description-input.tsx
+++ b/frontend/components/ui/tiptap/droplet-description-input.tsx
@@ -20,7 +20,7 @@ export function DropletDescriptionInput({
       Placeholder.configure({
         placeholder: "Nothing here yet...",
         emptyEditorClass:
-          "before:content-[attr(data-placeholder)] before:text-[#121216] before:absolute before:top-8 before:left-8 before:pointer-events-none before:select-none",
+          "before:content-[attr(data-placeholder)] before:text-slate-400 before:absolute before:top-8 before:left-8 before:pointer-events-none before:select-none dark:before:text-slate-500",
       }),
       Text,
     ],
@@ -33,7 +33,7 @@ export function DropletDescriptionInput({
     editorProps: {
       attributes: {
         class:
-          "prose prose-sky w-full h-full p-8 border rounded-lg bg-[#fcfcfd] dark:bg-slate-800 border-[#D0D5DD] dark:text-slate-300 dark:border-slate-600 hover:border-slate-400 focus:border-[#2D7597] transition-colors outline-none cursor-text",
+          "prose prose-sky w-full h-full p-8 border rounded-lg bg-[#fcfcfd] dark:bg-slate-900 border-[#D0D5DD] dark:text-slate-200 dark:border-slate-600 hover:border-slate-400 focus:border-[#2D7597] transition-colors outline-none cursor-text",
       },
     },
     immediatelyRender: false,

--- a/frontend/components/ui/tiptap/droplet-overview-input.tsx
+++ b/frontend/components/ui/tiptap/droplet-overview-input.tsx
@@ -30,7 +30,7 @@ export function DropletOverviewInput({
       Placeholder.configure({
         placeholder: "Nothing here yet...",
         emptyEditorClass:
-          "before:content-[attr(data-placeholder)] before:text-[#121216] before:absolute before:top-8 before:left-8 before:pointer-events-none before:select-none",
+          "before:content-[attr(data-placeholder)] before:text-slate-400 before:absolute before:top-8 before:left-8 before:pointer-events-none before:select-none dark:before:text-slate-500",
       }),
       Text,
       Link.configure({
@@ -53,7 +53,7 @@ export function DropletOverviewInput({
     editorProps: {
       attributes: {
         class:
-          "prose prose-sky w-full h-full p-8 border rounded-lg bg-[#fcfcfd] dark:bg-slate-800 border-[#D0D5DD] dark:text-slate-300 dark:border-slate-600 hover:border-slate-400 focus:border-[#2D7597] transition-colors outline-none cursor-text",
+          "prose prose-sky w-full h-full p-8 border rounded-lg bg-[#fcfcfd] dark:bg-slate-900 border-[#D0D5DD] dark:text-slate-200 dark:border-slate-600 hover:border-slate-400 focus:border-[#2D7597] transition-colors outline-none cursor-text",
       },
     },
     immediatelyRender: false,

--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -906,7 +906,7 @@ export function VoyageForm({
             type="button"
             onClick={() => handleSubmit("published")}
             disabled={isPending}
-            className="flex-1 bg-[#297496] hover:bg-[#225f7a]"
+            className="flex-1 bg-[#297496] text-white hover:bg-[#225f7a] dark:bg-[#297496] dark:text-white dark:hover:bg-[#225f7a]"
           >
             {isPending && isEditing && "Updating..."}
             {isPending && !isEditing && "Publishing..."}
@@ -918,7 +918,7 @@ export function VoyageForm({
             variant="outline"
             onClick={() => handleSubmit("draft")}
             disabled={isPending}
-            className="flex-1 border-[#297496] text-[#297496] hover:bg-[#297496]/10"
+            className="flex-1 border-[#297496] text-[#297496] hover:bg-[#297496]/10 dark:border-[#4AABCF] dark:bg-transparent dark:text-[#4AABCF] dark:hover:bg-[#297496]/20"
           >
             {isPending && "Saving..."}
             {!isPending && isEditing && "Save Changes"}

--- a/frontend/lib/requests/droplet.ts
+++ b/frontend/lib/requests/droplet.ts
@@ -296,6 +296,9 @@ export async function updateDroplet(
       ...(data.authorized_users && { authorized_users: data.authorized_users }),
       ...(data.tagIds && { tags: data.tagIds }),
       ...(data.isHidden !== undefined && { isHidden: data.isHidden }),
+      ...(data.presentationEnabled !== undefined && {
+        presentationEnabled: data.presentationEnabled,
+      }),
       ...(data.learningObjectives && {
         learningObjectives: data.learningObjectives.map((obj) => ({
           objective: obj,
@@ -364,6 +367,13 @@ export async function updateDroplet(
       data: null,
     };
   }
+}
+
+export async function togglePresentationEnabled(
+  dropletId: number,
+  enabled: boolean,
+) {
+  return updateDroplet(dropletId, { presentationEnabled: enabled });
 }
 
 export async function archiveDroplet(droplet: Droplet, archiveState: boolean) {

--- a/frontend/lib/requests/droplet.ts
+++ b/frontend/lib/requests/droplet.ts
@@ -2,7 +2,7 @@
 
 import { Droplet } from "@/types";
 import { StrapiRequestParams } from "@/types/strapi";
-import { fetchAPI } from "../utils";
+import { fetchAPI, isAuthorizedUserAdmin } from "../utils";
 import { revalidateTag } from "next/cache";
 import { deleteLesson } from "./lesson";
 import { DropletSchema } from "../validations/droplet";
@@ -373,6 +373,25 @@ export async function togglePresentationEnabled(
   dropletId: number,
   enabled: boolean,
 ) {
+  const user = await getCurrentUser();
+  if (!user?.email) {
+    return { ok: false, error: "Unauthorized", data: null };
+  }
+
+  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  const droplet = await getDropletById(dropletId, {
+    fields: ["id"],
+    populate: { authorized_users: { fields: ["id"] } },
+  });
+
+  const isAuthor =
+    droplet.authorized_users?.some(
+      (u: { id: number }) => u.id === authorizedUser.id,
+    ) ?? false;
+  if (!isAuthor && !isAuthorizedUserAdmin(user.roles)) {
+    return { ok: false, error: "Forbidden", data: null };
+  }
+
   return updateDroplet(dropletId, { presentationEnabled: enabled });
 }
 

--- a/frontend/lib/validations/droplet.ts
+++ b/frontend/lib/validations/droplet.ts
@@ -19,6 +19,7 @@ export const DropletSchema = z.object({
   difficulty: z.enum(difficulties),
   tagIds: z.number().array(),
   isHidden: z.boolean().optional(),
+  presentationEnabled: z.boolean().optional(),
   learningObjectives: z.string().min(2).max(200).array(),
   prerequisiteIds: z.number().array(),
   postrequisiteIds: z.number().array(),

--- a/frontend/tests/components/draft/sidebar.test.tsx
+++ b/frontend/tests/components/draft/sidebar.test.tsx
@@ -107,6 +107,7 @@ describe("Sidebar", () => {
     type: "knowledge" as DropletType,
     focusArea: "personal" as FocusArea,
     isHidden: false,
+    presentationEnabled: false,
     learningObjectives: [],
     inReview: false,
     afterReview: undefined,

--- a/frontend/tests/components/droplets/sidebar.test.tsx
+++ b/frontend/tests/components/droplets/sidebar.test.tsx
@@ -46,6 +46,7 @@ describe("Sidebar", () => {
     name: "Test Droplet",
     slug: "test-droplet",
     status: "published" as const, // Add this
+    presentationEnabled: true,
     lessons: [
       {
         orderIndex: 0,

--- a/frontend/types/index.d.ts
+++ b/frontend/types/index.d.ts
@@ -251,6 +251,7 @@ export type Droplet = {
   averageRating?: number;
   usersFavorited?: AuthorizedUser[];
   datasets?: Dataset[];
+  presentationEnabled?: boolean;
 };
 
 export type QuizAnswerOption = {


### PR DESCRIPTION
## Summary
- Adds `presentationEnabled` boolean toggle to the droplet draft sidebar so creators control when viewers can access presentation mode
- Present button is greyed out on the public page when disabled; direct URL shows a friendly warning with context-appropriate messaging (author vs viewer)
- Existing droplets default to presentation off — creators must enable explicitly
- Fixes dark mode across base Input/Label components, TipTap editors, multi-select badges, voyage form buttons, and placeholder text

## Test plan
- [ ] Verify Present button is greyed out on public droplet page for existing droplets
- [ ] Navigate to `/d/{slug}/present` directly — should show "Presentation Not Available" warning
- [ ] On draft page, toggle Presentation on (requires slide breaks) — verify toast feedback
- [ ] After enabling, verify Present button becomes clickable on public page
- [ ] Check dark mode on: draft page editors, voyage form, multi-select dropdowns, input fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a presentation mode toggle for droplets, allowing creators to enable/disable presentation functionality per droplet with a sidebar switch.
  * Updated presentation access messaging to display role-specific guidance.

* **Style**
  * Enhanced dark mode styling across input fields, labels, editors, buttons, and UI components for improved consistency and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->