### PR TITLE
Pointing the aws cdn url to prod bucket

### DIFF
--- a/frontend/ecs.prod.Dockerfile
+++ b/frontend/ecs.prod.Dockerfile
@@ -9,7 +9,8 @@ WORKDIR /app
 # Install jq for JSON parsing
 RUN apk update && apk add jq
 
-ENV AWS_CDN_URL=https://odyssey-dev-bucket.s3.us-east-2.amazonaws.com
+# ENV AWS_CDN_URL=https://odyssey-dev-bucket.s3.us-east-2.amazonaws.com
+ENV AWS_CDN_URL=https://odyssey-prod-bucket.s3.us-east-2.amazonaws.com
 
 # Accept build arguments from GitHub Actions
 ARG NEXT_PUBLIC_POSTHOG_KEY


### PR DESCRIPTION

## Description

The `frontend/ecs.prod.Dockerfile was referencing a dev url for the S3 cdn URL.  This is causing problems with prod being able to access files in the correct S3 bucket. 

## Motivation and Context

On Prod, I wasn't able to access droplet-level CSV files in the a Notebook block.  There were errors related to being prevented from accessing the correct s3 bucket. 

Note: Merging directly to prod because the change only affects prod deployment due to the way env vars and secrets are set up.

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration to direct CDN requests to production resources instead of development resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->