### PR TITLE
fix: address CodeRabbit findings on release #875

### DIFF
--- a/frontend/app/(general)/dashboard/page.tsx
+++ b/frontend/app/(general)/dashboard/page.tsx
@@ -22,7 +22,11 @@ export default async function DashboardRoute({ searchParams }: Props) {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(resolved)) {
     if (key === "tab" || value === undefined) continue;
-    params.set(key, Array.isArray(value) ? value.join(",") : value);
+    if (Array.isArray(value)) {
+      value.forEach((entry) => params.append(key, entry));
+    } else {
+      params.set(key, value);
+    }
   }
   const qs = params.toString();
   redirect(qs ? `${basePath}?${qs}` : basePath);

--- a/frontend/components/dashboard/user-playlists-grid.tsx
+++ b/frontend/components/dashboard/user-playlists-grid.tsx
@@ -42,10 +42,11 @@ export async function UserPlaylistsGrid({ sortKey }: { sortKey?: string }) {
     },
   );
 
-  const publicPlaylists = allPlaylists.filter((p: Playlist) => p.isPublic);
-  const customPlaylists = allPlaylists.filter((p: Playlist) => !p.isPublic);
+  const activePlaylists = allPlaylists.filter((p: Playlist) => !p.isArchived);
+  const publicPlaylists = activePlaylists.filter((p: Playlist) => p.isPublic);
+  const customPlaylists = activePlaylists.filter((p: Playlist) => !p.isPublic);
 
-  if (!allPlaylists || allPlaylists.length === 0) {
+  if (activePlaylists.length === 0) {
     return (
       <EmptyState
         icon={

--- a/frontend/components/feed/activity-tab-content.tsx
+++ b/frontend/components/feed/activity-tab-content.tsx
@@ -26,15 +26,16 @@ export async function ActivityTabContent({ contentType, searchParams }: Props) {
 
   const tagOptions =
     contentType === "droplets"
-      ? await getTags({ populate: { droplets: { fields: ["id"] } } }).then(
-          (tags) =>
-            tags
-              .filter((t) =>
-                t.droplets?.some(
-                  (d) => !d.isHidden && d.status === "published",
-                ),
-              )
-              .map((t) => ({ label: t.name, value: t.slug })),
+      ? await getTags({
+          populate: {
+            droplets: { fields: ["id", "isHidden", "status"] },
+          },
+        }).then((tags) =>
+          tags
+            .filter((t) =>
+              t.droplets?.some((d) => !d.isHidden && d.status === "published"),
+            )
+            .map((t) => ({ label: t.name, value: t.slug })),
         )
       : [];
 

--- a/frontend/components/feed/feed-client.tsx
+++ b/frontend/components/feed/feed-client.tsx
@@ -9,6 +9,7 @@ import {
   markAnnouncementUnread,
 } from "@/lib/requests/feed";
 import { cn } from "@/lib/utils";
+import { toast } from "sonner";
 
 type Tab = "unread" | "read";
 
@@ -61,6 +62,7 @@ export function FeedClient({
     setAnnouncements((prev) => prev.filter((a) => a.id !== id));
     const result = await markAnnouncementRead(id);
     if (!result.success) {
+      toast.error("Failed to mark as read");
       setRefreshKey((k) => k + 1);
     }
   };
@@ -69,6 +71,7 @@ export function FeedClient({
     setAnnouncements((prev) => prev.filter((a) => a.id !== id));
     const result = await markAnnouncementUnread(id);
     if (!result.success) {
+      toast.error("Failed to mark as unread");
       setRefreshKey((k) => k + 1);
     }
   };

--- a/frontend/components/ui/archive-button.tsx
+++ b/frontend/components/ui/archive-button.tsx
@@ -25,7 +25,7 @@ export function ArchiveButton({
     >
       <div className="group relative">
         <Icon className="h-5 w-5 text-black dark:text-white" stroke={1.8} />
-        <span className="absolute top-full left-1/2 mt-1 w-max -translate-x-1/2 transform rounded bg-gray-800 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100">
+        <span className="absolute top-full left-1/2 mt-1 w-max -translate-x-1/2 transform rounded bg-gray-800 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
           {label}
         </span>
       </div>

--- a/frontend/components/voyages/voyage-tree-map.tsx
+++ b/frontend/components/voyages/voyage-tree-map.tsx
@@ -47,8 +47,11 @@ function computeLayoutSizes(containerWidth: number, maxBranches: number) {
   // the spacing between branch centers.
   const idealBranchRow =
     maxBranches > 0
-      ? (maxBranches + 1) * DEFAULT_BRANCH_SIZE +
-        (maxBranches - 1) * DEFAULT_H_GAP
+      ? Math.max(
+          (maxBranches + 1) * DEFAULT_BRANCH_SIZE +
+            (maxBranches - 1) * DEFAULT_H_GAP,
+          2 * DEFAULT_MAIN_SIZE,
+        )
       : 2 * DEFAULT_MAIN_SIZE;
   const scale = usable > 0 ? Math.min(1, usable / idealBranchRow) : 1;
 

--- a/frontend/lib/requests/feed.ts
+++ b/frontend/lib/requests/feed.ts
@@ -7,6 +7,8 @@ import { revalidateTag } from "next/cache";
 import { CACHE_TAGS } from "../cache-tags";
 import { requireRole } from "@/lib/auth/require-role";
 import { AuthorizedUserRoleTitle } from "@/lib/globals";
+import { getCurrentUser } from "../auth/session";
+import { getAuthorizedUserByEmail } from "./authorized-user";
 
 const NEXT_PUBLIC_STRAPI_API_URL = process.env.NEXT_PUBLIC_STRAPI_API_URL;
 const STRAPI_ACCESS_TOKEN = process.env.STRAPI_ACCESS_TOKEN;
@@ -576,6 +578,9 @@ export async function createSystemBroadcast(content: string) {
  */
 export async function markAnnouncementRead(id: number) {
   try {
+    const ownership = await assertAnnouncementOwnership(id);
+    if (!ownership.ok) return { success: false, error: ownership.error };
+
     const response = await fetch(
       `${NEXT_PUBLIC_STRAPI_API_URL}/api/announcements/${id}`,
       {
@@ -608,6 +613,9 @@ export async function markAnnouncementRead(id: number) {
  */
 export async function markAnnouncementUnread(id: number) {
   try {
+    const ownership = await assertAnnouncementOwnership(id);
+    if (!ownership.ok) return { success: false, error: ownership.error };
+
     const response = await fetch(
       `${NEXT_PUBLIC_STRAPI_API_URL}/api/announcements/${id}`,
       {
@@ -632,6 +640,48 @@ export async function markAnnouncementUnread(id: number) {
     console.error("Error marking announcement as unread:", error);
     return { success: false, error };
   }
+}
+
+/**
+ * Verifies that the current authenticated user is the authorized_user on the
+ * announcement identified by `id`. Broadcasts (authorized_user = null) are
+ * rejected because their `readAt` column is shared across all recipients —
+ * marking one read would hide it from everyone. Per-user read state for
+ * broadcasts requires a schema change (join table) not yet in place.
+ */
+async function assertAnnouncementOwnership(
+  id: number,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const user = await getCurrentUser();
+  if (!user?.email) return { ok: false, error: "Not authenticated" };
+
+  const authorizedUser = await getAuthorizedUserByEmail(user.email);
+  if (!authorizedUser) return { ok: false, error: "Not authorized" };
+
+  const announcement = await fetchAPI<{
+    id: number;
+    authorized_user?: { id: number } | null;
+  }>(`/announcements/${id}`, {
+    urlParams: {
+      fields: ["id"],
+      populate: { authorized_user: { fields: ["id"] } },
+    },
+    next: { tags: [CACHE_TAGS.announcements], revalidate: 0 },
+  });
+
+  if (!announcement) return { ok: false, error: "Announcement not found" };
+
+  const ownerId = announcement.authorized_user?.id;
+  if (ownerId == null) {
+    return {
+      ok: false,
+      error: "Broadcast announcements cannot be marked read",
+    };
+  }
+  if (ownerId !== authorizedUser.id) {
+    return { ok: false, error: "Not authorized" };
+  }
+  return { ok: true };
 }
 
 /**

--- a/frontend/lib/requests/playlist.ts
+++ b/frontend/lib/requests/playlist.ts
@@ -294,6 +294,13 @@ export async function archivePlaylist(
       ),
     ]);
 
+    if (!authorizedUser) {
+      return { success: false, error: "Authorized user not found" };
+    }
+    if (!fullPlaylist) {
+      return { success: false, error: "Playlist not found" };
+    }
+
     const isAuthor = fullPlaylist.authors?.some(
       (a) => a.id === authorizedUser.id,
     );

--- a/frontend/lib/requests/voyage.ts
+++ b/frontend/lib/requests/voyage.ts
@@ -680,6 +680,13 @@ export async function archiveVoyage(voyageId: number, archiveState: boolean) {
       }),
     ]);
 
+    if (!authorizedUser) {
+      return { success: false, error: "Authorized user not found" };
+    }
+    if (!voyage) {
+      return { success: false, error: "Voyage not found" };
+    }
+
     const isAuthor = voyage.authors?.some((a) => a.id === authorizedUser.id);
     const isAdmin = isAuthorizedUserAdmin(user.roles);
     if (!isAuthor && !isAdmin) {

--- a/frontend/lib/validations/voyage.ts
+++ b/frontend/lib/validations/voyage.ts
@@ -56,6 +56,21 @@ export const VoyageTreeSchema = z
       }
     }
 
+    // Branch nodes must point to a main-path parent — nested branches are
+    // not supported (the deletion code assumes a flat main/branch structure).
+    const nodeByLocalId = new Map(data.nodes.map((n) => [n.localId, n]));
+    for (const node of data.nodes) {
+      if (node.parentLocalId === null) continue;
+      const parent = nodeByLocalId.get(node.parentLocalId);
+      if (parent && !parent.isMainPath) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Node "${node.label}" has a branch parent; branches must attach to a main-path node`,
+          path: ["nodes"],
+        });
+      }
+    }
+
     // Max 8 main path nodes (parentLocalId === null)
     const mainNodes = data.nodes.filter((n) => n.parentLocalId === null);
     if (mainNodes.length > 8) {

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -8,4 +8,12 @@ export default withAuth({
   },
 });
 
-export const config = { matcher: ["/admin", "/admin/:path*", "/d/:path*"] };
+export const config = {
+  matcher: [
+    "/admin",
+    "/admin/:path*",
+    "/d/:path*",
+    "/activity",
+    "/activity/:path*",
+  ],
+};


### PR DESCRIPTION
Addresses the 11 CodeRabbit findings surfaced on release PR #875. All verified against current code (not stale) before fixing.

## Critical

- **Archived playlists leak into active dashboard** — `user-playlists-grid` now filters on `!p.isArchived` before splitting into public/custom lists. Client only filters by search, so without this guard archived playlists appeared in both Active and Archived views.
- **`markAnnouncementRead`/`markAnnouncementUnread` had no ownership check** — any authenticated user could PUT `readAt` on any announcement id via the service token. Both now call a shared `assertAnnouncementOwnership(id)` which fetches the announcement, requires the caller to be the `authorized_user`, and rejects broadcasts (where `readAt` is a single shared column — per-user read state for broadcasts needs a schema change).

## Major

- **`/activity` not in middleware matcher** — unauth users reached `layout.tsx` and got a 404 via `notFound()`. Added `/activity` and `/activity/:path*` so they redirect to sign-in.

## Minor

- `dashboard/page.tsx` uses `params.append` for array values, matching `feed/page.tsx`.
- `activity-tab-content` populates `droplet.isHidden` and `droplet.status` so the published-droplet filter actually works (Strapi only returns listed fields).
- `feed-client` shows `toast.error` when mark read/unread fails.
- `archive-button` tooltip opens on `group-focus-within` too, not only hover.
- `voyage-tree-map` `idealBranchRow` now max()es against `2 * MAIN_SIZE` so single-branch rows don't overflow narrow containers.
- Voyage Zod schema rejects branch nodes whose parent isn't a main-path node, enforcing the flat main/branch assumption the deletion code relies on.

## Already landed in prior commit on this branch
- Null-safety on `archivePlaylist` and `archiveVoyage` (authorizedUser / fetched content).

## Test plan
- [x] `npm test` — 4342 pass
- [ ] Sanity-check `/activity/playlists` doesn't show archived cards
- [ ] Sanity-check unauth visit to `/activity` redirects to sign-in
- [ ] Mark a broadcast as read → expect "Broadcast announcements cannot be marked read" toast, broadcast stays in feed