### PR TITLE
BlockNote editor: link handling, autolink fix, inline code polish

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -146,12 +146,16 @@ html:not(.dark) .sp-wrapper .cm-editor ::selection {
 /* Tailwind Typography renders inline <code> with ::before/::after pseudo-
    elements that insert literal backticks around the text. We style code
    pills ourselves (Slack/Notion-like), so kill the backticks and apply the
-   same pill styling as the BlockNote editor for visual consistency. */
-.prose :where(code):not(:where([class~="not-prose"] *))::before,
-.prose :where(code):not(:where([class~="not-prose"] *))::after {
+   same pill styling as the BlockNote editor for visual consistency.
+   Scoped to inline <code> only — `:not(:where(pre *))` excludes fenced
+   code-block content so highlight.js / <pre><code> output stays untouched. */
+.prose
+  :where(code):not(:where([class~="not-prose"] *)):not(:where(pre *))::before,
+.prose
+  :where(code):not(:where([class~="not-prose"] *)):not(:where(pre *))::after {
   content: none !important;
 }
-.prose :where(code):not(:where([class~="not-prose"] *)) {
+.prose :where(code):not(:where([class~="not-prose"] *)):not(:where(pre *)) {
   padding: 0.15em 0.35em;
   border-radius: 4px;
   border: 1px solid #e0e0e0;
@@ -160,7 +164,9 @@ html:not(.dark) .sp-wrapper .cm-editor ::selection {
   color: #e01e5a;
   font-weight: inherit;
 }
-.dark .prose :where(code):not(:where([class~="not-prose"] *)) {
+.dark
+  .prose
+  :where(code):not(:where([class~="not-prose"] *)):not(:where(pre *)) {
   border-color: #4a4a4a;
   background-color: #2d2d2d;
   color: #e06b85;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -143,6 +143,29 @@ html:not(.dark) .sp-wrapper .cm-editor ::selection {
   background: #b3d4fd;
 }
 
+/* Tailwind Typography renders inline <code> with ::before/::after pseudo-
+   elements that insert literal backticks around the text. We style code
+   pills ourselves (Slack/Notion-like), so kill the backticks and apply the
+   same pill styling as the BlockNote editor for visual consistency. */
+.prose :where(code):not(:where([class~="not-prose"] *))::before,
+.prose :where(code):not(:where([class~="not-prose"] *))::after {
+  content: none !important;
+}
+.prose :where(code):not(:where([class~="not-prose"] *)) {
+  padding: 0.15em 0.35em;
+  border-radius: 4px;
+  border: 1px solid #e0e0e0;
+  background-color: #f8f8f8;
+  font-size: 0.9em;
+  color: #e01e5a;
+  font-weight: inherit;
+}
+.dark .prose :where(code):not(:where([class~="not-prose"] *)) {
+  border-color: #4a4a4a;
+  background-color: #2d2d2d;
+  color: #e06b85;
+}
+
 /* driver.js tour — custom popover styling */
 .draft-tour-popover.driver-popover {
   border-radius: 12px;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <link rel="icon" href="/icon.svg" type="image/svg+xml" sizes="any" />
-      <body className={inter.className}>
+      <body className={inter.className} suppressHydrationWarning>
         <ThemeClientProvider>
           <AuthSessionProvider>
             <PHProvider>

--- a/frontend/components/draft/lesson/blocknote-editor-client.tsx
+++ b/frontend/components/draft/lesson/blocknote-editor-client.tsx
@@ -92,7 +92,10 @@ const MarkdownLinkInputRule = Extension.create({
     if (!linkMarkType) return [];
     return [
       markInputRule({
-        find: /\[([^\]]+)\]\((\S+)\)$/,
+        // Match either a plain URL containing no parens or a URL with a
+        // single balanced `(...)` pair (e.g. Wikipedia article anchors).
+        // Guards against losing the final `)` of an unbalanced-paren URL.
+        find: /\[([^\]]+)\]\(([^\s()]+(?:\([^\s()]*\)[^\s()]*)?)\)$/,
         type: linkMarkType,
         // Returning `false` aborts the rule (unsafe or missing href). The
         // cast is because TipTap's type declares `getAttributes` as a
@@ -252,7 +255,6 @@ export function BlockNoteEditorClient({
       }
     });
     if (changed) view.dispatch(tr);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
 
   // Intercept Tab in tables at the DOM level to prevent block nesting

--- a/frontend/components/draft/lesson/blocknote-editor-client.tsx
+++ b/frontend/components/draft/lesson/blocknote-editor-client.tsx
@@ -16,6 +16,12 @@ import {
 } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
 import { blockNoteSchema } from "@/lib/blocknote/schema";
+import {
+  isAutolinkFalsePositive,
+  isSafeLinkHref,
+} from "@/lib/blocknote/autolink-filter";
+import { Extension, markInputRule } from "@tiptap/core";
+import { Plugin, PluginKey } from "prosemirror-state";
 import { addRowAfter, goToNextCell, isInTable } from "prosemirror-tables";
 import { useTheme } from "next-themes";
 import {
@@ -43,6 +49,65 @@ const SlideOverflowContext = createContext<Set<string>>(new Set());
 export const useSlideOverflow = () => useContext(SlideOverflowContext);
 
 const knownBlockTypes = new Set(Object.keys(blockNoteSchema.blockSpecs));
+
+// Removes link marks that are clearly autolink false-positives. See
+// `lib/blocknote/autolink-filter.ts` for the heuristic. Manual links —
+// where the visible text differs from the href — are always preserved.
+const StripSpuriousAutolinks = Extension.create({
+  name: "stripSpuriousAutolinks",
+  addProseMirrorPlugins() {
+    const linkMarkType = this.editor.schema.marks.link;
+    if (!linkMarkType) return [];
+    return [
+      new Plugin({
+        key: new PluginKey("stripSpuriousAutolinks"),
+        appendTransaction: (transactions, _oldState, newState) => {
+          if (!transactions.some((t) => t.docChanged)) return null;
+          const tr = newState.tr;
+          let changed = false;
+          newState.doc.descendants((node, pos) => {
+            if (!node.isText) return;
+            const linkMark = node.marks.find((m) => m.type === linkMarkType);
+            if (!linkMark) return;
+            const href = (linkMark.attrs as { href?: string }).href ?? "";
+            if (isAutolinkFalsePositive(node.text ?? "", href)) {
+              tr.removeMark(pos, pos + node.nodeSize, linkMarkType);
+              changed = true;
+            }
+          });
+          return changed ? tr : null;
+        },
+      }),
+    ];
+  },
+});
+
+// Markdown-style link shortcut: typing `[text](url)` wraps "text" in a link
+// mark with href=url. Fires on the closing paren. URIs with unsafe schemes
+// (javascript:, data:, etc.) are rejected so the mark isn't applied.
+const MarkdownLinkInputRule = Extension.create({
+  name: "markdownLinkInputRule",
+  addInputRules() {
+    const linkMarkType = this.editor.schema.marks.link;
+    if (!linkMarkType) return [];
+    return [
+      markInputRule({
+        find: /\[([^\]]+)\]\((\S+)\)$/,
+        type: linkMarkType,
+        // Returning `false` aborts the rule (unsafe or missing href). The
+        // cast is because TipTap's type declares `getAttributes` as a
+        // function returning Record<string, any>, but runtime supports the
+        // `false | null` short-circuit shown in `markInputRule` source.
+        getAttributes: ((match: RegExpMatchArray) => {
+          const href = match[2];
+          if (!isSafeLinkHref(href)) return false;
+          return { href };
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      }),
+    ];
+  },
+});
 
 const CUSTOM_BLOCK_TYPES = new Set([
   "latex",
@@ -138,6 +203,16 @@ export function BlockNoteEditorClient({
       headers: false,
       cellTextColor: false,
     },
+    // Additional TipTap extensions layered on top of BlockNote's defaults.
+    // The cast is required because BlockNote ships a nested @tiptap/core,
+    // so types from our top-level @tiptap/core don't line up.
+    _tiptapOptions: {
+      extensions: [
+        StripSpuriousAutolinks,
+        MarkdownLinkInputRule,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any,
+    },
   });
 
   const [documentBlocks, setDocumentBlocks] = useState<
@@ -153,6 +228,32 @@ export function BlockNoteEditorClient({
 
     return () => clearTimeout(timer);
   }, []);
+
+  // One-time cleanup of spurious autolink marks loaded from initialContent.
+  // The StripSpuriousAutolinks plugin only fires on doc-changing transactions,
+  // so link marks already present when the editor mounts (legacy autolinked
+  // filenames like "app.py") aren't touched otherwise.
+  useEffect(() => {
+    if (!editor) return;
+    const view = editor.prosemirrorView;
+    if (!view) return;
+    const linkMarkType = view.state.schema.marks.link;
+    if (!linkMarkType) return;
+    const tr = view.state.tr;
+    let changed = false;
+    view.state.doc.descendants((node, pos) => {
+      if (!node.isText) return;
+      const linkMark = node.marks.find((m) => m.type === linkMarkType);
+      if (!linkMark) return;
+      const href = (linkMark.attrs as { href?: string }).href ?? "";
+      if (isAutolinkFalsePositive(node.text ?? "", href)) {
+        tr.removeMark(pos, pos + node.nodeSize, linkMarkType);
+        changed = true;
+      }
+    });
+    if (changed) view.dispatch(tr);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor]);
 
   // Intercept Tab in tables at the DOM level to prevent block nesting
   useEffect(() => {

--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -5,6 +5,7 @@ import {
   cn,
   getPath,
   isAuthorizedUserAdmin,
+  isAuthorizedUserFaculty,
   isContentCreator,
   isContentEditor,
 } from "@/lib/utils";
@@ -377,9 +378,10 @@ export function Sidebar({
   const showActionButton = droplet.status !== "published" && !droplet.inReview;
   const isAdmin = isAuthorizedUserAdmin(user.roles);
   const isEditor = isContentEditor(user.roles);
+  const isFaculty = isAuthorizedUserFaculty(user.roles);
   const isCreator = isContentCreator(user.roles);
   const actionButtonProps =
-    showActionButton && (isAdmin || isEditor)
+    showActionButton && (isAdmin || isEditor || isFaculty)
       ? {
           actionType: (droplet.originalDropletId
             ? "publishDraft"

--- a/frontend/components/ui/blocknote/editor/custom-blocknote.css
+++ b/frontend/components/ui/blocknote/editor/custom-blocknote.css
@@ -59,14 +59,33 @@
   position: relative !important;
 }
 
-/* Hide link button in BlockNote formatting toolbar */
-.blocknote-no-link .bn-formatting-toolbar button[aria-label*="link" i],
-.blocknote-no-link .bn-formatting-toolbar button[aria-label*="Link" i],
-.blocknote-no-link .bn-formatting-toolbar button[title*="link" i],
-.blocknote-no-link .bn-formatting-toolbar button[title*="Link" i],
-.blocknote-no-link .bn-formatting-toolbar button[aria-label*="Create link" i] {
-  display: none !important;
+/* BlockNote sets an inline `white-space: normal` on `.bn-block-content`, which
+   inherits into CodeMirror and collapses leading indentation in readOnly code
+   previews. Restore CodeMirror's own `pre`/`break-spaces` behavior. */
+.bn-block-content .cm-content,
+.bn-block-content .cm-line {
+  white-space: pre !important;
 }
+.bn-block-content .cm-content.cm-lineWrapping,
+.bn-block-content .cm-lineWrapping .cm-line {
+  white-space: break-spaces !important;
+}
+
+/* BlockNote ships no default styling for link marks. Render them as standard
+   blue underlined links inside the editor. */
+.bn-inline-content a {
+  color: #2563eb;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.dark .bn-inline-content a {
+  color: #60a5fa;
+}
+
+/* NOTE: Link button used to be hidden from the formatting toolbar here. We
+   now allow link creation so users can wrap selected text in a link and so
+   the link hover toolbar ("Edit link") can surface. The `.blocknote-no-link`
+   wrapper class is retained for existing tests and any future scoping needs. */
 
 /* Slack-style inline code: border, background, rounded corners */
 .bn-inline-content code {

--- a/frontend/components/ui/blocknote/editor/custom-blocknote.css
+++ b/frontend/components/ui/blocknote/editor/custom-blocknote.css
@@ -72,14 +72,29 @@
 }
 
 /* BlockNote ships no default styling for link marks. Render them as standard
-   blue underlined links inside the editor. */
+   blue underlined links inside the editor, with hover/focus states so
+   keyboard users get a visible indicator. */
 .bn-inline-content a {
   color: #2563eb;
   text-decoration: underline;
   cursor: pointer;
 }
+.bn-inline-content a:hover {
+  color: #1d4ed8;
+}
+.bn-inline-content a:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
 .dark .bn-inline-content a {
   color: #60a5fa;
+}
+.dark .bn-inline-content a:hover {
+  color: #93c5fd;
+}
+.dark .bn-inline-content a:focus-visible {
+  outline-color: #60a5fa;
 }
 
 /* NOTE: Link button used to be hidden from the formatting toolbar here. We

--- a/frontend/lib/blocknote/autolink-filter.ts
+++ b/frontend/lib/blocknote/autolink-filter.ts
@@ -1,0 +1,38 @@
+// Shared helpers for deciding whether a BlockNote link mark is a real link
+// or an autolink false-positive (e.g. "app.py" auto-wrapped because ".py"
+// looks like a TLD). Used by both the BlockNote editor (to strip spurious
+// marks at edit time) and the Strapi renderer (to avoid rendering them as
+// clickable links in preview/published content).
+
+// A link whose visible text starts with a recognized scheme or "www." is
+// considered a genuine URL.
+const REAL_URL_PREFIX = /^(?:[a-z][a-z0-9+.-]*:\/\/|mailto:|tel:|www\.)/i;
+
+// Strips a leading scheme from an href so we can compare it to the visible
+// link text (autolinks set href = "<scheme>://" + text).
+const HREF_SCHEME_PREFIX = /^(?:[a-z][a-z0-9+.-]*:\/\/|mailto:|tel:)/i;
+
+// Schemes we're willing to emit into `href` attributes. Anything else (in
+// particular `javascript:`, `data:`) is an XSS vector and must be rejected
+// before it becomes a mark or a rendered anchor.
+const SAFE_URI = /^(?:https?:\/\/|mailto:|tel:|\/|#|\?)/i;
+
+export function linkTextLooksLikeRealUrl(text: string): boolean {
+  return REAL_URL_PREFIX.test(text);
+}
+
+export function isAutolinkFalsePositive(
+  text: string,
+  href: string | null | undefined,
+): boolean {
+  if (!href) return false;
+  const hrefWithoutScheme = href.replace(HREF_SCHEME_PREFIX, "");
+  if (hrefWithoutScheme !== text) return false;
+  return !linkTextLooksLikeRealUrl(text);
+}
+
+// Use at any site that turns a user-supplied string into an anchor href.
+export function isSafeLinkHref(href: string | null | undefined): boolean {
+  if (!href) return false;
+  return SAFE_URI.test(href);
+}

--- a/frontend/lib/blocknote/convert-blocks.ts
+++ b/frontend/lib/blocknote/convert-blocks.ts
@@ -135,6 +135,11 @@ function convertInlineContentToStrapiBlocks(
 ): StrapiBlocksTextNode[] {
   return inlineContent.flatMap((contentItem) => {
     if (contentItem.type === "link") {
+      // Strapi Blocks output is consumed by callout rendering (see line ~301
+      // in this file), which doesn't render clickable anchors — so links are
+      // intentionally flattened to their visible text and the href is
+      // dropped. The HTML conversion path (`convertInlineContentToHtml`)
+      // preserves links as `<a>` tags for generic/block rendering.
       return convertInlineContentToStrapiBlocks(contentItem.content ?? []);
     }
     const text = contentItem.text ?? "";

--- a/frontend/lib/blocknote/convert-blocks.ts
+++ b/frontend/lib/blocknote/convert-blocks.ts
@@ -7,6 +7,10 @@ import katex from "katex";
 import { Block, CustomBlockNoteBlock } from "@/types";
 import { SLIDE_BREAK_MARKER } from "@/lib/blocknote/slide-break";
 import { COLUMN_BREAK_MARKER } from "@/lib/blocknote/column-break";
+import {
+  isAutolinkFalsePositive,
+  isSafeLinkHref,
+} from "@/lib/blocknote/autolink-filter";
 
 type BlockNoteTextStyles = {
   bold?: boolean;
@@ -20,6 +24,10 @@ type BlockNoteInlineContent = {
   type?: string;
   text?: string;
   styles?: BlockNoteTextStyles;
+  // Present when type === "link": an auto-linked or user-inserted link node
+  // wraps its text in `content`.
+  href?: string;
+  content?: BlockNoteInlineContent[];
 };
 
 // Strapi Blocks text node (minimal subset we care about)
@@ -99,6 +107,22 @@ function convertInlineContentToHtml(
           const text = contentItem.text ?? "";
           return renderTextWithStyles(text, contentItem.styles);
         }
+        if (contentItem.type === "link") {
+          const inner = convertInlineContentToHtml(contentItem.content ?? []);
+          if (!inner) return "";
+          const linkText = (contentItem.content ?? [])
+            .map((c) => c.text ?? "")
+            .join("");
+          const rawHref = contentItem.href ?? "";
+          if (
+            isAutolinkFalsePositive(linkText, rawHref) ||
+            !isSafeLinkHref(rawHref)
+          ) {
+            return inner;
+          }
+          const href = escapeHtml(rawHref);
+          return `<a href="${href}" target="_blank" rel="noopener noreferrer">${inner}</a>`;
+        }
         return "";
       })
       .join("") || ""
@@ -109,7 +133,10 @@ function convertInlineContentToHtml(
 function convertInlineContentToStrapiBlocks(
   inlineContent: BlockNoteInlineContent[],
 ): StrapiBlocksTextNode[] {
-  return inlineContent.map((contentItem) => {
+  return inlineContent.flatMap((contentItem) => {
+    if (contentItem.type === "link") {
+      return convertInlineContentToStrapiBlocks(contentItem.content ?? []);
+    }
     const text = contentItem.text ?? "";
 
     const node: StrapiBlocksTextNode = {
@@ -126,7 +153,7 @@ function convertInlineContentToStrapiBlocks(
       // LaTeX is kept as plain text – rendered later by block renderers
     }
 
-    return node;
+    return [node];
   });
 }
 
@@ -139,6 +166,9 @@ function convertInlineContentToText(
       .map((contentItem) => {
         if (contentItem.type === "text") {
           return contentItem.text ?? "";
+        }
+        if (contentItem.type === "link") {
+          return convertInlineContentToText(contentItem.content ?? []);
         }
         return "";
       })

--- a/frontend/tests/components/draft/sidebar.test.tsx
+++ b/frontend/tests/components/draft/sidebar.test.tsx
@@ -394,5 +394,24 @@ describe("Sidebar", () => {
         screen.queryByTestId("content-action-button"),
       ).not.toBeInTheDocument();
     });
+
+    it("uses publishDraft actionType when the droplet is a draft revision", () => {
+      render(
+        <Sidebar
+          user={
+            {
+              ...mockUser,
+              roles: [AuthorizedUserRoleTitle.SysAdmin],
+            } as any
+          }
+          droplet={{ ...mockDroplet, originalDropletId: 42 } as any}
+          availableDroplets={[]}
+          {...defaultProps}
+        />,
+      );
+      const btn = screen.getByTestId("content-action-button");
+      expect(btn).toHaveAttribute("data-action-type", "publishDraft");
+      expect(btn).toHaveAttribute("data-button-text", "Publish");
+    });
   });
 });

--- a/frontend/tests/components/draft/sidebar.test.tsx
+++ b/frontend/tests/components/draft/sidebar.test.tsx
@@ -28,9 +28,23 @@ jest.mock("@/components/draft/add-lesson", () => ({
   AddLesson: () => <div data-testid="add-lesson" />,
 }));
 
-// Mock the ContentActionButton component to avoid complex setup
+// Mock the ContentActionButton component to avoid complex setup.
+// Surface the actionType and buttonText so permission tests can assert on
+// which button (Publish vs Review) the sidebar hands to a given user role.
 jest.mock("@/components/draft/metadata/content-action-button", () => ({
-  ContentActionButton: () => <div data-testid="content-action-button" />,
+  ContentActionButton: ({
+    actionType,
+    buttonText,
+  }: {
+    actionType: string;
+    buttonText: string;
+  }) => (
+    <div
+      data-testid="content-action-button"
+      data-action-type={actionType}
+      data-button-text={buttonText}
+    />
+  ),
 }));
 
 describe("Sidebar", () => {
@@ -333,5 +347,52 @@ describe("Sidebar", () => {
     );
 
     expect(screen.getByText("Overview")).toBeInTheDocument();
+  });
+
+  describe("publish button permissions", () => {
+    const renderWithRoles = (roles: AuthorizedUserRoleTitle[]) =>
+      render(
+        <Sidebar
+          user={{ ...mockUser, roles } as any}
+          droplet={mockDroplet as any}
+          availableDroplets={[]}
+          {...defaultProps}
+        />,
+      );
+
+    it("shows Publish button for SysAdmin", () => {
+      renderWithRoles([AuthorizedUserRoleTitle.SysAdmin]);
+      const btn = screen.getByTestId("content-action-button");
+      expect(btn).toHaveAttribute("data-action-type", "publish");
+      expect(btn).toHaveAttribute("data-button-text", "Publish");
+    });
+
+    it("shows Publish button for ContentEditor", () => {
+      renderWithRoles([AuthorizedUserRoleTitle.ContentEditor]);
+      const btn = screen.getByTestId("content-action-button");
+      expect(btn).toHaveAttribute("data-action-type", "publish");
+      expect(btn).toHaveAttribute("data-button-text", "Publish");
+    });
+
+    it("shows Publish button for Faculty", () => {
+      renderWithRoles([AuthorizedUserRoleTitle.Faculty]);
+      const btn = screen.getByTestId("content-action-button");
+      expect(btn).toHaveAttribute("data-action-type", "publish");
+      expect(btn).toHaveAttribute("data-button-text", "Publish");
+    });
+
+    it("shows Review button for ContentCreator (no direct publish)", () => {
+      renderWithRoles([AuthorizedUserRoleTitle.ContentCreator]);
+      const btn = screen.getByTestId("content-action-button");
+      expect(btn).toHaveAttribute("data-action-type", "requestReview");
+      expect(btn).toHaveAttribute("data-button-text", "Review");
+    });
+
+    it("shows no action button for User role", () => {
+      renderWithRoles([AuthorizedUserRoleTitle.User]);
+      expect(
+        screen.queryByTestId("content-action-button"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/tests/lib/blocknote/autolink-filter.test.ts
+++ b/frontend/tests/lib/blocknote/autolink-filter.test.ts
@@ -1,0 +1,113 @@
+import {
+  isAutolinkFalsePositive,
+  isSafeLinkHref,
+  linkTextLooksLikeRealUrl,
+} from "@/lib/blocknote/autolink-filter";
+
+describe("autolink-filter", () => {
+  describe("linkTextLooksLikeRealUrl", () => {
+    it.each([
+      ["https://google.com", true],
+      ["http://example.com", true],
+      ["www.example.com", true],
+      ["mailto:a@b.com", true],
+      ["tel:+14155551212", true],
+      ["ftp://files.example.com", true],
+      ["HTTPS://MIXED.CASE", true],
+      ["app.py", false],
+      ["requirements.txt", false],
+      ["data.csv", false],
+      ["click here", false],
+      ["", false],
+    ])("%s -> %s", (input, expected) => {
+      expect(linkTextLooksLikeRealUrl(input)).toBe(expected);
+    });
+  });
+
+  describe("isSafeLinkHref", () => {
+    it.each([
+      ["https://google.com", true],
+      ["http://example.com", true],
+      ["mailto:a@b.com", true],
+      ["tel:+14155551212", true],
+      ["/relative/path", true],
+      ["#anchor", true],
+      ["?query=1", true],
+      ["javascript:alert(1)", false],
+      ["JavaScript:alert(1)", false],
+      ["data:text/html,<script>", false],
+      ["vbscript:msgbox", false],
+      ["file:///etc/passwd", false],
+      ["", false],
+      [null, false],
+      [undefined, false],
+    ])("%s -> %s", (input, expected) => {
+      expect(isSafeLinkHref(input)).toBe(expected);
+    });
+  });
+
+  describe("isAutolinkFalsePositive", () => {
+    // Autolink false-positives: href equals "scheme://" + text, and text
+    // doesn't look like a URL on its own.
+    it("strips `app.py` auto-wrapped as https://app.py", () => {
+      expect(isAutolinkFalsePositive("app.py", "https://app.py")).toBe(true);
+    });
+
+    it("strips `requirements.txt` auto-wrapped", () => {
+      expect(
+        isAutolinkFalsePositive("requirements.txt", "https://requirements.txt"),
+      ).toBe(true);
+    });
+
+    it("strips `data.csv` auto-wrapped", () => {
+      expect(isAutolinkFalsePositive("data.csv", "https://data.csv")).toBe(
+        true,
+      );
+    });
+
+    // Real URLs with matching text are preserved.
+    it("keeps href=text when text already has a scheme", () => {
+      expect(
+        isAutolinkFalsePositive("https://google.com", "https://google.com"),
+      ).toBe(false);
+    });
+
+    it("keeps `www.` prefixed text", () => {
+      expect(
+        isAutolinkFalsePositive("www.example.com", "https://www.example.com"),
+      ).toBe(false);
+    });
+
+    // Manual links: href differs from text, always kept.
+    it("keeps manual link with arbitrary text (click here)", () => {
+      expect(isAutolinkFalsePositive("click here", "https://openai.com")).toBe(
+        false,
+      );
+    });
+
+    it("keeps manual mailto link with arbitrary text", () => {
+      expect(
+        isAutolinkFalsePositive("email the team", "mailto:team@example.com"),
+      ).toBe(false);
+    });
+
+    it("keeps manual link with scheme-in-text but different href", () => {
+      expect(
+        isAutolinkFalsePositive(
+          "https://short.link",
+          "https://actual-target.example.com",
+        ),
+      ).toBe(false);
+    });
+
+    // Guards
+    it("returns false when href is empty", () => {
+      expect(isAutolinkFalsePositive("app.py", "")).toBe(false);
+    });
+
+    it("returns false when href is nullish", () => {
+      expect(isAutolinkFalsePositive("app.py", null)).toBe(false);
+      expect(isAutolinkFalsePositive("app.py", undefined)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the v2 → v1 converter so BlockNote `type: "link"` inline content no longer vanishes in preview. Existing content that had this bug (autolinked filenames like `app.py`) now renders correctly.
- Prevents BlockNote's autolinker from wrapping bare filenames (`app.py`, `requirements.txt`, `data.csv`) as links in the first place, via a ProseMirror plugin that strips false positives plus a one-time cleanup of legacy content on editor mount.
- Re-enables link creation (formatting toolbar button + hover "Edit link" tooltip), which was hidden as a workaround for the renderer bug this PR fixes.
- Adds a markdown `[text](url)` input rule with safe-URI validation.
- Faculty role gets the Publish button on drafts (was a dead role in the permission matrix).
- Fixes hydration warning from browser extensions injecting attributes on `<body>`.
- Removes the literal backticks Tailwind Typography inserts around inline `<code>` in preview, and applies the editor's Slack-style pill so edit and preview match.
- Fixes CodeMirror indentation collapsing inside readOnly code-block previews (BlockNote's inline `white-space: normal` on `.bn-block-content` was inheriting into CodeMirror).

## Security
URI scheme allow-list (`http`, `https`, `mailto`, `tel`, `/`, `#`, `?`) applied in both the markdown input rule and the renderer. `javascript:`, `data:`, `vbscript:`, `file:` hrefs are rejected (renderer falls back to plain text; input rule aborts without applying the mark). Shared logic lives in `lib/blocknote/autolink-filter.ts` with unit tests covering the full truth table.

## Test plan
- [x] Load a droplet with a lesson whose bulletListItem contains an inline link (e.g. test droplet `bug-repro-app-py-link-stripping`).
- [x] In preview: real URLs render as blue links, filenames like `app.py` render as plain text.
- [x] In the editor: type `app.py` — stays plain text. Type `https://google.com` + space — autolinks. Paste `http://...` — autolinks.
- [x] Type `[Google](https://google.com)` then the closing `)` — collapses to a blue "Google" link.
- [x] Try `[xss](javascript:alert(1))` — stays as literal markdown text (mark not applied).
- [x] Select text → click link button in floating toolbar → add URL → link is created.
- [x] Hover a link → "Edit link" toolbar appears.
- [x] Faculty user: open a draft droplet, see the Publish button.
- [x] SysAdmin/ContentEditor: still see Publish. ContentCreator: still sees Review. User role: no action button.
- [x] Code block in a lesson: indentation (`def func():\n    print(...)`) renders correctly in both edit and readOnly preview.
- [x] Inline code `` `foo` `` in preview renders as pill with no surrounding backticks.
- [x] Full Jest suite (4384 tests, 303 suites) passes locally including new `autolink-filter` suite and the Faculty permission-matrix additions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Faculty role can now publish content alongside admins and editors.
  * Improved link handling in the editor with enhanced validation.

* **Bug Fixes**
  * Removed spurious autolinks incorrectly created in the editor.
  * Fixed link styling and whitespace display in content.

* **Style**
  * Enhanced inline code styling with "code pill" appearance and dark mode support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->