### PR TITLE
fix(csp): allow S3 dataset fetches in notebook code blocks

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -53,7 +53,7 @@ const nextConfig = {
             value: `
               default-src 'self';
               script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us-assets.i.posthog.com https://cdn.jsdelivr.net;
-              connect-src 'self' https://app.posthog.com https://*.posthog.com https://strapi.odyssey.khoury.northeastern.edu https://emkc.org https://cdn.jsdelivr.net https://*.codesandbox.io;
+              connect-src 'self' https://app.posthog.com https://*.posthog.com https://strapi.odyssey.khoury.northeastern.edu https://emkc.org https://cdn.jsdelivr.net https://*.codesandbox.io https://*.s3.us-east-2.amazonaws.com;
               style-src 'self' 'unsafe-inline';
               img-src 'self' data: https: blob:;
               font-src 'self' data:;

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,5 +1,32 @@
 import pkg from "./package.json" with { type: "json" };
 
+// Derive CSP-safe origins from the S3/CDN env vars so the config follows the
+// actual bucket (any region) or a CloudFront distribution without edits.
+function originFromEnv(value) {
+  if (!value) return null;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+const datasetOrigins = [
+  originFromEnv(process.env.AWS_S3_BUCKET_URL),
+  originFromEnv(process.env.AWS_CDN_URL),
+].filter(Boolean);
+
+const connectSrc = [
+  "'self'",
+  "https://app.posthog.com",
+  "https://*.posthog.com",
+  "https://strapi.odyssey.khoury.northeastern.edu",
+  "https://emkc.org",
+  "https://cdn.jsdelivr.net",
+  "https://*.codesandbox.io",
+  ...datasetOrigins,
+].join(" ");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   env: {
@@ -53,7 +80,7 @@ const nextConfig = {
             value: `
               default-src 'self';
               script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us-assets.i.posthog.com https://cdn.jsdelivr.net;
-              connect-src 'self' https://app.posthog.com https://*.posthog.com https://strapi.odyssey.khoury.northeastern.edu https://emkc.org https://cdn.jsdelivr.net https://*.codesandbox.io https://*.s3.us-east-2.amazonaws.com;
+              connect-src ${connectSrc};
               style-src 'self' 'unsafe-inline';
               img-src 'self' data: https: blob:;
               font-src 'self' data:;


### PR DESCRIPTION
ODY-442: CSP blocked pyodide-context from fetching attached datasets from S3, causing FileNotFoundError on pd.read_csv() in every notebook block. Add the S3 host pattern to connect-src so datasets can load.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network security configuration to enable connections to cloud storage services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->