### PR TITLE
fix: route student-facing code-block-viewer through /api/run-code

### DIFF
--- a/frontend/components/draft/lesson/code-block-viewer.tsx
+++ b/frontend/components/draft/lesson/code-block-viewer.tsx
@@ -4,8 +4,7 @@ import { useState } from "react";
 import { Play, Check, X, AlertCircle, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CodeEditor } from "@/components/ui/code-editor";
-
-const PISTON_API_URL = "https://emkc.org/api/v2/piston/execute";
+import { executeCode } from "@/lib/code-execution";
 
 const LANGUAGE_LABELS: Record<string, string> = {
   javascript: "JavaScript",
@@ -22,68 +21,6 @@ const LANGUAGE_LABELS: Record<string, string> = {
   rust: "Rust",
   kotlin: "Kotlin",
   swift: "Swift",
-};
-
-const executePistonCode = async (
-  language: string,
-  code: string,
-  fileName: string,
-  pistonLanguageName: string,
-) => {
-  try {
-    const response = await fetch(PISTON_API_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        language: pistonLanguageName,
-        version: "*",
-        files: [{ name: fileName, content: code }],
-        stdin: "",
-        args: [],
-        compile_timeout: 10000,
-        run_timeout: 3000,
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`API error: ${response.status}`);
-    }
-
-    const result = await response.json();
-
-    if (result.compile && result.compile.code !== 0) {
-      return {
-        success: false,
-        output:
-          result.compile.stderr ||
-          result.compile.output ||
-          "Compilation failed",
-      };
-    }
-
-    if (result.run.code !== 0 && result.run.stderr) {
-      return {
-        success: false,
-        output: result.run.stderr,
-      };
-    }
-
-    const output =
-      result.run.stdout ||
-      result.run.output ||
-      "Code executed successfully (no output)";
-    return {
-      success: true,
-      output: output.trim(),
-    };
-  } catch (error: unknown) {
-    return {
-      success: false,
-      output: `Execution error: ${error instanceof Error ? error.message : String(error)}`,
-    };
-  }
 };
 
 interface CodeBlockViewerProps {
@@ -113,50 +50,7 @@ export function CodeBlockViewer({
     setExecutionSuccess(true);
 
     try {
-      // Map language to Piston language name
-      const pistonLanguageMap: Record<string, string> = {
-        javascript: "javascript",
-        typescript: "typescript",
-        python: "python",
-        java: "java",
-        cpp: "c++",
-        c: "c",
-        csharp: "csharp",
-        php: "php",
-        ruby: "ruby",
-        bash: "bash",
-        go: "go",
-        rust: "rust",
-        kotlin: "kotlin",
-        swift: "swift",
-      };
-
-      // Get proper file name for language
-      const fileNames: Record<string, string> = {
-        javascript: "index.js",
-        typescript: "index.ts",
-        python: "main.py",
-        java: "Main.java",
-        cpp: "main.cpp",
-        c: "main.c",
-        csharp: "Main.cs",
-        php: "index.php",
-        ruby: "main.rb",
-        bash: "script.sh",
-        go: "main.go",
-        rust: "main.rs",
-        kotlin: "Main.kt",
-        swift: "main.swift",
-      };
-
-      const pistonLanguage = pistonLanguageMap[language] || language;
-      const fileName = fileNames[language] || "main.txt";
-      const result = await executePistonCode(
-        language,
-        code,
-        fileName,
-        pistonLanguage,
-      );
+      const result = await executeCode(language, code);
       setOutput(result.output);
       setExecutionSuccess(result.success);
     } catch (error: unknown) {

--- a/frontend/components/ui/blocknote/blocks/code-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/code-block.tsx
@@ -5,11 +5,7 @@ import { useState, useEffect, ErrorInfo } from "react";
 import React from "react";
 import { Play, Edit, Lock, Check, X, AlertCircle, Loader2 } from "lucide-react";
 import { CodeEditor } from "@/components/ui/code-editor";
-
-// Server-side proxy. Browser never calls Piston directly — see
-// frontend/app/api/run-code/route.ts. Python is executed in-browser via
-// Pyodide and never hits the network.
-const RUN_CODE_URL = "/api/run-code";
+import { executeCode } from "@/lib/code-execution";
 
 // Languages supported by both Piston and CodeMirror
 const SUPPORTED_LANGUAGES = {
@@ -81,94 +77,6 @@ function getPlaceholder(language: string): string {
   return "// Write your code here";
 }
 
-type ExecResult = { success: boolean; output: string };
-
-async function executePython(code: string): Promise<ExecResult> {
-  try {
-    const { runPython } = await import("@/lib/pyodide/runtime");
-    const result = await runPython(code);
-    if (result.error) {
-      return { success: false, output: result.error.trim() };
-    }
-    const out =
-      (result.stdout || "").trim() || "Code executed successfully (no output)";
-    return { success: true, output: out };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { success: false, output: `Execution error: ${msg}` };
-  }
-}
-
-async function executeViaProxy(
-  language: string,
-  code: string,
-): Promise<ExecResult> {
-  const langConfig = allLanguages.find((l) => l.value === language);
-  if (!langConfig || !langConfig.pistonName) {
-    return {
-      success: false,
-      output: `Language ${language} is not supported for execution`,
-    };
-  }
-
-  try {
-    const response = await fetch(RUN_CODE_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        language: langConfig.pistonName,
-        code,
-        fileName: langConfig.fileName,
-      }),
-    });
-
-    if (!response.ok) {
-      const body = await response.json().catch(() => ({}));
-      const msg = body?.error ?? `Execution service error (${response.status})`;
-      return { success: false, output: msg };
-    }
-
-    const result = await response.json();
-
-    if (result.compile && result.compile.code !== 0) {
-      return {
-        success: false,
-        output:
-          result.compile.stderr ||
-          result.compile.output ||
-          "Compilation failed",
-      };
-    }
-
-    // Treat any non-zero run exit as a failure so silent failures
-    // (exit(1) with no stderr) aren't shown as success in green.
-    if (result.run && result.run.code !== 0) {
-      const errOut =
-        (result.run.stderr || "").trim() ||
-        (result.run.output || "").trim() ||
-        (result.run.stdout || "").trim() ||
-        `Process exited with code ${result.run.code}`;
-      return { success: false, output: errOut };
-    }
-
-    const output =
-      result.run?.stdout ||
-      result.run?.output ||
-      "Code executed successfully (no output)";
-    return { success: true, output: String(output).trim() };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { success: false, output: `Execution error: ${msg}` };
-  }
-}
-
-async function executeCode(
-  language: string,
-  code: string,
-): Promise<ExecResult> {
-  if (language === "python") return executePython(code);
-  return executeViaProxy(language, code);
-}
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const CodeBlockComponent = ({ block, editor }: any) => {
   const [isEditing, setIsEditing] = useState(false);

--- a/frontend/lib/code-execution.ts
+++ b/frontend/lib/code-execution.ts
@@ -1,0 +1,120 @@
+"use client";
+
+// Shared execution helper for both the BlockNote editor code block and the
+// student-facing CodeBlockViewer. Python runs in-browser via Pyodide; every
+// other language goes through the auth-gated /api/run-code proxy.
+const RUN_CODE_URL = "/api/run-code";
+
+export type ExecResult = { success: boolean; output: string };
+
+type LanguageConfig = { pistonName: string; fileName: string };
+
+// Maps the language values used by code blocks (editor dropdown + saved
+// content) to the Piston language name and a sensible filename. The proxy
+// itself enforces a server-side allowlist; this map only exists to translate
+// client-side UI values into the wire format.
+export const LANGUAGE_CONFIG: Record<string, LanguageConfig> = {
+  javascript: { pistonName: "javascript", fileName: "index.js" },
+  typescript: { pistonName: "typescript", fileName: "index.ts" },
+  python: { pistonName: "python", fileName: "main.py" },
+  java: { pistonName: "java", fileName: "Main.java" },
+  cpp: { pistonName: "c++", fileName: "main.cpp" },
+  "c++": { pistonName: "c++", fileName: "main.cpp" },
+  c: { pistonName: "c", fileName: "main.c" },
+  csharp: { pistonName: "csharp", fileName: "Main.cs" },
+  php: { pistonName: "php", fileName: "index.php" },
+  ruby: { pistonName: "ruby", fileName: "main.rb" },
+  bash: { pistonName: "bash", fileName: "script.sh" },
+  go: { pistonName: "go", fileName: "main.go" },
+  rust: { pistonName: "rust", fileName: "main.rs" },
+  kotlin: { pistonName: "kotlin", fileName: "Main.kt" },
+  swift: { pistonName: "swift", fileName: "main.swift" },
+};
+
+async function executePython(code: string): Promise<ExecResult> {
+  try {
+    const { runPython } = await import("@/lib/pyodide/runtime");
+    const result = await runPython(code);
+    if (result.error) {
+      return { success: false, output: result.error.trim() };
+    }
+    const out =
+      (result.stdout || "").trim() || "Code executed successfully (no output)";
+    return { success: true, output: out };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { success: false, output: `Execution error: ${msg}` };
+  }
+}
+
+async function executeViaProxy(
+  language: string,
+  code: string,
+): Promise<ExecResult> {
+  const cfg = LANGUAGE_CONFIG[language];
+  if (!cfg) {
+    return {
+      success: false,
+      output: `Language ${language} is not supported for execution`,
+    };
+  }
+
+  try {
+    const response = await fetch(RUN_CODE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        language: cfg.pistonName,
+        code,
+        fileName: cfg.fileName,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      const msg =
+        body?.error ?? `Execution service error (${response.status})`;
+      return { success: false, output: msg };
+    }
+
+    const result = await response.json();
+
+    if (result.compile && result.compile.code !== 0) {
+      return {
+        success: false,
+        output:
+          result.compile.stderr ||
+          result.compile.output ||
+          "Compilation failed",
+      };
+    }
+
+    // Treat any non-zero run exit as a failure so silent failures
+    // (exit(1) with no stderr) aren't shown as success.
+    if (result.run && result.run.code !== 0) {
+      const errOut =
+        (result.run.stderr || "").trim() ||
+        (result.run.output || "").trim() ||
+        (result.run.stdout || "").trim() ||
+        `Process exited with code ${result.run.code}`;
+      return { success: false, output: errOut };
+    }
+
+    const output =
+      result.run?.stdout ||
+      result.run?.output ||
+      "Code executed successfully (no output)";
+    return { success: true, output: String(output).trim() };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { success: false, output: `Execution error: ${msg}` };
+  }
+}
+
+export async function executeCode(
+  language: string,
+  code: string,
+): Promise<ExecResult> {
+  if (language === "python") return executePython(code);
+  return executeViaProxy(language, code);
+}

--- a/frontend/lib/code-execution.ts
+++ b/frontend/lib/code-execution.ts
@@ -72,8 +72,7 @@ async function executeViaProxy(
 
     if (!response.ok) {
       const body = await response.json().catch(() => ({}));
-      const msg =
-        body?.error ?? `Execution service error (${response.status})`;
+      const msg = body?.error ?? `Execution service error (${response.status})`;
       return { success: false, output: msg };
     }
 


### PR DESCRIPTION
## Summary

`CodeBlockViewer` — the student-facing code block used by `lesson-renderer.tsx` and `presentation-block-renderer.tsx` — was missed in #931. It still called `emkc.org` directly, so students viewing a published lesson saw the same `API error: 401` the editor block used to throw.

## Fix

- Extracted execution logic into `frontend/lib/code-execution.ts` so both the editor block (`code-block.tsx`) and the viewer (`code-block-viewer.tsx`) use the same proxy + Pyodide path through a single `executeCode(language, code)` helper.
- Removed the duplicated `executePistonCode`, language map, and filename map from the viewer.
- Removed the duplicated execution functions from the editor block; both now import from `lib/code-execution`.

Net: language allowlist + filename mapping live in one place. No more drift between the two components.

## What changed

- `frontend/lib/code-execution.ts` (new) — shared `executeCode` helper, `LANGUAGE_CONFIG` for piston-name + filename lookups.
- `frontend/components/draft/lesson/code-block-viewer.tsx` — now imports `executeCode`; dropped 70+ lines of duplicate logic.
- `frontend/components/ui/blocknote/blocks/code-block.tsx` — same; dropped 80+ lines.

## Test plan

- [x] No `emkc.org` references anywhere in `frontend/` (verified via grep)
- [x] No hardcoded `PISTON_API_URL = "https://..."` constants (verified via grep)
- [x] Both `CodeBlockViewer` call sites (`droplets/lessons/lesson-renderer`, `presentation-block-renderer`) point at the same updated component
- [x] Editor block and viewer both import `executeCode` from `lib/code-execution`
- [x] Student lesson view at `/d/{slug}/{lessonSlug}`: JS + C++ Run → `POST /api/run-code` → 200, output renders in green (verified in browser via Playwright)
- [x] No `emkc.org` request appears in DevTools Network on the student page
- [x] Presentation mode uses the same updated `CodeBlockViewer`, same code path
- [x] Editor preview at `/draft/d/...` still works (covered by #931)
- [x] Type-check clean for changed files
- [x] Lint clean (one pre-existing exhaustive-deps warning unrelated to this change)
- [x] All 4388 frontend tests pass (CI pre-push hook)