### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.2.0",
   "description": "A Strapi application",
   "scripts": {
     "dev": "strapi develop",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odyssey",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps `frontend/package.json` and `backend/package.json` to 2.2.0 to align with release PR #875. No code changes.