### PR TITLE
improvement(voyages): add "Start your Voyage" heading above island map

### DIFF
--- a/frontend/app/(voyages)/v/[slug]/page.tsx
+++ b/frontend/app/(voyages)/v/[slug]/page.tsx
@@ -491,7 +491,14 @@ export default async function VoyagePage({ params }: Props) {
           {/* Right: Map (takes remaining space) */}
           <div className="min-w-0 flex-1">
             {treeNodes.length > 0 ? (
-              <VoyageTreeMap nodes={treeNodes} />
+              <div>
+                <h2 className="mb-4 text-center text-3xl font-bold tracking-tight text-slate-800 italic sm:text-4xl dark:text-slate-100">
+                  Start your Voyage
+                </h2>
+                <div className="pt-32">
+                  <VoyageTreeMap nodes={treeNodes} />
+                </div>
+              </div>
             ) : (
               <div className="flex h-64 items-center justify-center rounded-xl border border-dashed border-slate-300 text-slate-400 dark:border-slate-600">
                 No playlists added to this voyage yet.


### PR DESCRIPTION
## Summary
- Adds a large italic "Start your Voyage" heading above the VoyageTreeMap on `/v/[slug]`
- Gives the first main island a visual entry point instead of landing directly on the step-1 badge
- Only affects the published/draft voyage view page; create form and other voyage pages are untouched

## Test plan
- [x] Visit any published voyage — heading renders centered above the first island
- [x] Dark mode color holds up (slate-100 on dark)
- [x] Empty voyage (no islands) still shows the "No playlists added" fallback
- [x] Prettier passes
- [x] ESLint passes (no warnings or errors)
- [x] Full Jest suite passes (303 suites, 4385 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Start your Voyage" heading to the voyage map display.

* **Style**
  * Enhanced spacing around the voyage map for improved layout presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->