### PR TITLE
fix: draft editor stability — auto-save, memory, and layout fixes

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,8 +2,6 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-ENV NODE_OPTIONS=--max-old-space-size=2048
-
 COPY package*.json ./
 
 RUN npm install --include=dev

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,8 @@ FROM node:22-alpine
 
 WORKDIR /app
 
+ENV NODE_OPTIONS=--max-old-space-size=2048
+
 COPY package*.json ./
 
 RUN npm install --include=dev

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -55,9 +55,7 @@ export default function RootLayout({
                     </div>
 
                     <main className="flex-grow">{children}</main>
-                    <div className="scale-x-80 md:scale-x-100">
-                      <Footer />
-                    </div>
+                    <Footer />
                   </div>
                   <Suspense fallback={null}>
                     <FirstVisitPopupLoader />

--- a/frontend/components/draft/lesson/blocks/generic.tsx
+++ b/frontend/components/draft/lesson/blocks/generic.tsx
@@ -27,7 +27,7 @@ export function GenericEditor({
   };
 
   return (
-    <div className="w-full max-w-2xl rounded-md border border-[#D0D5DD] p-4 hover:shadow-md dark:border-slate-600">
+    <div className="w-full rounded-md border border-[#D0D5DD] p-4 hover:shadow-md dark:border-slate-600">
       <div className="mb-4 flex w-full flex-row items-center justify-between">
         <h2 className="text-lg">Text Block</h2>
         <Trash2Icon

--- a/frontend/components/draft/lesson/blocks/open-ended-quiz.tsx
+++ b/frontend/components/draft/lesson/blocks/open-ended-quiz.tsx
@@ -68,7 +68,7 @@ export function OpenEndedQuizEditor({
   };
 
   return (
-    <div className="w-full max-w-2xl">
+    <div className="w-full">
       <div className="flex w-full flex-row items-center justify-between p-4">
         <h2 className="text-lg">Open Ended Quiz</h2>
         <Trash2Icon

--- a/frontend/components/draft/lesson/blocks/quiz.tsx
+++ b/frontend/components/draft/lesson/blocks/quiz.tsx
@@ -89,7 +89,7 @@ export function QuizEditor({
     questions[0]?.answerOptions?.[0]?.content === "True";
 
   return (
-    <div className="w-full max-w-2xl pb-4">
+    <div className="w-full pb-4">
       <div className="mb-4 flex w-full flex-row items-center justify-between p-4">
         <h2 className="text-lg">
           {isTrueFalse ? "True/False Quiz" : "Multiple Choice Quiz"}

--- a/frontend/components/draft/lesson/lesson-renderer.tsx
+++ b/frontend/components/draft/lesson/lesson-renderer.tsx
@@ -206,7 +206,7 @@ export function LessonRenderer({
     if (editorVersion !== "v1") return;
     debounceUpdate(blocks);
     return () => {
-      debounceUpdate.cancel();
+      debounceUpdate.flush();
     };
   }, [blocks, debounceUpdate, editorVersion]);
 

--- a/frontend/components/draft/lesson/lesson-renderer.tsx
+++ b/frontend/components/draft/lesson/lesson-renderer.tsx
@@ -31,7 +31,11 @@ import { getDropletBySlug } from "@/lib/requests/droplet";
 import { Block } from "@/types";
 import type { Block as BlockNoteBlock } from "@blocknote/core";
 import { toast } from "sonner";
-import { deleteLesson, updateLesson } from "@/lib/requests/lesson";
+import {
+  deleteLesson,
+  updateLesson,
+  revalidateLesson,
+} from "@/lib/requests/lesson";
 import AddLessonBlock from "./add-tools";
 import { BlockNoteEditor } from "./blocknote-editor";
 import { SLIDE_BREAK_MARKER } from "@/lib/blocknote/slide-break";
@@ -130,9 +134,11 @@ export function LessonRenderer({
 
   const updateBlocksBackend = useCallback(
     async (blocks: Block[]) => {
-      const response = await updateLesson(lesson.id, {
-        blocks: blocks as unknown as BaseBlock[],
-      });
+      const response = await updateLesson(
+        lesson.id,
+        { blocks: blocks as unknown as BaseBlock[] },
+        { skipRevalidation: true },
+      );
 
       if (!response || response.error || !response.ok) {
         return;
@@ -143,10 +149,11 @@ export function LessonRenderer({
 
   const updateBlocksV2Backend = useCallback(
     async (blocksV2: unknown) => {
-      const response = await updateLesson(lesson.id, {
-        blocksV2,
-        blocksVersion: "v2",
-      });
+      const response = await updateLesson(
+        lesson.id,
+        { blocksV2, blocksVersion: "v2" },
+        { skipRevalidation: true },
+      );
 
       if (!response || response.error || !response.ok) {
         return;
@@ -156,7 +163,7 @@ export function LessonRenderer({
   );
 
   const debounceUpdateV2 = useMemo(
-    () => debounce(updateBlocksV2Backend, 1000, { maxWait: 3000 }),
+    () => debounce(updateBlocksV2Backend, 1500, { maxWait: 4000 }),
     [updateBlocksV2Backend],
   );
 
@@ -183,9 +190,17 @@ export function LessonRenderer({
   );
 
   const debounceUpdate = useMemo(
-    () => debounce(updateBlocksBackend, 1000, { maxWait: 3000 }),
+    () => debounce(updateBlocksBackend, 1500, { maxWait: 4000 }),
     [updateBlocksBackend],
   );
+
+  // Revalidate lesson cache once when leaving the editor,
+  // so navigating back serves fresh data from Strapi.
+  useEffect(() => {
+    return () => {
+      revalidateLesson().catch(() => {});
+    };
+  }, []);
 
   useEffect(() => {
     if (editorVersion !== "v1") return;

--- a/frontend/components/droplets/lessons/droplet-lesson-wrapper.tsx
+++ b/frontend/components/droplets/lessons/droplet-lesson-wrapper.tsx
@@ -62,7 +62,12 @@ export function DropletLessonWrapper({
   return (
     <>
       <div className="lesson-wrapper relative z-30 h-full w-full overflow-x-hidden">
-        <div className="flex w-full flex-col px-40 pt-6">
+        <div
+          className={cn(
+            "flex w-full flex-col px-40 pt-6 transition-[padding] duration-300",
+            expanded && "pr-[415px]",
+          )}
+        >
           <LessonRenderer
             lesson={lesson}
             droplet={droplet}

--- a/frontend/components/droplets/lessons/generic-block-renderer.tsx
+++ b/frontend/components/droplets/lessons/generic-block-renderer.tsx
@@ -715,7 +715,7 @@ const GenericBlockRenderer: React.FC<GenericBlockRendererProps> = ({
           onMouseUp={() => handleMouseUp()}
           onMouseDown={(e) => handleMouseDown(e)}
           onClick={handleContentClick}
-          className="prose prose-lg prose-sky prose-table:block prose-code:text-inherit prose-table:overflow-x-scroll prose-p:my-1 prose-li:my-1 prose-headings:text-inherit prose-strong:text-inherit select-text dark:text-slate-300"
+          className="prose prose-lg prose-sky prose-table:block prose-code:text-inherit prose-table:overflow-x-scroll prose-p:my-1 prose-li:my-1 prose-headings:text-inherit prose-strong:text-inherit max-w-none select-text dark:text-slate-300"
           dangerouslySetInnerHTML={{
             __html: DOMPurify.sanitize(nonTableContent),
           }}

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -444,7 +444,7 @@ function LessonBlockRenderer({
           )}
 
           <div className="">
-            <div className="prose prose-sky prose-headings:text-inherit prose-code:text-inherit prose-strong:text-inherit justify-left prose-li:marker:text-slate-700 mx-auto text-black">
+            <div className="prose prose-sky prose-headings:text-inherit prose-code:text-inherit prose-strong:text-inherit justify-left prose-li:marker:text-slate-700 mx-auto max-w-none text-black">
               <BlocksRenderer content={block.content} />
             </div>
           </div>
@@ -460,7 +460,7 @@ function LessonBlockRenderer({
           </CollapsibleTrigger>
           <CollapsibleContent className="mt-4 border-t border-t-slate-200 pt-3 dark:border-slate-500">
             <div
-              className="prose prose-sky prose-headings:text-inherit prose-strong:text-inherit prose-code:text-inherit dark:text-slate-300"
+              className="prose prose-sky prose-headings:text-inherit prose-strong:text-inherit prose-code:text-inherit max-w-none dark:text-slate-300"
               dangerouslySetInnerHTML={{ __html: block.content }}
             ></div>
           </CollapsibleContent>

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -462,7 +462,9 @@ function LessonBlockRenderer({
           <CollapsibleContent className="mt-4 border-t border-t-slate-200 pt-3 dark:border-slate-500">
             <div
               className="prose prose-sky prose-headings:text-inherit prose-strong:text-inherit prose-code:text-inherit max-w-none dark:text-slate-300"
-              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(block.content) }}
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(block.content),
+              }}
             ></div>
           </CollapsibleContent>
         </Collapsible>

--- a/frontend/components/droplets/lessons/lesson-renderer.tsx
+++ b/frontend/components/droplets/lessons/lesson-renderer.tsx
@@ -40,6 +40,7 @@ import { NotebookCodeViewer } from "@/components/notebook/notebook-code-viewer";
 import { PyodideProvider } from "@/lib/pyodide/pyodide-context";
 import { DatasetProvider } from "@/lib/contexts/dataset-context";
 import dynamic from "next/dynamic";
+import DOMPurify from "isomorphic-dompurify";
 
 const SandpackViewer = dynamic(
   () =>
@@ -461,7 +462,7 @@ function LessonBlockRenderer({
           <CollapsibleContent className="mt-4 border-t border-t-slate-200 pt-3 dark:border-slate-500">
             <div
               className="prose prose-sky prose-headings:text-inherit prose-strong:text-inherit prose-code:text-inherit max-w-none dark:text-slate-300"
-              dangerouslySetInnerHTML={{ __html: block.content }}
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(block.content) }}
             ></div>
           </CollapsibleContent>
         </Collapsible>

--- a/frontend/components/footer/page.tsx
+++ b/frontend/components/footer/page.tsx
@@ -11,70 +11,72 @@ export default async function Footer() {
   const linkStyles =
     "text-xs font-regular md:text-base text-white hover:scale-105";
   return (
-    <footer className="relative z-50 flex w-full flex-col items-center bg-[#83C1E1] dark:bg-[#3A6B85]">
-      <Wave
-        fill="#2F5569"
-        paused={false}
-        style={{ display: "flex" }}
-        options={{
-          height: 2,
-          amplitude: 20,
-          speed: 0.15,
-          points: 3,
-        }}
-        className="bg-transparent dark:bg-transparent"
-      />
+    <footer className="relative z-50 w-full scale-x-80 bg-[#83C1E1] md:scale-x-100 dark:bg-[#3A6B85]">
+      <div className="flex w-full flex-col items-center">
+        <Wave
+          fill="#2F5569"
+          paused={false}
+          style={{ display: "flex" }}
+          options={{
+            height: 2,
+            amplitude: 20,
+            speed: 0.15,
+            points: 3,
+          }}
+          className="bg-transparent dark:bg-transparent"
+        />
 
-      <div className="-my-24 flex h-[150px] w-full flex-row justify-between bg-[#2F5569] px-6 pb-6 md:px-16">
-        <div className="flex w-1/2 flex-row justify-start gap-4 md:w-1/4">
-          <Separator
-            orientation={"vertical"}
-            className="h-full w-[1.5px] bg-slate-200 dark:bg-slate-200"
-          />
-          <div className="flex flex-col items-center justify-between py-2">
-            <Link className={linkStyles} href="/about">
-              About Odyssey
-            </Link>
-            <Link className={linkStyles} href="/features">
-              Features
-            </Link>
-            <Link className={linkStyles} href="/contributors">
-              Contributors
-            </Link>
-          </div>
-        </div>
-        <div className="hidden w-1/2 items-center justify-center md:flex">
-          <Link href="/">
-            <Image
-              src={"/circular_logo.svg"}
-              alt="Khoury Odyssey Logo"
-              width={100}
-              height={100}
-              priority
-              className="hover:scale-105"
+        <div className="-my-24 flex h-[150px] w-full flex-row justify-between bg-[#2F5569] px-6 pb-6 md:px-16">
+          <div className="flex w-1/2 flex-row justify-start gap-4 md:w-1/4">
+            <Separator
+              orientation={"vertical"}
+              className="h-full w-[1.5px] bg-slate-200 dark:bg-slate-200"
             />
-          </Link>
-        </div>
-        <div className="flex w-1/2 flex-col items-end justify-center gap-3 md:w-1/4">
-          <div className="flex flex-row items-center gap-2">
-            <Link
-              href="https://github.com/KhourySpecialProjects/odyssey"
-              role="link"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <div className="flex flex-col items-center justify-between py-2">
+              <Link className={linkStyles} href="/about">
+                About Odyssey
+              </Link>
+              <Link className={linkStyles} href="/features">
+                Features
+              </Link>
+              <Link className={linkStyles} href="/contributors">
+                Contributors
+              </Link>
+            </div>
+          </div>
+          <div className="hidden w-1/2 items-center justify-center md:flex">
+            <Link href="/">
               <Image
-                src={"/github.svg"}
-                alt="Odyssey Github Repo"
-                width={40}
-                height={40}
+                src={"/circular_logo.svg"}
+                alt="Khoury Odyssey Logo"
+                width={100}
+                height={100}
                 priority
                 className="hover:scale-105"
               />
             </Link>
-            <DarkMode className="" />
           </div>
-          <ReportBugButton user={user} />
+          <div className="flex w-1/2 flex-col items-end justify-center gap-3 md:w-1/4">
+            <div className="flex flex-row items-center gap-2">
+              <Link
+                href="https://github.com/KhourySpecialProjects/odyssey"
+                role="link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Image
+                  src={"/github.svg"}
+                  alt="Odyssey Github Repo"
+                  width={40}
+                  height={40}
+                  priority
+                  className="hover:scale-105"
+                />
+              </Link>
+              <DarkMode className="" />
+            </div>
+            <ReportBugButton user={user} />
+          </div>
         </div>
       </div>
     </footer>

--- a/frontend/components/ui/tiptap/generic-block-input.tsx
+++ b/frontend/components/ui/tiptap/generic-block-input.tsx
@@ -88,7 +88,7 @@ export function GenericBlockInput({
     editorProps: {
       attributes: {
         class:
-          "w-full border min-h-32 prose-code:text-inherit border-slate-200 dark:border-slate-500 p-3 prose prose-lg prose-p:my-1 prose-li:my-1 prose-sky prose-headings:text-inherit prose-strong:text-inherit prose-table:block prose-table:overflow-x-scroll rounded-b-md hover:shadow focus:shadow-lg outline-none dark:text-slate-300",
+          "w-full border min-h-32 prose-code:text-inherit border-slate-200 dark:border-slate-500 p-3 prose prose-lg max-w-none prose-p:my-1 prose-li:my-1 prose-sky prose-headings:text-inherit prose-strong:text-inherit prose-table:block prose-table:overflow-x-scroll rounded-b-md hover:shadow focus:shadow-lg outline-none dark:text-slate-300",
       },
       handleKeyDown: (view: EditorView, event: KeyboardEvent) => {
         if (event.key === "Tab") {

--- a/frontend/hooks/useEditingLock.ts
+++ b/frontend/hooks/useEditingLock.ts
@@ -128,42 +128,54 @@ export function useEditingLock(lessonId: number) {
     };
 
     const init = async () => {
-      const userId = await getCurrentAuthorizedUserId();
-      if (!mountedRef.current) return;
-      userIdRef.current = userId;
+      try {
+        const userId = await getCurrentAuthorizedUserId();
+        if (!mountedRef.current) return;
+        userIdRef.current = userId;
 
-      if (!userId) {
-        setState({
-          isLocked: false,
-          isOwnLock: false,
-          lockedBy: null,
-          isLoading: false,
-          error: "Could not resolve your user account",
-        });
-        return;
-      }
+        if (!userId) {
+          setState({
+            isLocked: false,
+            isOwnLock: false,
+            lockedBy: null,
+            isLoading: false,
+            error: "Could not resolve your user account",
+          });
+          return;
+        }
 
-      const result = await acquireLessonLock(lessonId);
-      if (!mountedRef.current) return;
+        const result = await acquireLessonLock(lessonId);
+        if (!mountedRef.current) return;
 
-      if (result.success) {
-        setState({
-          isLocked: true,
-          isOwnLock: true,
-          lockedBy: null,
-          isLoading: false,
-          error: null,
-        });
-        startHeartbeat();
-      } else {
-        setState({
-          isLocked: true,
-          isOwnLock: false,
-          lockedBy: result.lockedBy ?? null,
-          isLoading: false,
-          error: result.lockedBy ? null : result.error ?? null,
-        });
-        startPolling();
+        if (result.success) {
+          setState({
+            isLocked: true,
+            isOwnLock: true,
+            lockedBy: null,
+            isLoading: false,
+            error: null,
+          });
+          startHeartbeat();
+        } else {
+          setState({
+            isLocked: true,
+            isOwnLock: false,
+            lockedBy: result.lockedBy ?? null,
+            isLoading: false,
+            error: result.lockedBy ? null : result.error ?? null,
+          });
+          startPolling();
+        }
+      } catch {
+        if (mountedRef.current) {
+          setState({
+            isLocked: false,
+            isOwnLock: false,
+            lockedBy: null,
+            isLoading: false,
+            error: "Failed to initialize editing lock",
+          });
+        }
       }
     };
 

--- a/frontend/hooks/useEditingLock.ts
+++ b/frontend/hooks/useEditingLock.ts
@@ -55,23 +55,31 @@ export function useEditingLock(lessonId: number) {
     const startHeartbeat = () => {
       clearTimeout(heartbeatRef.current);
       const tick = async () => {
-        const uid = userIdRef.current;
-        if (!uid || !mountedRef.current) return;
-        const ok = await heartbeatLessonLock(lessonId);
-        if (!mountedRef.current) return;
-        if (!ok) {
-          // Lock was lost — switch to polling
-          setState({
-            isLocked: true,
-            isOwnLock: false,
-            lockedBy: null,
-            isLoading: false,
-            error: null,
-          });
-          startPolling();
-          return;
+        try {
+          const uid = userIdRef.current;
+          if (!uid || !mountedRef.current) return;
+          const ok = await heartbeatLessonLock(lessonId);
+          if (!mountedRef.current) return;
+          if (!ok) {
+            // Lock was lost — switch to polling
+            setState({
+              isLocked: true,
+              isOwnLock: false,
+              lockedBy: null,
+              isLoading: false,
+              error: null,
+            });
+            startPolling();
+            return;
+          }
+          heartbeatRef.current = setTimeout(tick, HEARTBEAT_INTERVAL);
+        } catch {
+          // Server action failed (network error, server restart, etc.)
+          // Schedule a retry instead of leaving an unhandled rejection
+          if (mountedRef.current) {
+            heartbeatRef.current = setTimeout(tick, HEARTBEAT_INTERVAL);
+          }
         }
-        heartbeatRef.current = setTimeout(tick, HEARTBEAT_INTERVAL);
       };
       heartbeatRef.current = setTimeout(tick, HEARTBEAT_INTERVAL);
     };
@@ -79,35 +87,42 @@ export function useEditingLock(lessonId: number) {
     const startPolling = () => {
       clearTimeout(pollRef.current);
       const tick = async () => {
-        if (!mountedRef.current) return;
-        const uid = userIdRef.current;
-        if (!uid) return;
-
-        const status = await getLessonLockStatus(lessonId);
-        if (!mountedRef.current) return;
-
-        if (!status.isLocked) {
-          const result = await acquireLessonLock(lessonId);
+        try {
           if (!mountedRef.current) return;
-          if (result.success) {
-            setState({
-              isLocked: true,
-              isOwnLock: true,
-              lockedBy: null,
-              isLoading: false,
-              error: null,
+          const uid = userIdRef.current;
+          if (!uid) return;
+
+          const status = await getLessonLockStatus(lessonId);
+          if (!mountedRef.current) return;
+
+          if (!status.isLocked) {
+            const result = await acquireLessonLock(lessonId);
+            if (!mountedRef.current) return;
+            if (result.success) {
+              setState({
+                isLocked: true,
+                isOwnLock: true,
+                lockedBy: null,
+                isLoading: false,
+                error: null,
+              });
+              startHeartbeat();
+              return;
+            }
+          } else {
+            // Only update state if lockedBy actually changed
+            setState((prev) => {
+              if (prev.lockedBy?.id === status.lockedBy?.id) return prev;
+              return { ...prev, lockedBy: status.lockedBy };
             });
-            startHeartbeat();
-            return;
           }
-        } else {
-          // Only update state if lockedBy actually changed
-          setState((prev) => {
-            if (prev.lockedBy?.id === status.lockedBy?.id) return prev;
-            return { ...prev, lockedBy: status.lockedBy };
-          });
+          pollRef.current = setTimeout(tick, POLL_INTERVAL);
+        } catch {
+          // Server action failed — retry on next interval
+          if (mountedRef.current) {
+            pollRef.current = setTimeout(tick, POLL_INTERVAL);
+          }
         }
-        pollRef.current = setTimeout(tick, POLL_INTERVAL);
       };
       pollRef.current = setTimeout(tick, POLL_INTERVAL);
     };
@@ -159,7 +174,7 @@ export function useEditingLock(lessonId: number) {
       clearTimeout(heartbeatRef.current);
       clearTimeout(pollRef.current);
       const uid = userIdRef.current;
-      if (uid) releaseLessonLock(lessonId);
+      if (uid) releaseLessonLock(lessonId).catch(() => {});
     };
   }, [lessonId]);
 

--- a/frontend/hooks/useEditingLock.ts
+++ b/frontend/hooks/useEditingLock.ts
@@ -109,6 +109,12 @@ export function useEditingLock(lessonId: number) {
               startHeartbeat();
               return;
             }
+            // Acquire failed (race with another editor) — update state
+            setState((prev) => ({
+              ...prev,
+              lockedBy: result.lockedBy ?? prev.lockedBy,
+              isLoading: false,
+            }));
           } else {
             // Only update state if lockedBy actually changed
             setState((prev) => {

--- a/frontend/lib/requests/lesson.ts
+++ b/frontend/lib/requests/lesson.ts
@@ -157,9 +157,14 @@ export async function deleteLesson(id: number, revalidate: boolean = true) {
 export async function updateLesson(
   id: number,
   data: Partial<z.infer<typeof LessonSchema>>,
-  options: { reload?: boolean; regenerateSlug?: boolean } = {
+  options: {
+    reload?: boolean;
+    regenerateSlug?: boolean;
+    skipRevalidation?: boolean;
+  } = {
     reload: false,
     regenerateSlug: false,
+    skipRevalidation: false,
   },
 ) {
   try {
@@ -195,9 +200,11 @@ export async function updateLesson(
       return { ok: false, error: errorMessage, data: null };
     }
 
-    revalidateTag(CACHE_TAGS.droplets);
-    revalidateTag(CACHE_TAGS.lesson);
-    revalidateTag(CACHE_TAGS.allEnrollments);
+    if (!options.skipRevalidation) {
+      revalidateTag(CACHE_TAGS.droplets);
+      revalidateTag(CACHE_TAGS.lesson);
+      revalidateTag(CACHE_TAGS.allEnrollments);
+    }
 
     return { ok: true, error: null, data: responseData.data };
   } catch (err) {

--- a/frontend/tests/components/draft/lesson-renderer.test.tsx
+++ b/frontend/tests/components/draft/lesson-renderer.test.tsx
@@ -61,6 +61,7 @@ jest.mock("@/components/draft/lesson/delete-lesson", () => ({
 jest.mock("@/lib/requests/lesson", () => ({
   updateLesson: jest.fn(),
   deleteLesson: jest.fn(),
+  revalidateLesson: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockUseEditingLock = jest.fn().mockReturnValue({


### PR DESCRIPTION
## Summary
- **Auto-save no longer triggers full cache revalidation** — each save is now 1 PUT to Strapi instead of 7 requests + recompilation. Revalidation happens once on editor unmount.
- **Heartbeat/poll unhandled rejections fixed** — `useEditingLock` tick functions and cleanup now have try/catch to prevent `[object Event]` error overlay crashes.
- **Docker dev server memory stability** — added 2GB Node.js heap limit to Dockerfile to prevent OOM kills.
- **V1 block width constraints removed** — text blocks, quizzes, and open-ended quizzes now stretch to fill available width in both draft editor and public view.
- **Footer stacking context fixed** — moved `scale-x-80` from layout wrapper into footer component so `z-50` works at root stacking level, preventing sidebar from clipping over footer.

## Changes

### Auto-save & Memory
| File | Change |
|---|---|
| `lib/requests/lesson.ts` | Added `skipRevalidation` option to `updateLesson` |
| `components/draft/lesson/lesson-renderer.tsx` | Auto-save uses `skipRevalidation: true`, revalidates once on unmount, debounce 1.5s/4s |
| `Dockerfile` | `NODE_OPTIONS=--max-old-space-size=2048` |

### Error Handling
| File | Change |
|---|---|
| `hooks/useEditingLock.ts` | try/catch in heartbeat tick, poll tick, and init; `.catch()` on cleanup release |

### Layout
| File | Change |
|---|---|
| `components/draft/lesson/blocks/generic.tsx` | Removed `max-w-2xl` |
| `components/draft/lesson/blocks/quiz.tsx` | Removed `max-w-2xl` |
| `components/draft/lesson/blocks/open-ended-quiz.tsx` | Removed `max-w-2xl` |
| `components/ui/tiptap/generic-block-input.tsx` | Added `max-w-none` to override `prose` 65ch cap |
| `components/droplets/lessons/generic-block-renderer.tsx` | Added `max-w-none` (public view) |
| `components/droplets/lessons/lesson-renderer.tsx` | Added `max-w-none` on callout + expandable blocks |
| `components/footer/page.tsx` | Moved `scale-x-80` inside footer, fixed stacking context |
| `app/layout.tsx` | Removed `scale-x-80` wrapper div |

### Tests
| File | Change |
|---|---|
| `tests/components/draft/lesson-renderer.test.tsx` | Added `revalidateLesson` mock |

## Root Cause
The March 12 cache audit (`3a993467`) added `revalidateTag(CACHE_TAGS.allEnrollments)` to `updateLesson`, which meant every auto-save keystroke triggered 3 tag invalidations → ~7 Strapi refetches + Next.js recompilation. This overwhelmed the Docker dev server's 3.8GB memory, causing OOM kills every ~20 seconds.

## Test plan
- [x] All 302 test suites pass (4341 tests)
- [x] Prettier clean
- [x] ESLint clean
- [ ] Draft editor auto-save no longer crashes Docker container
- [ ] `[object Event]` error overlay no longer appears during editing
- [ ] Preview button navigation doesn't produce `Failed to fetch` errors
- [ ] V1 text blocks stretch to full width in draft editor
- [ ] V1 text blocks stretch to full width in public lesson view
- [ ] Footer renders above sidebar when scrolling on draft pages
- [ ] Footer visual appearance unchanged on mobile (scale-x-80 still applies)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for editing operations to prevent unhandled failures.

* **Style**
  * Restructured footer layout and removed responsive scaling.
  * Removed width constraints on content blocks for improved responsiveness.

* **Chores**
  * Optimized Docker memory configuration.
  * Added cache revalidation options to lesson updates for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->