### PR TITLE
Fix voyage update flow + voyage form UX improvements

### DIFF
--- a/frontend/app/(creation)/new/voyage/page.tsx
+++ b/frontend/app/(creation)/new/voyage/page.tsx
@@ -42,11 +42,8 @@ export default async function NewVoyage() {
   }
 
   return (
-    <div className="flex min-h-screen w-full flex-col items-center bg-white px-4 pt-12 md:px-12 dark:bg-slate-900">
-      <h1 className="mb-7 text-2xl font-bold tracking-tight text-slate-900 sm:text-4xl dark:text-white">
-        Create New Voyage
-      </h1>
-      <div className="w-full max-w-6xl">
+    <div className="flex min-h-screen w-full flex-col bg-white px-4 pt-12 pb-16 md:px-12 dark:bg-slate-900">
+      <div className="mx-auto w-full max-w-[1600px]">
         <VoyageForm
           playlists={publicPlaylists}
           droplets={publishedDroplets}

--- a/frontend/app/(editing)/draft/v/[slug]/page.tsx
+++ b/frontend/app/(editing)/draft/v/[slug]/page.tsx
@@ -43,11 +43,8 @@ export default async function EditVoyagePage({ params }: Props) {
   if (!authUser || !voyage) return notFound();
 
   return (
-    <div className="flex min-h-screen w-full flex-col items-center bg-white px-4 pt-12 md:px-12 dark:bg-slate-900">
-      <h1 className="mb-7 text-2xl font-bold tracking-tight text-slate-900 sm:text-4xl dark:text-white">
-        Edit Voyage
-      </h1>
-      <div className="w-full max-w-6xl">
+    <div className="flex min-h-screen w-full flex-col bg-white px-4 pt-12 pb-16 md:px-12 dark:bg-slate-900">
+      <div className="mx-auto w-full max-w-[1600px]">
         <VoyageForm
           playlists={publicPlaylists}
           droplets={publishedDroplets}

--- a/frontend/components/voyages/voyage-form.tsx
+++ b/frontend/components/voyages/voyage-form.tsx
@@ -32,6 +32,7 @@ import {
   BookOpenIcon,
   DropletIcon,
   CircleDashedIcon,
+  HelpCircleIcon,
 } from "lucide-react";
 
 type NodeMode = "playlist" | "droplet" | "placeholder";
@@ -157,6 +158,21 @@ export function VoyageForm({
     () => selectedNodes.filter((n) => n.isMainPath),
     [selectedNodes],
   );
+
+  // Branch count per main-path parent — used to hide "full" parents (≥4)
+  // from the "Branches from" dropdown, matching the Zod validation cap.
+  const branchCountsByParent = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const n of selectedNodes) {
+      if (!n.isMainPath && n.parentLocalId) {
+        counts.set(n.parentLocalId, (counts.get(n.parentLocalId) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }, [selectedNodes]);
+
+  // Zod caps main-path islands at 8 — disable add buttons once that's hit.
+  const mainAtCap = mainPathNodes.length >= 8;
 
   const addPlaylist = useCallback((playlist: Playlist) => {
     const dropletCount = playlist.droplets?.length ?? 0;
@@ -447,7 +463,11 @@ export function VoyageForm({
         return;
       }
 
-      router.push(`/v/${result.data?.slug}`);
+      const target =
+        status === "draft"
+          ? `/draft/v/${result.data?.slug}`
+          : `/v/${result.data?.slug}`;
+      router.push(target);
     });
   }
 
@@ -455,18 +475,23 @@ export function VoyageForm({
     <div className="flex w-full flex-col gap-8 lg:flex-row">
       <VoyageFormTour run={runTour} setRun={setRunTour} />
       {/* Left: Form panel */}
-      <div className="flex w-full flex-col gap-6 lg:w-1/2">
-        {/* Tour trigger */}
-        <div className="flex justify-end">
+      <div className="flex w-full flex-col gap-6 lg:w-2/5">
+        {/* Title + tour trigger */}
+        <div className="flex items-center gap-3">
+          <h1 className="text-4xl font-semibold text-black dark:text-white">
+            {isEditing ? "Edit Voyage" : "Create New Voyage"}
+          </h1>
           <button
             type="button"
             onClick={() => {
               localStorage.removeItem(VOYAGE_TOUR_KEY);
               setRunTour(true);
             }}
-            className="text-xs text-slate-400 transition-colors hover:text-[#297496]"
+            aria-label="Take a tour"
+            title="Take a tour"
+            className="text-slate-400 transition-colors hover:text-[#297496]"
           >
-            Take a tour
+            <HelpCircleIcon className="h-5 w-5" />
           </button>
         </div>
         {/* Name */}
@@ -498,7 +523,14 @@ export function VoyageForm({
 
         {/* Node picker */}
         <div className="flex flex-col gap-3">
-          <Label>Islands</Label>
+          <div className="flex items-baseline justify-between">
+            <Label>Islands</Label>
+            {mainAtCap && (
+              <span className="text-xs text-amber-600 dark:text-amber-400">
+                Max 8 main islands reached
+              </span>
+            )}
+          </div>
 
           {/* Node type selector */}
           <div
@@ -588,7 +620,7 @@ export function VoyageForm({
                       type="button"
                       className="flex w-full items-center justify-between px-4 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
                       onClick={() => addPlaylist(playlist)}
-                      disabled={isPending}
+                      disabled={isPending || mainAtCap}
                     >
                       <span className="truncate font-medium">
                         {playlist.name}
@@ -634,7 +666,7 @@ export function VoyageForm({
                       type="button"
                       className="flex w-full items-center justify-between px-4 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
                       onClick={() => addDroplet(droplet)}
-                      disabled={isPending}
+                      disabled={isPending || mainAtCap}
                     >
                       <span className="truncate font-medium">
                         {droplet.name}
@@ -669,7 +701,7 @@ export function VoyageForm({
                 type="button"
                 variant="outline"
                 onClick={addPlaceholder}
-                disabled={isPending || !placeholderLabel.trim()}
+                disabled={isPending || !placeholderLabel.trim() || mainAtCap}
                 className="shrink-0"
               >
                 <PlusIcon className="h-4 w-4" />
@@ -806,6 +838,17 @@ export function VoyageForm({
                               <option value="">None (main path)</option>
                               {mainPathNodes
                                 .filter((m) => m.localId !== node.localId)
+                                .filter((m) => {
+                                  // Keep the currently-selected parent visible
+                                  // even if it's now "full"; otherwise hide
+                                  // parents that already have 4 branches.
+                                  const count =
+                                    branchCountsByParent.get(m.localId) ?? 0;
+                                  return (
+                                    node.parentLocalId === m.localId ||
+                                    count < 4
+                                  );
+                                })
                                 .sort((a, b) => a.orderIndex - b.orderIndex)
                                 .map((m) => (
                                   <option key={m.localId} value={m.localId}>
@@ -928,7 +971,7 @@ export function VoyageForm({
       </div>
 
       {/* Right: Live tree preview */}
-      <div id="tour-preview" className="w-full lg:w-1/2">
+      <div id="tour-preview" className="w-full lg:w-3/5">
         <div className="sticky top-8">
           <h3 className="mb-3 text-sm font-medium text-slate-700 dark:text-slate-300">
             Live Preview

--- a/frontend/components/voyages/voyage-tree-island.tsx
+++ b/frontend/components/voyages/voyage-tree-island.tsx
@@ -606,15 +606,16 @@ export function VoyageTreeIsland({
 
       {/* Label */}
       <div className="-mt-1 flex justify-center">
-        <span
-          className={`rounded-lg border border-slate-100 px-3 py-1.5 font-bold shadow ${
+        <div
+          title={label}
+          className={`truncate rounded-lg border border-slate-100 px-3 py-1.5 text-center font-bold shadow ${
             isMain
-              ? "max-w-[200px] bg-white text-sm dark:bg-slate-800"
-              : "max-w-[160px] bg-white text-xs dark:bg-slate-800"
+              ? "w-[200px] bg-white text-sm dark:bg-slate-800"
+              : "w-[160px] bg-white text-xs dark:bg-slate-800"
           } ${isLocked ? "opacity-60" : ""} text-slate-900 dark:border-slate-700 dark:text-slate-100`}
         >
           {label}
-        </span>
+        </div>
       </div>
 
       {/* Subtitle */}

--- a/frontend/components/voyages/voyage-tree-map.tsx
+++ b/frontend/components/voyages/voyage-tree-map.tsx
@@ -20,29 +20,36 @@ export interface TreeNode {
 
 interface VoyageTreeMapProps {
   nodes: TreeNode[];
+  /** Horizontal center ratio for islands (0–1). 0.5 centers, >0.5 shifts right. */
+  centerOffsetRatio?: number;
 }
 
 // Default desktop sizes. On narrower containers these scale down proportionally
 // so multi-branch rows stay within the viewport.
 const DEFAULT_MAIN_SIZE = 260;
 const DEFAULT_BRANCH_SIZE = 210;
-const DEFAULT_H_GAP = 80;
-const DEFAULT_V_GAP = 160;
+const DEFAULT_H_GAP = 100;
+const DEFAULT_V_GAP = 180;
 const PADDING = 60;
 const MIN_MAIN_SIZE = 140;
 const MIN_BRANCH_SIZE = 110;
-const MIN_H_GAP = 24;
+const MIN_H_GAP = 32;
 
 /** Compute layout sizes that fit within the container, accounting for
- *  the widest branch row in the tree. */
+ *  the widest branch row in the tree. Sizing is based on the full
+ *  container width (symmetric); horizontal placement is clamped
+ *  separately in assignPositions so the tree can shift right without
+ *  overflowing. */
 function computeLayoutSizes(containerWidth: number, maxBranches: number) {
-  // Available width for a branch row after padding.
   const usable = Math.max(containerWidth - PADDING * 2, 0);
-  // Desktop ideal width for the widest branch row.
+  // Each island div is rendered at width = size × 2 (to fit label bleed),
+  // so the effective row width includes one extra island's worth on top of
+  // the spacing between branch centers.
   const idealBranchRow =
     maxBranches > 0
-      ? maxBranches * DEFAULT_BRANCH_SIZE + (maxBranches - 1) * DEFAULT_H_GAP
-      : DEFAULT_MAIN_SIZE;
+      ? (maxBranches + 1) * DEFAULT_BRANCH_SIZE +
+        (maxBranches - 1) * DEFAULT_H_GAP
+      : 2 * DEFAULT_MAIN_SIZE;
   const scale = usable > 0 ? Math.min(1, usable / idealBranchRow) : 1;
 
   const MAIN_SIZE = Math.max(DEFAULT_MAIN_SIZE * scale, MIN_MAIN_SIZE);
@@ -82,16 +89,37 @@ function buildTree(nodes: TreeNode[]): LayoutNode[] {
   });
 }
 
-/** Assign positions: top-down centered, branches spread horizontally below parent */
+/** Assign positions: top-down, branches spread horizontally below parent.
+ *  cx is clamped so the widest rendered row (main island or branch row,
+ *  each rendered at size × 2 width) stays within the container — the
+ *  tree shifts toward centerOffsetRatio as far as it can without
+ *  overflowing. */
 function assignPositions(
   roots: LayoutNode[],
   containerWidth: number,
   sizes: ReturnType<typeof computeLayoutSizes>,
+  centerOffsetRatio = 0.5,
 ): { all: LayoutNode[]; height: number } {
   const { MAIN_SIZE, BRANCH_SIZE, H_GAP, V_GAP } = sizes;
   const all: LayoutNode[] = [];
   let y = PADDING;
-  const cx = containerWidth / 2;
+
+  const maxBranches = roots.reduce((m, r) => Math.max(m, r.children.length), 0);
+  const mainHalfWidth = MAIN_SIZE;
+  const branchRowHalfWidth =
+    maxBranches > 0
+      ? (maxBranches * BRANCH_SIZE + (maxBranches - 1) * H_GAP) / 2 +
+        BRANCH_SIZE / 2
+      : 0;
+  const widestHalf = Math.max(mainHalfWidth, branchRowHalfWidth);
+  const minCx = widestHalf + PADDING;
+  const maxCx = containerWidth - widestHalf - PADDING;
+  const desiredCx = containerWidth * centerOffsetRatio;
+  // When the widest row plus padding doesn't fit, fall back to centering.
+  const cx =
+    minCx > maxCx
+      ? containerWidth / 2
+      : Math.min(Math.max(desiredCx, minCx), maxCx);
 
   for (const root of roots) {
     root.x = cx;
@@ -141,7 +169,10 @@ function bezierPath(
   return `M ${px} ${sy} C ${px} ${my}, ${cx} ${my}, ${cx} ${ey}`;
 }
 
-export function VoyageTreeMap({ nodes }: VoyageTreeMapProps) {
+export function VoyageTreeMap({
+  nodes,
+  centerOffsetRatio = 0.5,
+}: VoyageTreeMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
 
@@ -172,8 +203,8 @@ export function VoyageTreeMap({ nodes }: VoyageTreeMapProps) {
   );
 
   const { all: layoutNodes, height: totalHeight } = useMemo(
-    () => assignPositions(tree, containerWidth, sizes),
-    [tree, containerWidth, sizes],
+    () => assignPositions(tree, containerWidth, sizes, centerOffsetRatio),
+    [tree, containerWidth, sizes, centerOffsetRatio],
   );
 
   // Scale SVG visible heights by the same ratio used for layout sizing.

--- a/frontend/lib/requests/voyage.ts
+++ b/frontend/lib/requests/voyage.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import qs from "qs";
 import { Voyage } from "@/types";
 import { fetchAPI, flattenAttributes } from "@/lib/utils";
 import { revalidateTag } from "next/cache";
@@ -251,6 +250,8 @@ export async function getVoyageBySlug(
               droplets: { fields: ["id"] },
             },
           },
+          droplet: { fields: ["id", "name", "slug", "status"] },
+          claimedBy: { fields: ["id"] },
           parentNode: { fields: ["id"] },
         },
         sort: ["orderIndex:asc"],
@@ -500,42 +501,51 @@ export async function updateVoyageWithNodes(data: {
       slug: string;
     };
 
-    // Phase 2: Delete all existing nodes for this voyage (paginated, with error checking)
-    const allNodeIds: number[] = [];
+    // Phase 2: Delete all existing nodes for this voyage. fetchAPI prepends
+    // `/api` to the path, so the path here must be `/voyage-nodes`, NOT
+    // `/api/voyage-nodes` (that would double-prefix and 404).
+    const branchNodeIds: number[] = [];
+    const mainNodeIds: number[] = [];
     let page = 1;
     for (;;) {
-      const query = qs.stringify({
-        filters: { voyage: { id: { $eq: data.id } } },
-        pagination: { page, pageSize: 100 },
-        fields: ["id"],
-      });
-      const nodesPage = await fetchAPI(`/api/voyage-nodes?${query}`, {
-        next: { tags: [CACHE_TAGS.voyages] },
-      });
-      if (Array.isArray(nodesPage)) {
-        allNodeIds.push(...nodesPage.map((n: { id: number }) => n.id));
+      const nodesPage = await fetchAPI<{ id: number; isMainPath: boolean }[]>(
+        `/voyage-nodes`,
+        {
+          urlParams: {
+            filters: { voyage: { id: { $eq: data.id } } },
+            pagination: { page, pageSize: 100 },
+            fields: ["id", "isMainPath"],
+          },
+          next: { tags: [CACHE_TAGS.voyages] },
+        },
+      );
+      if (!Array.isArray(nodesPage)) break;
+      for (const n of nodesPage) {
+        if (n.isMainPath) mainNodeIds.push(n.id);
+        else branchNodeIds.push(n.id);
       }
-      // fetchAPI auto-flattens, so pagination meta comes from the raw response;
-      // break after one page if we got fewer than pageSize results
-      if (!Array.isArray(nodesPage) || nodesPage.length < 100) break;
+      if (nodesPage.length < 100) break;
       page++;
     }
 
-    await Promise.all(
-      allNodeIds.map(async (nodeId) => {
-        const res = await fetch(
-          `${NEXT_PUBLIC_STRAPI_API_URL}/api/voyage-nodes/${nodeId}`,
-          {
-            method: "DELETE",
-            headers: { Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}` },
-          },
-        );
-        if (!res.ok) {
-          throw new Error(`Failed to delete voyage-node ${nodeId}`);
-        }
-        return res;
-      }),
-    );
+    const deleteNode = async (nodeId: number) => {
+      const res = await fetch(
+        `${NEXT_PUBLIC_STRAPI_API_URL}/api/voyage-nodes/${nodeId}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${STRAPI_ACCESS_TOKEN}` },
+        },
+      );
+      // 404 = already deleted, treat as success.
+      if (!res.ok && res.status !== 404) {
+        throw new Error(`Failed to delete voyage-node ${nodeId}`);
+      }
+    };
+
+    // Branches hold parentNode FKs pointing to main nodes — delete branches
+    // first so main deletes never race against a live child FK.
+    await Promise.all(branchNodeIds.map(deleteNode));
+    await Promise.all(mainNodeIds.map(deleteNode));
 
     // Phase 3: Re-create nodes (main path first, then branches)
     const nodeError = await createVoyageNodes(data.id, data.nodes);
@@ -546,9 +556,10 @@ export async function updateVoyageWithNodes(data: {
     return { ok: true, error: null, data: voyage };
   } catch (err) {
     console.error(err);
+    const message = err instanceof Error ? err.message : "Unknown error";
     return {
       ok: false,
-      error: "Database Error: Failed to update voyage.",
+      error: `Database Error: ${message}`,
       data: null,
     };
   }


### PR DESCRIPTION
## Summary
- Fixes "Database Error: Failed to update voyage" — root cause was `fetchAPI("/api/voyage-nodes?...")` double-prefixing the path (`fetchAPI` already prepends `/api`), so every update 404'd on the Phase-2 GET and got caught as a generic "Database Error".
- Deletes branch nodes before main-path nodes on update to avoid FK constraint races on voyages with branches.
- Treats 404 on DELETE as success so cleanup is idempotent.
- Populates `droplet` and `claimedBy` on `voyage_nodes` in `getVoyageBySlug`, so droplet-type islands no longer degrade to placeholders on edit.
- Surfaces the real exception message in the catch block instead of an opaque "Database Error".
- Draft saves now redirect to `/draft/v/{slug}` instead of `/v/{slug}`.
- Voyage form UX: `max-w-[1600px]` centered page, 2/5 form + 3/5 preview split, bottom padding; edit and create pages share layout.
- Tree map: clamp `cx` so a shifted tree can't overflow; island labels use `truncate` + tooltip for consistent card heights.
- UI enforces schema caps: "Branches from" dropdown hides parents already at 4 branches; add buttons disabled at 8 main islands with an inline warning.

## Test plan
- [x] Create a new voyage end-to-end (playlists + droplets + placeholders + branches)
- [x] Edit an existing draft voyage with droplet-type nodes and branches, save, confirm nothing degrades
- [x] Verify draft save redirects to \`/draft/v/{slug}\` and the page loads
- [x] Confirm the tree preview is centered and doesn't overflow with varying island/branch counts
- [x] Confirm the 4-branch-per-parent and 8-main-island caps are enforced in the UI
- [x] Regression: enrolled users on a published voyage still see correct progress after an edit