### PR TITLE
fix(presentation): default-safe gate so legacy droplets keep working

### DIFF
--- a/frontend/app/(presentation)/d/[slug]/present/page.tsx
+++ b/frontend/app/(presentation)/d/[slug]/present/page.tsx
@@ -50,8 +50,10 @@ export default async function PresentationPage({ params }: Props) {
 
   if (!isAdmin && !isAuthor && !isEnrolled) return notFound();
 
-  // Block presentation if not enabled by the creator
-  if (!droplet.presentationEnabled) {
+  // Block presentation if the author explicitly disabled it.
+  // Legacy droplets (`presentationEnabled == null`) fall through so they keep
+  // working; new droplets default to `false` and require an explicit opt-in.
+  if (droplet.presentationEnabled === false) {
     return <NoPresentationWarning dropletSlug={slug} reason="disabled" />;
   }
 

--- a/frontend/components/draft/sidebar.tsx
+++ b/frontend/components/draft/sidebar.tsx
@@ -681,17 +681,18 @@ export function Sidebar({
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <label className="flex items-center gap-2 text-xs font-medium text-slate-600 dark:text-slate-400">
+                    <label
+                      id="presentation-toggle-label"
+                      className="flex items-center gap-2 text-xs font-medium text-slate-600 dark:text-slate-400"
+                    >
                       <IconPresentation className="h-3.5 w-3.5" />
                       Presentation
                     </label>
                   </TooltipTrigger>
                   <TooltipContent side="top">
-                    {!hasSlideBreaks
-                      ? "Add slide breaks first to enable presentation for viewers"
-                      : presentationEnabled
-                        ? "Viewers can access presentation mode"
-                        : "Viewers cannot access presentation mode"}
+                    {presentationEnabled
+                      ? "Viewers can access presentation mode"
+                      : "Viewers cannot access presentation mode"}
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -699,11 +700,8 @@ export function Sidebar({
                 type="button"
                 role="switch"
                 aria-checked={presentationEnabled}
-                aria-label="Toggle presentation mode for viewers"
-                disabled={
-                  isTogglingPresentation ||
-                  (!hasSlideBreaks && !presentationEnabled)
-                }
+                aria-labelledby="presentation-toggle-label"
+                disabled={isTogglingPresentation}
                 onClick={handleTogglePresentation}
                 className={cn(
                   "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",

--- a/frontend/components/droplets/sidebar.tsx
+++ b/frontend/components/droplets/sidebar.tsx
@@ -69,7 +69,7 @@ export default function Sidebar({
   const canPresent =
     isEnrolled &&
     (droplet.lessons?.length ?? 0) > 0 &&
-    droplet.presentationEnabled;
+    droplet.presentationEnabled !== false;
 
   const activeLinkClasses =
     "flex w-full items-center gap-3 rounded-xl px-3 py-2.5 transition-colors bg-[#287697]/10 text-[#287697] dark:bg-[#287697]/20 dark:text-[#4AABCF]";


### PR DESCRIPTION
## Summary
- Switch viewer presentation gates from `!droplet.presentationEnabled` to `=== false`, so legacy droplets (where `presentationEnabled` is `null` because Strapi's `default: false` doesn't backfill existing rows) keep working. New droplets still default to `false` and require an explicit author opt-in via the toggle.
- Fix the draft-sidebar Presentation toggle being permanently disabled — the disabled flag was driven by `hasSlideBreaks` computed from server-populated lesson data, which never updated when the author added a slide break in the BlockNote editor. Authors can now flip the toggle anytime (incl. before adding breaks, or while breaks exist but the droplet isn't ready for viewers).
- Add the missing `aria-labelledby` on the toggle switch (audit ODY-428).

## Why
Without the field migration, every existing published droplet on prod hits the "Presentation Not Available" screen because `null` was treated as "off." See `docs/plans/presentation-toggle-dark-mode-audit.md` (ODY-427).

## Behavior matrix
| `presentationEnabled` | viewer can present? |
| --- | --- |
| `true` | yes |
| `false` (new droplet default, or author opt-out) | no |
| `null` (legacy droplet predating the field) | yes — backward compat |

## Test plan
- [ ] Legacy droplet (DB row with `presentation_enabled = NULL`): Present button visible in sidebar, presentation page renders.
- [ ] New droplet, toggle off: Present button disabled in sidebar; direct nav to `/d/<slug>/present` shows "Presentation Not Available."
- [ ] New droplet, toggle on, with slide breaks: presentation works.
- [ ] New droplet, toggle on, no slide breaks: shows "no-slides" warning (existing behavior).
- [ ] Draft sidebar: toggle is clickable before adding any slide break, persists across page refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed presentation feature logic to properly handle legacy data states, ensuring presentations are only disabled when explicitly set.
  * Updated presentation eligibility checks for consistency across the application.

* **Improvements**
  * Enhanced accessibility for the presentation toggle with explicit element labeling.
  * Simplified presentation toggle messaging to focus on essential information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->