### PR TITLE
feat: in-app code execution — Pyodide for Python, server proxy for other languages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,10 +53,25 @@ services:
       - ./frontend/.docker.env
     environment:
       - WATCHPACK_POLLING=true
+      # PISTON_API_URL / JUDGE0_API_URL / JUDGE0_API_KEY come from
+      # frontend/.env.local. Judge0 wins if both are set.
     ports:
       - 3000:3000
     depends_on:
       - strapi
+      - piston
+    networks:
+      - frontend
+
+  piston:
+    container_name: piston
+    image: ghcr.io/engineer-man/piston:latest
+    restart: unless-stopped
+    privileged: true
+    volumes:
+      - piston-data:/piston
+    ports:
+      - "127.0.0.1:2000:2000"
     networks:
       - frontend
 
@@ -64,6 +79,7 @@ volumes:
   strapi-data:
   frontend_node_modules:
   frontend_cache:
+  piston-data:
 
 networks:
   frontend:

--- a/frontend/app/api/run-code/route.ts
+++ b/frontend/app/api/run-code/route.ts
@@ -1,0 +1,263 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth/options";
+
+// Two supported upstreams, env-selected:
+//   1. Judge0 (hosted, e.g. RapidAPI) — set JUDGE0_API_URL + JUDGE0_API_KEY.
+//      No infra needed. Free RapidAPI tier ≈ 50 req/day; paid plans go higher.
+//   2. Piston (self-hosted or whitelisted) — set PISTON_API_URL.
+//      Unlimited within your container budget; needs a privileged EC2.
+// Judge0 wins if both are set. When neither is set, non-Python execution
+// returns 503 and Python continues to work in-browser via Pyodide.
+const JUDGE0_URL = process.env.JUDGE0_API_URL ?? "";
+const JUDGE0_KEY = process.env.JUDGE0_API_KEY ?? "";
+const PISTON_URL = process.env.PISTON_API_URL ?? "";
+
+const MAX_CODE_BYTES = 50_000;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 10;
+const UPSTREAM_TIMEOUT_MS = 15_000;
+
+// Allowlist of language identifiers exposed to clients. Keep in sync with
+// code-block.tsx. These strings are *also* the Piston language names.
+const ALLOWED_LANGUAGES = new Set([
+  "javascript",
+  "typescript",
+  "python",
+  "java",
+  "c++",
+  "c",
+  "csharp",
+  "php",
+  "ruby",
+  "bash",
+  "go",
+  "rust",
+  "kotlin",
+  "swift",
+]);
+
+// Judge0 CE language IDs (https://ce.judge0.com/languages).
+const JUDGE0_LANGUAGE_IDS: Record<string, number> = {
+  javascript: 63, // Node.js 12.14.0
+  typescript: 74, // 3.7.4
+  python: 71, // 3.8.1
+  java: 62, // OpenJDK 13.0.1
+  "c++": 54, // GCC 9.2.0
+  c: 50, // GCC 9.2.0
+  csharp: 51, // Mono 6.6.0.161
+  php: 68, // 7.4.1
+  ruby: 72, // 2.7.0
+  bash: 46, // 5.0.0
+  go: 60, // 1.13.5
+  rust: 73, // 1.40.0
+  kotlin: 78, // 1.3.70
+  swift: 83, // 5.2.3
+};
+
+// Must start with an alphanumeric/underscore; no path traversal.
+const ALLOWED_FILENAME = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,63}$/;
+
+// Per-task in-memory rate limit. ECS may run multiple tasks, so the effective
+// limit is N * RATE_LIMIT_MAX/min — fine as a friction layer, not a hard cap.
+const hits = new Map<string, number[]>();
+
+function rateLimited(key: string): boolean {
+  const now = Date.now();
+  // Opportunistic sweep so the map doesn't grow forever as users come and go.
+  for (const [k, ts] of hits) {
+    const fresh = ts.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+    if (fresh.length === 0) hits.delete(k);
+    else if (fresh.length !== ts.length) hits.set(k, fresh);
+  }
+  const recent = hits.get(key) ?? [];
+  if (recent.length >= RATE_LIMIT_MAX) return true;
+  recent.push(now);
+  hits.set(key, recent);
+  return false;
+}
+
+// Normalize provider responses into Piston's response shape so the existing
+// client (code-block.tsx) doesn't need to know which upstream ran.
+type NormalizedRun = {
+  compile?: { code: number; stdout: string; stderr: string; output: string };
+  run: { code: number; stdout: string; stderr: string; output: string };
+  language: string;
+};
+
+async function runViaJudge0(
+  language: string,
+  code: string,
+): Promise<NormalizedRun> {
+  const langId = JUDGE0_LANGUAGE_IDS[language];
+  if (!langId) throw new Error(`No Judge0 ID for ${language}`);
+
+  const url = new URL(JUDGE0_URL);
+  url.searchParams.set("base64_encoded", "true");
+  url.searchParams.set("wait", "true");
+
+  // Judge0 RapidAPI uses x-rapidapi-* headers; self-hosted uses neither.
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (JUDGE0_KEY) {
+    headers["x-rapidapi-key"] = JUDGE0_KEY;
+    try {
+      headers["x-rapidapi-host"] = new URL(JUDGE0_URL).host;
+    } catch {
+      // ignore — let upstream URL validation fail noisily
+    }
+  }
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      source_code: Buffer.from(code, "utf8").toString("base64"),
+      language_id: langId,
+      stdin: "",
+    }),
+    signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`judge0 ${res.status}`);
+
+  const j = (await res.json()) as {
+    stdout?: string | null;
+    stderr?: string | null;
+    compile_output?: string | null;
+    status?: { id?: number; description?: string };
+    message?: string | null;
+  };
+
+  const decode = (s: string | null | undefined) =>
+    s ? Buffer.from(s, "base64").toString("utf8") : "";
+  const stdout = decode(j.stdout);
+  const stderr = decode(j.stderr);
+  const compileOut = decode(j.compile_output);
+  const statusId = j.status?.id ?? 0;
+  // Judge0 status: 3 = Accepted; 6 = Compilation Error; 11/12 = runtime errors.
+  const compileFailed = statusId === 6;
+  const runFailed = statusId !== 3 && !compileFailed;
+  return {
+    compile: compileFailed
+      ? { code: 1, stdout: "", stderr: compileOut, output: compileOut }
+      : { code: 0, stdout: "", stderr: "", output: "" },
+    run: {
+      code: runFailed ? 1 : 0,
+      stdout,
+      stderr: stderr || (runFailed ? j.status?.description ?? "" : ""),
+      output: stdout,
+    },
+    language,
+  };
+}
+
+async function runViaPiston(
+  language: string,
+  code: string,
+  fileName: string,
+): Promise<NormalizedRun> {
+  const res = await fetch(PISTON_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": "odyssey-khoury/1.0 (+https://khouryodyssey.org)",
+    },
+    body: JSON.stringify({
+      language,
+      version: "*",
+      files: [{ name: fileName, content: code }],
+      stdin: "",
+      args: [],
+      compile_timeout: 10000,
+      run_timeout: 3000,
+    }),
+    signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`piston ${res.status}`);
+  return (await res.json()) as NormalizedRun;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (rateLimited(session.user.email)) {
+      return NextResponse.json(
+        { error: "Rate limit exceeded. Try again in a minute." },
+        { status: 429 },
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const { language, code, fileName } = (body ?? {}) as {
+      language?: unknown;
+      code?: unknown;
+      fileName?: unknown;
+    };
+
+    if (typeof language !== "string" || !ALLOWED_LANGUAGES.has(language)) {
+      return NextResponse.json(
+        { error: "Unsupported language" },
+        { status: 400 },
+      );
+    }
+    if (typeof code !== "string") {
+      return NextResponse.json({ error: "Invalid code" }, { status: 400 });
+    }
+    if (Buffer.byteLength(code, "utf8") > MAX_CODE_BYTES) {
+      return NextResponse.json({ error: "Code too large" }, { status: 413 });
+    }
+    if (
+      typeof fileName !== "string" ||
+      !ALLOWED_FILENAME.test(fileName) ||
+      fileName.includes("..")
+    ) {
+      return NextResponse.json({ error: "Invalid file name" }, { status: 400 });
+    }
+
+    const useJudge0 = !!JUDGE0_URL;
+    const usePiston = !useJudge0 && !!PISTON_URL;
+    if (!useJudge0 && !usePiston) {
+      return NextResponse.json(
+        {
+          error:
+            "Code execution for this language is currently unavailable. Python runs in your browser; other languages require a configured execution backend.",
+        },
+        { status: 503 },
+      );
+    }
+
+    let result: NormalizedRun;
+    try {
+      result = useJudge0
+        ? await runViaJudge0(language, code)
+        : await runViaPiston(language, code, fileName);
+    } catch (err) {
+      const isAbort = err instanceof Error && err.name === "TimeoutError";
+      return NextResponse.json(
+        {
+          error: isAbort
+            ? "Execution timed out"
+            : "Execution service unreachable",
+        },
+        { status: isAbort ? 504 : 502 },
+      );
+    }
+
+    return NextResponse.json(result, {
+      headers: { "Cache-Control": "no-store" },
+    });
+  } catch {
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/frontend/components/ui/blocknote/blocks/code-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/code-block.tsx
@@ -6,8 +6,10 @@ import React from "react";
 import { Play, Edit, Lock, Check, X, AlertCircle, Loader2 } from "lucide-react";
 import { CodeEditor } from "@/components/ui/code-editor";
 
-// Piston API configuration - calling directly
-const PISTON_API_URL = "https://emkc.org/api/v2/piston/execute";
+// Server-side proxy. Browser never calls Piston directly — see
+// frontend/app/api/run-code/route.ts. Python is executed in-browser via
+// Pyodide and never hits the network.
+const RUN_CODE_URL = "/api/run-code";
 
 // Languages supported by both Piston and CodeMirror
 const SUPPORTED_LANGUAGES = {
@@ -79,7 +81,28 @@ function getPlaceholder(language: string): string {
   return "// Write your code here";
 }
 
-const executePistonCode = async (language: string, code: string) => {
+type ExecResult = { success: boolean; output: string };
+
+async function executePython(code: string): Promise<ExecResult> {
+  try {
+    const { runPython } = await import("@/lib/pyodide/runtime");
+    const result = await runPython(code);
+    if (result.error) {
+      return { success: false, output: result.error.trim() };
+    }
+    const out =
+      (result.stdout || "").trim() || "Code executed successfully (no output)";
+    return { success: true, output: out };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { success: false, output: `Execution error: ${msg}` };
+  }
+}
+
+async function executeViaProxy(
+  language: string,
+  code: string,
+): Promise<ExecResult> {
   const langConfig = allLanguages.find((l) => l.value === language);
   if (!langConfig || !langConfig.pistonName) {
     return {
@@ -89,34 +112,24 @@ const executePistonCode = async (language: string, code: string) => {
   }
 
   try {
-    const response = await fetch(PISTON_API_URL, {
+    const response = await fetch(RUN_CODE_URL, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         language: langConfig.pistonName,
-        version: "*",
-        files: [
-          {
-            name: langConfig.fileName,
-            content: code,
-          },
-        ],
-        stdin: "",
-        args: [],
-        compile_timeout: 10000,
-        run_timeout: 3000,
+        code,
+        fileName: langConfig.fileName,
       }),
     });
 
     if (!response.ok) {
-      throw new Error(`API error: ${response.status}`);
+      const body = await response.json().catch(() => ({}));
+      const msg = body?.error ?? `Execution service error (${response.status})`;
+      return { success: false, output: msg };
     }
 
     const result = await response.json();
 
-    // Handle compilation errors
     if (result.compile && result.compile.code !== 0) {
       return {
         success: false,
@@ -127,31 +140,35 @@ const executePistonCode = async (language: string, code: string) => {
       };
     }
 
-    // Handle runtime errors
-    if (result.run.code !== 0 && result.run.stderr) {
-      return {
-        success: false,
-        output: result.run.stderr,
-      };
+    // Treat any non-zero run exit as a failure so silent failures
+    // (exit(1) with no stderr) aren't shown as success in green.
+    if (result.run && result.run.code !== 0) {
+      const errOut =
+        (result.run.stderr || "").trim() ||
+        (result.run.output || "").trim() ||
+        (result.run.stdout || "").trim() ||
+        `Process exited with code ${result.run.code}`;
+      return { success: false, output: errOut };
     }
 
-    // Return successful output
     const output =
-      result.run.stdout ||
-      result.run.output ||
+      result.run?.stdout ||
+      result.run?.output ||
       "Code executed successfully (no output)";
-    return {
-      success: true,
-      output: output.trim(),
-    };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    return {
-      success: false,
-      output: `Execution error: ${error.message}`,
-    };
+    return { success: true, output: String(output).trim() };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { success: false, output: `Execution error: ${msg}` };
   }
-};
+}
+
+async function executeCode(
+  language: string,
+  code: string,
+): Promise<ExecResult> {
+  if (language === "python") return executePython(code);
+  return executeViaProxy(language, code);
+}
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const CodeBlockComponent = ({ block, editor }: any) => {
   const [isEditing, setIsEditing] = useState(false);
@@ -213,7 +230,7 @@ const CodeBlockComponent = ({ block, editor }: any) => {
     setExecutionSuccess(true);
 
     try {
-      const result = await executePistonCode(block.props.language, code);
+      const result = await executeCode(block.props.language, code);
       setOutput(result.output);
       setExecutionSuccess(result.success);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

The BlockNote code block called emkc.org's public Piston API directly from the browser with no auth header. emkc went whitelist-only on 2026-02-15 and started returning 401 to all unauthenticated traffic, breaking the Run button across the platform.

This PR replaces that flow with two paths:

- **Python** runs in the browser via Pyodide (no network hop, sandboxed by the runtime, no third-party dependency).
- **All other languages** route through a new auth-gated server proxy at `/api/run-code` that forwards to either **Judge0** or a **self-hosted Piston** instance, env-selected.

## What changed

- `frontend/app/api/run-code/route.ts` (new) — auth-gated proxy. Validates language allowlist, file name, and 50KB code-size cap. Per-user in-memory rate limit (10/min) with opportunistic sweep so the map doesn't grow forever. 15s upstream timeout via `AbortSignal.timeout`. Distinct 504/502/503 responses. Normalizes Judge0 responses into Piston's shape so the client doesn't care which upstream ran.
- `frontend/components/ui/blocknote/blocks/code-block.tsx` — Python now uses Pyodide (dynamic import keeps the WASM out of the initial bundle); other languages call `/api/run-code`. Fixed a silent-success bug where non-zero exits with empty stderr were rendered as success.
- `docker-compose.yml` — adds a local Piston container so dev works offline; frontend `depends_on` it.

## Deploy

No new AWS infra required. Production picks an upstream by env:

- **Now — Judge0** — add `JUDGE0_API_URL` and `JUDGE0_API_KEY` to Secrets Manager (`odyssey/{dev2,prod}/frontend`), reference both as `secrets:` on the live frontend task definition, register the new revision, `update-service`.
- **Later — self-hosted Piston** (if traffic outgrows Judge0) — stand up a privileged EC2 in the existing VPC, register it in Cloud Map as `piston.odyssey.local`, set `PISTON_API_URL` to its private endpoint. Same proxy code, no client changes.

If neither env var is set, non-Python execution returns a 503 with a clear message and Python keeps working.

## Test plan

- [x] Pyodide path: Python block runs in-browser, no `/api/run-code` request in Network tab
- [x] Proxy → Judge0: JS, C++, Bash blocks return correct stdout/stderr, compile errors surface as red
- [x] Proxy → Piston (local): same outputs against the docker-compose Piston container
- [x] Auth gate: incognito tab gets 401 from `/api/run-code`
- [x] Rate limit: 11th call within 60s returns 429
- [x] Oversize body (>50KB) returns 413
- [x] Type-check clean; lint clean (one pre-existing exhaustive-deps warning unrelated to this change)
- [x] Existing 4388 tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side code execution API endpoint
  * Introduced Piston code execution service for the application
  * Added in-browser Python execution capability via Pyodide

* **Infrastructure**
  * Updated Docker Compose configuration to include Piston service with persistent data storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->