### PR TITLE
moved saved automatically to right and italicize

### DIFF
--- a/frontend/components/draft/lesson/lesson-renderer.tsx
+++ b/frontend/components/draft/lesson/lesson-renderer.tsx
@@ -605,7 +605,7 @@ export function LessonRenderer({
       ) : (
         <div className="mt-8 w-full px-10 md:px-40">
           <div className="w-full min-w-[300px] md:min-w-[700px]">
-            <p className="mb-4 text-base text-slate-600 dark:text-slate-300">
+            <p className="mb-4 text-right text-sm text-slate-400 italic dark:text-slate-400">
               Changes saved automatically
             </p>
             <DatasetProvider datasets={datasets}>


### PR DESCRIPTION
italicize and make font lighter grey. Moved to the right of lesson editor.

<img width="1036" height="392" alt="image" src="https://github.com/user-attachments/assets/977b9866-2e3c-49f9-8f01-16113b34701d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of the "Changes saved automatically" status message to be smaller, lighter, and right-aligned for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->