### PR TITLE
ODY-447 - Update creator grids to be sortable and filterable. 

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1032.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A Strapi application",
   "scripts": {
     "dev": "strapi develop",

--- a/docs/plans/ODY-447-audit.md
+++ b/docs/plans/ODY-447-audit.md
@@ -1,0 +1,103 @@
+# Audit: ODY-447 — Creator page sort, filter, and search
+
+Date: 2026-05-02
+Files changed: 15 (1358 +, 110 -)
+Branch: feature/ody-447-creator-page-sort-filter vs production
+
+Investigations run: data flow, regression scan, performance, test coverage. Validator pass applied.
+
+---
+
+## Confirmed Issues
+
+### Critical (must fix before merge)
+
+_None._
+
+### Warnings (should fix)
+
+1. **`useMemo` dependency on `searchParams` object reference is brittle and silenced with `eslint-disable`.**
+   File: `frontend/components/my-content/droplets-creator-grid.tsx:52-59` (also `playlists-creator-grid.tsx:36-42`, `voyages-creator-grid.tsx:39-45`).
+   The memoized `filtered` list reads `filterParams` outside the dep array. The hook depends on `searchParams` (which Next.js returns as a new `ReadonlyURLSearchParams` instance on every navigation), so memoization is effectively per-render whenever ANY search param changes — even unrelated ones. Acceptable performance-wise on small client arrays, but the eslint-disable hides the real fix: derive the actual filter key string (e.g. `searchParams.toString()`) or pull individual `.get(key)` values into the dep list. Without that, the comment "stable via useMemo dep below" is misleading — the dep is the param-bag identity, not the filter values.
+
+2. **Toolbar uses `throttleMs` instead of debouncing; spec asked for "debounced like /explore".**
+   File: `frontend/components/my-content/my-content-toolbar.tsx:22`.
+   `useQueryState("q", { throttleMs: 300 })` throttles URL updates (rate-limits to once per 300ms while typing). This is functionally close to debounce, and the validator confirmed it does prevent the previous re-fire bug, but the plan / `/explore` pattern uses true debounce (commit-after-quiet-period). Behavior diverges slightly: on a long type, throttle commits intermediate values; debounce only commits after the user stops. Low-impact, but worth a comment in the file or aligning with `/explore`'s `Search` component.
+
+3. **`SortableItem` test type is unused / dead.**
+   File: `frontend/__tests__/apply-sort-filter.test.ts:11-15`.
+   Defined but only referenced by inline annotations that could just as well use `WithName & WithDates` from the source. Cosmetic only.
+
+4. **`DROPLET_PARAM_KEYS` is exported but never imported anywhere.**
+   File: `frontend/components/my-content/droplets-creator-grid.tsx:128`.
+   Dead export. The canonical allowlist lives in `TAB_ALLOWED_PARAMS` inside `my-content-tabs.tsx`. Either delete the export or refactor both files to share a single source of truth so they cannot drift.
+
+5. **`TAB_ALLOWED_PARAMS` and `clearFilters` lists duplicate the same param schema in 4 places.**
+   Files: `my-content-tabs.tsx:31-44`, `droplets-creator-grid.tsx:62-73`, `playlists-creator-grid.tsx:46`, `voyages-creator-grid.tsx:49`.
+   The allowlist for each tab is hand-maintained in two places (tab-switch cleanup AND clear-filters). Adding a new filter for, say, droplets requires editing two arrays in two files. Not a bug today, but a near-certain source of drift. Co-locate the param map in `sort-filter-options.ts` and import.
+
+### Suggestions (nice to have)
+
+6. **`applySort` returns original order for unknown sort key but still allocates a new array via `[...items].sort()`** — fine, just noting.
+
+7. **No test asserts that tab counts remain unfiltered when filters are applied** — the spec calls this out explicitly (AC: "Existing tab counts continue to reflect the total items per tab (not the filtered count)"). The component test mocks the grids so this is structurally guaranteed by reading `droplets.length` directly, but a regression test would be cheap insurance.
+
+8. **`my-content-toolbar.tsx` does not pull the per-tab `defaultValue` for `Sort` from anywhere shared** — it always passes `CREATOR_DEFAULT_SORT` regardless of `tab`. Currently fine (all three tabs share the same default), but the plan structured them as three lists per tab, so a future per-tab override would silently break.
+
+---
+
+## Disputed (validator concluded these are NOT issues)
+
+- **"Suspense boundary wraps a client component that uses `useSearchParams` — needed for streaming, but `MyContentTabs` itself doesn't suspend."** Validator: Next.js 15 requires any client component reading `useSearchParams()` to be inside a `<Suspense>` for static rendering compatibility. The wrapper at `app/(general)/my-content/page.tsx:55` is correct and necessary, not redundant.
+
+- **"`activeTab` derived from `useSearchParams` causes an extra render after `router.push`."** Validator: this is the explicit fix for the "tab switching not reactive" bug noted in the changeset summary. The previous local-state approach was the bug. Current pattern is correct.
+
+- **"`applySort` mutates `items` because of `sorted.sort()`."** Validator: `sorted` is `[...items]`, a copy. Test on line 113 asserts non-mutation. Confirmed safe.
+
+- **"`isHidden`/`isArchived` on filter predicates default to `false` but the schema may return `null`."** Validator: predicates use `?? false`, which handles both `undefined` and `null`. Confirmed safe.
+
+- **"Empty input arrays will render the 'No items yet' empty state even if the user has active filters."** Validator: this is intentional and matches the spec — when there is genuinely nothing to filter, the "No items yet" CTA is correct; the "no matches" state only fires when the unfiltered array is non-empty.
+
+- **"Adding `createdAt`/`updatedAt` to the `creation` populate may bloat the response."** Validator: these are scalar timestamps already on every Strapi entity, populated by default on the root entity and trivial in size. Adding them to the explicit `fields` list is a no-op for entities that already returned them and a fix for ones that didn't (the populate is field-restricted).
+
+---
+
+## Observations (no issues, but noted)
+
+- **Backend types drift unrelated to feature.** `backend/types/generated/contentTypes.d.ts` shows in `git status` as modified but is NOT in the branch's commit set vs production. This is local auto-generated drift and not part of the changeset. Discard or ignore.
+
+- **`useEffect` redirect on invisible-tab.** `my-content-tabs.tsx:75-82` correctly resets `tab` if the URL points at a hidden tab. Good defensive code.
+
+- **No XSS / injection vectors introduced.** All filter values are read from URL params and compared against a fixed enum list of options before being passed into predicates; user-input only feeds into a substring match on `name`, which is rendered by existing tile components that already escape.
+
+- **Auth boundary unchanged.** `app/(general)/my-content/page.tsx` still gates entry behind `isAuthorizedUserAdmin || isContentCreator || isAuthorizedUserFaculty`. Not weakened.
+
+- **`fetchAPI` / cache tags untouched.** The feature is purely client-side. Spec said "no new Strapi requests, no schema changes, no new cache tags" — confirmed adhered to. The only request-layer change is adding `createdAt` / `updatedAt` to `USER_POPULATES.creation`'s `fields` list, which is consistent with the rule "only populate relations you actually render" since the new "Created on" date and the "Newest" / "Recently Updated" sort options need them.
+
+- **`DropletTile` regression check.** The prop addition is opt-in (`showCreatedDate = false`). Of 11 call sites identified, only `droplets-creator-grid.tsx` opts in. The two cosmetic changes (`gap-2` on left container, `gap-1` on right container) affect every call site visually — small spacing tweak, low risk, no functional regression.
+
+- **Tests pass.** `npx jest __tests__/apply-sort-filter.test.ts __tests__/my-content-tabs.test.tsx` → 36/36 passing.
+
+- **Tailwind v3.4 / Next.js 15 / Strapi v4.22 constraints respected.** No `@theme`, no Document Service API, no `documentId`, no v5 flat responses. `cache` and `next` not both passed. All clear.
+
+---
+
+## Regression Risk
+
+Low. `DropletTile` is the only widely-imported file changed; the prop is opt-in with a safe default and the only style changes are gap utilities. `USER_POPULATES.creation` adds two scalar fields to two field lists — strictly additive to the response shape.
+
+## Test Coverage
+
+Strong on the pure helpers (8 tests on `applySort`, 5 on `matchesSearch`, plus per-type filter coverage). Tab-switch param cleanup has 3 dedicated tests covering the three meaningful transitions. Untested: the per-grid `clearFilters` button behavior and the "no matches" empty state rendering. Not blockers — the helpers under those code paths are tested and the component wiring is straightforward.
+
+---
+
+## Verdict: APPROVE WITH CONDITIONS
+
+The feature is functionally correct, well-tested, follows project patterns, and is low-risk to merge. Before merge, address Warnings 4 (delete dead export) and 5 (deduplicate the param allowlist) — both are 5-minute cleanups that prevent near-certain future drift. Warnings 1-3 can be deferred to a follow-up but should be tracked.
+
+---
+
+## Linear Tickets Created
+
+(Created below as Bug tickets parented to ODY-447 where applicable.)

--- a/docs/plans/ODY-447.md
+++ b/docs/plans/ODY-447.md
@@ -1,0 +1,130 @@
+# ODY-447: Update the creator page grid to allow sorting and filtering
+
+## Problem
+
+`/my-content` (the creator's "My Content" page) shows three tabs — Droplets, Playlists, Voyages — each rendering a flat grid of every item the creator owns. Once a creator has more than a handful of items, the grid becomes hard to scan: there is no search, no sort, no way to filter by status (draft vs published, archived vs active) or by content attributes (type, focus area, difficulty). Other grids on the platform (notably `/explore`) already solve this with a search input, multi-select filters, and a sort dropdown driven by URL search params. We want the creator-facing grid to feel consistent with that pattern.
+
+## Acceptance Criteria
+
+- [ ] When viewing `/my-content`, a creator sees a search input, sort dropdown, and (where relevant) filter chips above the active tab's grid.
+- [ ] Search filters the grid by item name (case-insensitive substring) and updates as the creator types (debounced like `/explore`).
+- [ ] Sort options for **Droplets**: A–Z, Z–A, Newest, Oldest, Recently Updated.
+- [ ] Sort options for **Playlists**: A–Z, Z–A, Newest, Oldest, Recently Updated.
+- [ ] Sort options for **Voyages**: A–Z, Z–A, Newest, Oldest, Recently Updated.
+- [ ] Filters for **Droplets**: Status (Draft / Published), Visibility (Active / Archived), Focus Area (Personal / Professional / Technical), Type (Knowledge / Skill), Difficulty (Beginner / Intermediate / Advanced).
+- [ ] Filters for **Playlists**: Visibility (Active / Archived), Public/Private.
+- [ ] Filters for **Voyages**: Visibility (Active / Archived).
+- [ ] Multi-select filters work the same way as `/explore`: each filter chip is independent, OR within a filter, AND across filters.
+- [ ] State persists in the URL via search params (`q`, `sort`, `status`, `visibility`, `focusArea`, `type`, `difficulty`, `public`) so that links can be shared/bookmarked and back-button works.
+- [ ] Switching tabs preserves the URL `tab` param but clears tab-specific filter params (a filter that doesn't apply to the new tab shouldn't silently linger).
+- [ ] Empty-state copy distinguishes "no items at all" from "no items match these filters" and offers a "Clear filters" action in the latter case.
+- [ ] All sort/filter logic is client-side (data is already fully loaded by the page) — no new Strapi requests, no schema changes, no new cache tags.
+- [ ] Existing tab counts continue to reflect the **total** items per tab (not the filtered count).
+
+## Out of Scope
+
+- Server-side pagination of `/my-content`. The page already loads all owned items via `getCachedUserCreation`; we are not changing that.
+- New Strapi schema fields, request functions, or cache tags.
+- Visual redesign — we reuse existing `Sort`, `Filter`, and `SearchBar` primitives. Styling matches `/explore`.
+- Adding sort/filter to `/explore` (already exists) or to other grids (e.g., dashboard, profile) — strictly the `/my-content` grid.
+- Persisting filter preferences server-side or per-user.
+
+## Design Decisions
+
+### 1. Client-side filtering and sorting
+
+`MyContentTabs` (`components/my-content/my-content-tabs.tsx`) is already a client component receiving the full arrays of `droplets`, `playlists`, and `voyages` from the server page. There is no benefit to round-tripping for filter/sort — the data is in memory. This matches the `/explore` page's `SortedDropletsGrid`, which also sorts and filters client-side over a pre-fetched array.
+
+### 2. Reuse `/explore` primitives
+
+The existing `Filter` (`components/explore/filter.tsx`) and `Sort` (`components/explore/sort.tsx`) components already implement the desired UX (popover with multi-select, dropdown with radio sort, URL-search-param backed). They are generic enough to use as-is — they take `name`, `label`, `options` props for `Filter` and `options`, `defaultValue` for `Sort`. We will import them directly from `components/explore/` rather than duplicating.
+
+The `SearchBar` primitive used by `/explore`'s `Search` is in `components/admin/search-bar.tsx`. We will use it directly with a local `useQueryState("q", ...)` from nuqs (simpler than the `SearchContext` pattern, which exists for cross-component coordination not needed here).
+
+### 3. Per-tab URL params, with cleanup on tab switch
+
+Each tab has different applicable filters. To avoid stale params lingering when a creator switches tabs, the tab-switch handler will clear the param keys that don't apply to the new tab. The `tab`, `q`, and `sort` params remain across tabs (they are universally applicable).
+
+Param map:
+
+| Param        | Applies to tabs              |
+| ------------ | ---------------------------- |
+| `tab`        | all                          |
+| `q`          | all                          |
+| `sort`       | all                          |
+| `status`     | droplets                     |
+| `visibility` | droplets, playlists, voyages |
+| `focusArea`  | droplets                     |
+| `type`       | droplets                     |
+| `difficulty` | droplets                     |
+| `public`     | playlists                    |
+
+### 4. New sort/filter constants live in `components/my-content/`
+
+The sort options for `/my-content` differ from `/explore` (no "completion", no "rating", no "due date" — these don't apply to creator-owned content; instead we add "Newest" / "Recently Updated"). The filters also differ (status, visibility are creator concepts). To avoid polluting `lib/globals.ts` with creator-specific options, we colocate them in a new module `components/my-content/sort-filter-options.ts`.
+
+### 5. Extract grid bodies into small subcomponents
+
+`MyContentTabs` is already ~220 lines. Adding sort/filter inline would balloon it. We extract three thin subcomponents (`DropletsCreatorGrid`, `PlaylistsCreatorGrid`, `VoyagesCreatorGrid`) that each take the full array plus the current filter/sort state, apply the transform with `useMemo`, and render the existing tile components or the empty state. `MyContentTabs` becomes a thin coordinator over tabs + toolbar + the active grid.
+
+### 6. Empty-state divergence
+
+When a tab has zero items total, show the existing "No droplets yet / Create a new droplet to get started." message. When a tab has items but none match the active filters/search, show a different message with a "Clear filters" button (mirrors the "No Droplets Found" empty state in `SortedDropletsGrid`). Use the existing `EmptyState` UI primitive plus a button.
+
+## Implementation Tasks
+
+- [x] **Task 1: Define sort and filter option constants** (independent)
+
+  - **Read:** `frontend/lib/globals.ts` (existing `SortFilterItem`, `FilterOption` shapes), `frontend/components/explore/sort.tsx`, `frontend/components/explore/filter.tsx` (to confirm the prop shapes the constants must satisfy).
+  - **Create:** `frontend/components/my-content/sort-filter-options.ts`
+  - **What:** Export three sort lists (`dropletCreatorSorting`, `playlistCreatorSorting`, `voyageCreatorSorting`) typed as `SortFilterItem[]`. Each contains: A–Z, Z–A, Newest (`createdAt:desc`), Oldest (`createdAt:asc`), Recently Updated (`updatedAt:desc`). Default sort: Recently Updated. Also export filter arrays: `DROPLET_CREATOR_FILTERS` (status, visibility, focusArea, type, difficulty), `PLAYLIST_CREATOR_FILTERS` (visibility, public), `VOYAGE_CREATOR_FILTERS` (visibility). Each filter follows the `{ name, label, options: FilterOption[] }` shape that `components/explore/filter.tsx` consumes.
+  - **Context:** `SortFilterItem.sortKey` is a string-literal union in `lib/globals.ts`. Adding new sort keys (`updatedAt:asc`, `updatedAt:desc`) requires extending that union — do that in `lib/globals.ts` as part of this task. Do not invent a parallel type.
+  - **Verify:** `npx tsc --noEmit` passes; no runtime work yet.
+
+- [x] **Task 2: Build the toolbar component** (depends on Task 1)
+
+  - **Read:** `frontend/components/explore/sort.tsx`, `frontend/components/explore/filter.tsx`, `frontend/components/explore/search.tsx`, `frontend/components/admin/search-bar.tsx`
+  - **Create:** `frontend/components/my-content/my-content-toolbar.tsx`
+  - **What:** A `"use client"` component that takes `tab: "droplets" | "playlists" | "voyages"` and renders: (1) a `SearchBar` wired to a `useQueryState("q", ...)` from nuqs with 300ms debounce (mirror `components/explore/search.tsx`'s debounce), (2) the appropriate filter chips for the tab (using imported `Filter` from `components/explore/filter.tsx`), (3) the appropriate `Sort` dropdown (using imported `Sort` from `components/explore/sort.tsx`) with the per-tab sort list and "Recently Updated" as default. Layout matches `/explore`'s toolbar row (flex, gap-2, wrapping).
+  - **Context:** `Filter` and `Sort` already read/write the URL via `useSearchParams`/`useRouter`. The toolbar just renders them with the right props per tab.
+  - **Verify:** Render the toolbar with `tab="droplets"` in the dev app; clicking filter chips updates the URL; clicking sort updates `?sort=`.
+
+- [x] **Task 3: Extract a sorting/filtering helper** (independent)
+
+  - **Read:** `frontend/components/explore/sorted-droplets-grid.tsx` (for the sort-by-string-key pattern)
+  - **Create:** `frontend/components/my-content/apply-sort-filter.ts`
+  - **What:** Two pure helpers. (a) `applySort<T>(items, sortKey)` — handles `name:asc|desc`, `createdAt:asc|desc`, `updatedAt:asc|desc` generically; tolerates missing fields. (b) `matchesSearch(item, query)` — case-insensitive substring on `item.name`. Filter predicates can stay inline in each grid (they're tab-specific) or be exported here as small functions like `dropletMatchesFilters(droplet, params)`. Prefer exporting the predicates so the grids stay declarative.
+  - **Context:** All three content types share a `name`, `createdAt`, `updatedAt` field, so a single generic sort works. Filters are type-specific and live as separate predicates.
+  - **Verify:** Add a Jest unit test `apply-sort-filter.test.ts` covering: A-Z sort, Newest sort, search match/no-match, droplet status filter, playlist visibility filter. Use minimal fixture objects.
+
+- [x] **Task 4: Refactor `MyContentTabs` to use the toolbar and extracted grids** (depends on Tasks 1, 2, 3)
+
+  - **Read:** `frontend/components/my-content/my-content-tabs.tsx`
+  - **Modify:** `frontend/components/my-content/my-content-tabs.tsx`
+  - **Create:** `frontend/components/my-content/droplets-creator-grid.tsx`, `frontend/components/my-content/playlists-creator-grid.tsx`, `frontend/components/my-content/voyages-creator-grid.tsx`
+  - **What:**
+    - Each new grid component is a `"use client"` component that takes the full array plus the active sort/filter/search state (read via `useSearchParams` or nuqs), applies `applySort` + `matchesSearch` + the type-specific filter predicate via `useMemo`, and renders the same tiles currently inlined in `my-content-tabs.tsx`. If the input array is empty, render the existing "No X yet" `EmptyState`. If the filtered array is empty but the input wasn't, render a new "No matching X" `EmptyState` with a "Clear filters" button that resets the relevant URL params.
+    - `MyContentTabs` keeps the tab bar and the "New X" button on the right. Below the tab bar, render `<MyContentToolbar tab={activeTab} />`. Below that, render the appropriate creator grid.
+    - When the tab changes, clear params not applicable to the new tab. Implement this by extending the existing `setActiveTab` call: build a `URLSearchParams` from the current search, delete keys outside the new tab's allowlist, then push.
+  - **Context:** Tab counts in the tab bar (`droplets.length`, etc.) must remain the **unfiltered** total — read from props directly, not from filtered arrays.
+  - **Verify:** Manually exercise each tab: search, each filter, each sort; confirm tab switch clears non-applicable params; confirm tab counts don't change as filters apply; confirm "Clear filters" on the no-match empty state restores all items.
+
+- [x] **Task 5: Add a Jest test for the tab-switch param-cleanup behavior** (depends on Task 4)
+
+  - **Read:** `frontend/components/my-content/my-content-tabs.tsx`, an existing component test in `frontend/__tests__/` for the test-setup pattern
+  - **Create:** `frontend/__tests__/my-content-tabs.test.tsx` (or colocated equivalent matching project convention)
+  - **What:** Render `MyContentTabs` with sample data and a mocked router. Set `?tab=droplets&focusArea=technical&visibility=archived`. Click the Playlists tab. Assert the new URL contains `tab=playlists&visibility=archived` but NOT `focusArea` (which doesn't apply to playlists).
+  - **Context:** nuqs and `next/navigation` need the standard test mocks — check `frontend/jest.setup.ts` and existing tests for the established mocking pattern before writing. Don't reinvent.
+  - **Verify:** `cd frontend && npm test -- my-content-tabs` passes.
+
+- [x] **Task 6: Manual smoke test and accessibility pass** (depends on Task 4)
+
+  - **What:** With the dev server running, sign in as a Content Creator. Walk through every sort and every filter on each tab. Verify keyboard navigation through filter popovers and sort dropdown. Verify URL state survives a hard refresh. Verify with Playwright MCP if available.
+  - **Verify:** No console errors; each combination renders sensibly; empty-state copy matches the spec.
+
+## Notes for the implementer
+
+- The page (`app/(general)/my-content/page.tsx`) does not need changes. Data fetching stays as-is — `getCachedUserCreation` already returns the full owned arrays.
+- Do not introduce a new `SearchContext` like `/explore` uses. The simpler `useQueryState("q")` from nuqs is sufficient since the search input lives in the same component subtree as the grids.
+- The `Filter` component in `components/explore/filter.tsx` is generic — it does not assume "droplet" semantics. It is fine to import it from `/explore` for the creator page. If at some later point we want to move it to `components/ui/`, that's a separate refactor.
+- Do not re-fetch from Strapi when filters change. All filtering and sorting happens in the browser over arrays already in memory.

--- a/frontend/__tests__/apply-sort-filter.test.ts
+++ b/frontend/__tests__/apply-sort-filter.test.ts
@@ -1,0 +1,286 @@
+import {
+  applySort,
+  matchesSearch,
+  dropletMatchesFilters,
+  playlistMatchesFilters,
+  voyageMatchesFilters,
+} from "@/components/my-content/apply-sort-filter";
+import { Droplet, Playlist, Voyage } from "@/types";
+
+// Minimal fixture types for testing
+type SortableItem = {
+  name: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+const makeDroplet = (overrides: Partial<Droplet>): Droplet =>
+  ({
+    id: 1,
+    slug: "test",
+    name: "Test Droplet",
+    type: "knowledge",
+    focusArea: "technical",
+    difficulty: "beginner",
+    isHidden: false,
+    status: "published",
+    learningObjectives: [],
+    ...overrides,
+  }) as Droplet;
+
+const makePlaylist = (overrides: Partial<Playlist>): Playlist =>
+  ({
+    id: 1,
+    name: "Test Playlist",
+    slug: "test",
+    isPublic: true,
+    duration: "short",
+    isArchived: false,
+    ...overrides,
+  }) as Playlist;
+
+const makeVoyage = (overrides: Partial<Voyage>): Voyage =>
+  ({
+    id: 1,
+    name: "Test Voyage",
+    slug: "test",
+    description: "",
+    status: "published",
+    isSequential: false,
+    isArchived: false,
+    ...overrides,
+  }) as Voyage;
+
+describe("applySort", () => {
+  it("sorts items A-Z by name", () => {
+    const items: SortableItem[] = [
+      { name: "Zebra" },
+      { name: "Apple" },
+      { name: "Mango" },
+    ];
+    const result = applySort(items, "name:asc");
+    expect(result.map((i) => i.name)).toEqual(["Apple", "Mango", "Zebra"]);
+  });
+
+  it("sorts items Z-A by name", () => {
+    const items: SortableItem[] = [
+      { name: "Zebra" },
+      { name: "Apple" },
+      { name: "Mango" },
+    ];
+    const result = applySort(items, "name:desc");
+    expect(result.map((i) => i.name)).toEqual(["Zebra", "Mango", "Apple"]);
+  });
+
+  it("sorts Newest first (createdAt:desc)", () => {
+    const items: SortableItem[] = [
+      { name: "Old", createdAt: "2023-01-01T00:00:00.000Z" },
+      { name: "New", createdAt: "2024-06-01T00:00:00.000Z" },
+      { name: "Mid", createdAt: "2023-12-01T00:00:00.000Z" },
+    ];
+    const result = applySort(items, "createdAt:desc");
+    expect(result.map((i) => i.name)).toEqual(["New", "Mid", "Old"]);
+  });
+
+  it("sorts Oldest first (createdAt:asc)", () => {
+    const items: SortableItem[] = [
+      { name: "Old", createdAt: "2023-01-01T00:00:00.000Z" },
+      { name: "New", createdAt: "2024-06-01T00:00:00.000Z" },
+      { name: "Mid", createdAt: "2023-12-01T00:00:00.000Z" },
+    ];
+    const result = applySort(items, "createdAt:asc");
+    expect(result.map((i) => i.name)).toEqual(["Old", "Mid", "New"]);
+  });
+
+  it("sorts by updatedAt:desc (Recently Updated)", () => {
+    const items: SortableItem[] = [
+      { name: "A", updatedAt: "2023-01-01T00:00:00.000Z" },
+      { name: "B", updatedAt: "2024-06-01T00:00:00.000Z" },
+    ];
+    const result = applySort(items, "updatedAt:desc");
+    expect(result.map((i) => i.name)).toEqual(["B", "A"]);
+  });
+
+  it("tolerates missing date fields (items without date go last)", () => {
+    const items: SortableItem[] = [
+      { name: "NoDates" },
+      { name: "HasDate", createdAt: "2024-01-01T00:00:00.000Z" },
+    ];
+    const result = applySort(items, "createdAt:desc");
+    expect(result[0].name).toBe("HasDate");
+  });
+
+  it("does not mutate the original array", () => {
+    const items: SortableItem[] = [{ name: "B" }, { name: "A" }];
+    const original = [...items];
+    applySort(items, "name:asc");
+    expect(items).toEqual(original);
+  });
+
+  it("returns original order for unknown sort key", () => {
+    const items: SortableItem[] = [{ name: "B" }, { name: "A" }];
+    const result = applySort(items, "unknown:asc");
+    expect(result.map((i) => i.name)).toEqual(["B", "A"]);
+  });
+});
+
+describe("matchesSearch", () => {
+  it("returns true for exact match", () => {
+    expect(matchesSearch({ name: "Hello World" }, "Hello World")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchesSearch({ name: "Hello World" }, "hello")).toBe(true);
+    expect(matchesSearch({ name: "hello world" }, "HELLO")).toBe(true);
+  });
+
+  it("returns true for substring match", () => {
+    expect(matchesSearch({ name: "Introduction to Python" }, "Python")).toBe(
+      true,
+    );
+  });
+
+  it("returns false when no match", () => {
+    expect(matchesSearch({ name: "Introduction to Python" }, "Java")).toBe(
+      false,
+    );
+  });
+
+  it("returns true when query is empty", () => {
+    expect(matchesSearch({ name: "Anything" }, "")).toBe(true);
+  });
+});
+
+describe("dropletMatchesFilters", () => {
+  it("returns true when no filters active", () => {
+    const droplet = makeDroplet({ status: "draft", isHidden: false });
+    expect(dropletMatchesFilters(droplet, {})).toBe(true);
+  });
+
+  it("filters by status=draft", () => {
+    const draft = makeDroplet({ status: "draft" });
+    const published = makeDroplet({ status: "published" });
+    expect(dropletMatchesFilters(draft, { status: ["draft"] })).toBe(true);
+    expect(dropletMatchesFilters(published, { status: ["draft"] })).toBe(false);
+  });
+
+  it("filters by visibility=archived", () => {
+    const archived = makeDroplet({ isHidden: true });
+    const active = makeDroplet({ isHidden: false });
+    expect(dropletMatchesFilters(archived, { visibility: ["archived"] })).toBe(
+      true,
+    );
+    expect(dropletMatchesFilters(active, { visibility: ["archived"] })).toBe(
+      false,
+    );
+  });
+
+  it("filters by visibility=active", () => {
+    const active = makeDroplet({ isHidden: false });
+    const archived = makeDroplet({ isHidden: true });
+    expect(dropletMatchesFilters(active, { visibility: ["active"] })).toBe(
+      true,
+    );
+    expect(dropletMatchesFilters(archived, { visibility: ["active"] })).toBe(
+      false,
+    );
+  });
+
+  it("filters by focusArea", () => {
+    const personal = makeDroplet({ focusArea: "personal" });
+    const technical = makeDroplet({ focusArea: "technical" });
+    expect(dropletMatchesFilters(personal, { focusArea: ["personal"] })).toBe(
+      true,
+    );
+    expect(dropletMatchesFilters(technical, { focusArea: ["personal"] })).toBe(
+      false,
+    );
+  });
+
+  it("supports OR within a filter (multiple values)", () => {
+    const personal = makeDroplet({ focusArea: "personal" });
+    const technical = makeDroplet({ focusArea: "technical" });
+    const professional = makeDroplet({ focusArea: "professional" });
+    const filter = { focusArea: ["personal", "technical"] };
+    expect(dropletMatchesFilters(personal, filter)).toBe(true);
+    expect(dropletMatchesFilters(technical, filter)).toBe(true);
+    expect(dropletMatchesFilters(professional, filter)).toBe(false);
+  });
+
+  it("applies AND across different filters", () => {
+    const droplet = makeDroplet({ status: "draft", focusArea: "technical" });
+    // Both conditions must be true
+    expect(
+      dropletMatchesFilters(droplet, {
+        status: ["draft"],
+        focusArea: ["technical"],
+      }),
+    ).toBe(true);
+    // One condition fails
+    expect(
+      dropletMatchesFilters(droplet, {
+        status: ["published"],
+        focusArea: ["technical"],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("playlistMatchesFilters", () => {
+  it("returns true when no filters active", () => {
+    const playlist = makePlaylist({});
+    expect(playlistMatchesFilters(playlist, {})).toBe(true);
+  });
+
+  it("filters by visibility=archived", () => {
+    const archived = makePlaylist({ isArchived: true });
+    const active = makePlaylist({ isArchived: false });
+    expect(playlistMatchesFilters(archived, { visibility: ["archived"] })).toBe(
+      true,
+    );
+    expect(playlistMatchesFilters(active, { visibility: ["archived"] })).toBe(
+      false,
+    );
+  });
+
+  it("filters by public=public (isPublic true)", () => {
+    const pub = makePlaylist({ isPublic: true });
+    const priv = makePlaylist({ isPublic: false });
+    expect(playlistMatchesFilters(pub, { public: ["public"] })).toBe(true);
+    expect(playlistMatchesFilters(priv, { public: ["public"] })).toBe(false);
+  });
+
+  it("filters by public=private (isPublic false)", () => {
+    const priv = makePlaylist({ isPublic: false });
+    const pub = makePlaylist({ isPublic: true });
+    expect(playlistMatchesFilters(priv, { public: ["private"] })).toBe(true);
+    expect(playlistMatchesFilters(pub, { public: ["private"] })).toBe(false);
+  });
+});
+
+describe("voyageMatchesFilters", () => {
+  it("returns true when no filters active", () => {
+    const voyage = makeVoyage({});
+    expect(voyageMatchesFilters(voyage, {})).toBe(true);
+  });
+
+  it("filters by visibility=archived", () => {
+    const archived = makeVoyage({ isArchived: true });
+    const active = makeVoyage({ isArchived: false });
+    expect(voyageMatchesFilters(archived, { visibility: ["archived"] })).toBe(
+      true,
+    );
+    expect(voyageMatchesFilters(active, { visibility: ["archived"] })).toBe(
+      false,
+    );
+  });
+
+  it("filters by visibility=active", () => {
+    const active = makeVoyage({ isArchived: false });
+    const archived = makeVoyage({ isArchived: true });
+    expect(voyageMatchesFilters(active, { visibility: ["active"] })).toBe(true);
+    expect(voyageMatchesFilters(archived, { visibility: ["active"] })).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/__tests__/my-content-tabs.test.tsx
+++ b/frontend/__tests__/my-content-tabs.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MyContentTabs } from "@/components/my-content/my-content-tabs";
+import { Droplet, Playlist, Voyage } from "@/types";
+
+// --- navigation mock ---------------------------------------------------
+// handleTabChange calls router.push directly, so this is what we assert on.
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+let mockSearchParamsString =
+  "tab=droplets&focusArea=technical&visibility=archived";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  usePathname: () => "/my-content",
+  useSearchParams: () => new URLSearchParams(mockSearchParamsString),
+}));
+
+// --- child component mocks --------------------------------------------
+jest.mock("@/components/my-content/my-content-toolbar", () => ({
+  MyContentToolbar: ({ tab }: { tab: string }) => (
+    <div data-testid="toolbar" data-tab={tab} />
+  ),
+}));
+jest.mock("@/components/my-content/droplets-creator-grid", () => ({
+  DropletsCreatorGrid: () => <div data-testid="droplets-grid" />,
+}));
+jest.mock("@/components/my-content/playlists-creator-grid", () => ({
+  PlaylistsCreatorGrid: () => <div data-testid="playlists-grid" />,
+}));
+jest.mock("@/components/my-content/voyages-creator-grid", () => ({
+  VoyagesCreatorGrid: () => <div data-testid="voyages-grid" />,
+}));
+
+// --- fixtures ---------------------------------------------------------
+const makeDroplet = (id: number): Droplet =>
+  ({
+    id,
+    name: `Droplet ${id}`,
+    slug: `droplet-${id}`,
+    status: "published",
+    type: "knowledge",
+    focusArea: "technical",
+    difficulty: "beginner",
+    isHidden: false,
+    learningObjectives: [],
+  }) as Droplet;
+
+const makePlaylist = (id: number): Playlist =>
+  ({
+    id,
+    name: `Playlist ${id}`,
+    slug: `playlist-${id}`,
+    isPublic: true,
+    duration: "short",
+    isArchived: false,
+  }) as Playlist;
+
+const makeVoyage = (id: number): Voyage =>
+  ({
+    id,
+    name: `Voyage ${id}`,
+    slug: `voyage-${id}`,
+    description: "",
+    status: "published",
+    isSequential: false,
+    isArchived: false,
+  }) as Voyage;
+
+const defaultProps = {
+  droplets: [makeDroplet(1), makeDroplet(2)],
+  playlists: [makePlaylist(1)],
+  voyages: [makeVoyage(1)],
+  showPlaylists: true,
+  showVoyages: true,
+  currentUserId: 42,
+};
+
+function renderTabs(
+  searchParams = "tab=droplets&focusArea=technical&visibility=archived",
+) {
+  mockSearchParamsString = searchParams;
+  return render(<MyContentTabs {...defaultProps} />);
+}
+
+// --- tests ------------------------------------------------------------
+describe("MyContentTabs", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders all three tab buttons", () => {
+    renderTabs();
+    expect(
+      screen.getByRole("button", { name: /droplets/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /playlists/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /voyages/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows unfiltered counts on tab buttons", () => {
+    renderTabs();
+    expect(
+      screen.getByRole("button", { name: /droplets \(2\)/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /playlists \(1\)/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /voyages \(1\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the toolbar with the active tab", () => {
+    renderTabs("tab=droplets");
+    const toolbar = screen.getByTestId("toolbar");
+    expect(toolbar).toHaveAttribute("data-tab", "droplets");
+  });
+
+  it("renders the droplets grid when active tab is droplets", () => {
+    renderTabs("tab=droplets");
+    expect(screen.getByTestId("droplets-grid")).toBeInTheDocument();
+  });
+
+  it("renders the playlists grid when active tab is playlists", () => {
+    renderTabs("tab=playlists");
+    expect(screen.getByTestId("playlists-grid")).toBeInTheDocument();
+  });
+
+  it("renders the voyages grid when active tab is voyages", () => {
+    renderTabs("tab=voyages");
+    expect(screen.getByTestId("voyages-grid")).toBeInTheDocument();
+  });
+
+  describe("tab-switch param cleanup", () => {
+    it("clears droplet-only params (focusArea) but preserves shared params (visibility) when switching to playlists", async () => {
+      renderTabs("tab=droplets&focusArea=technical&visibility=archived");
+
+      await userEvent.click(screen.getByRole("button", { name: /playlists/i }));
+
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const calledUrl = mockPush.mock.calls[0][0] as string;
+      const params = new URLSearchParams(calledUrl.split("?")[1]);
+
+      expect(params.get("tab")).toBe("playlists");
+      // visibility is allowed on playlists — must be preserved
+      expect(params.get("visibility")).toBe("archived");
+      // focusArea is droplets-only — must be removed
+      expect(params.has("focusArea")).toBe(false);
+    });
+
+    it("preserves q and sort when switching tabs, removes tab-specific params", async () => {
+      renderTabs("tab=droplets&q=python&sort=name%3Aasc&status=draft");
+
+      await userEvent.click(screen.getByRole("button", { name: /playlists/i }));
+
+      const calledUrl = mockPush.mock.calls[0][0] as string;
+      const params = new URLSearchParams(calledUrl.split("?")[1]);
+
+      expect(params.get("q")).toBe("python");
+      expect(params.get("sort")).toBe("name:asc");
+      // status is droplets-only
+      expect(params.has("status")).toBe(false);
+    });
+
+    it("clears public param when switching from playlists to voyages", async () => {
+      renderTabs("tab=playlists&public=public&visibility=active");
+
+      await userEvent.click(screen.getByRole("button", { name: /voyages/i }));
+
+      const calledUrl = mockPush.mock.calls[0][0] as string;
+      const params = new URLSearchParams(calledUrl.split("?")[1]);
+
+      expect(params.get("tab")).toBe("voyages");
+      expect(params.get("visibility")).toBe("active");
+      // public is playlists-only
+      expect(params.has("public")).toBe(false);
+    });
+  });
+});

--- a/frontend/app/(general)/my-content/page.tsx
+++ b/frontend/app/(general)/my-content/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/utils";
 import { redirect } from "next/navigation";
 import { Metadata } from "next";
+import { Suspense } from "react";
 import { getCachedUserCreation } from "@/lib/requests/cached";
 import { getVoyagesAdmin } from "@/lib/requests/voyage";
 import { MyContentTabs } from "@/components/my-content/my-content-tabs";
@@ -51,14 +52,16 @@ export default async function CreateRoute() {
         </p>
       </div>
 
-      <MyContentTabs
-        droplets={authorizedUser.droplets ?? []}
-        playlists={playlists ?? []}
-        voyages={voyages}
-        showPlaylists={showPlaylists}
-        showVoyages={isAdminOrFaculty}
-        currentUserId={authorizedUser.id}
-      />
+      <Suspense fallback={null}>
+        <MyContentTabs
+          droplets={authorizedUser.droplets ?? []}
+          playlists={playlists ?? []}
+          voyages={voyages}
+          showPlaylists={showPlaylists}
+          showVoyages={isAdminOrFaculty}
+          currentUserId={authorizedUser.id}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/components/droplets/droplet-tile.tsx
+++ b/frontend/components/droplets/droplet-tile.tsx
@@ -39,6 +39,7 @@ interface DropletTileProps {
   isAdmin?: boolean;
   isCreator?: boolean;
   creatorArchive?: boolean;
+  showCreatedDate?: boolean;
 }
 
 export function DropletTile({
@@ -53,6 +54,7 @@ export function DropletTile({
   isAdmin,
   isCreator,
   creatorArchive,
+  showCreatedDate = false,
 }: DropletTileProps) {
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const [isTextClamped, setIsTextClamped] = useState(false);
@@ -503,7 +505,7 @@ ${
           </div>
 
           <div className="flex w-full flex-nowrap items-center justify-between gap-2">
-            <div className="flex min-w-0 items-center">
+            <div className="flex min-w-0 items-center gap-2">
               {droplet.averageRating && droplet.averageRating != 0.0 ? (
                 <div className="max-w-full origin-left scale-[0.55]">
                   <StarRating
@@ -514,9 +516,19 @@ ${
                   />
                 </div>
               ) : null}
+              {showCreatedDate && droplet.createdAt && (
+                <span className="flex flex-col text-xs text-slate-400 dark:text-slate-400">
+                  <span>Created on</span>
+                  <span>
+                    {DateTime.fromISO(droplet.createdAt).toFormat(
+                      "MMM d, yyyy",
+                    )}
+                  </span>
+                </span>
+              )}
             </div>
 
-            <div className="ml-2 flex flex-shrink-0 items-center gap-2">
+            <div className="ml-2 flex flex-shrink-0 items-center gap-1">
               <Button
                 size="sm"
                 onClick={(e) => {

--- a/frontend/components/my-content/apply-sort-filter.ts
+++ b/frontend/components/my-content/apply-sort-filter.ts
@@ -41,8 +41,9 @@ export function applySort<T extends WithName & WithDates>(
  * Returns true when query is empty.
  */
 export function matchesSearch(item: WithName, query: string): boolean {
-  if (!query) return true;
-  return item.name.toLowerCase().includes(query.toLowerCase());
+  const trimmed = query.trim();
+  if (!trimmed) return true;
+  return item.name.toLowerCase().includes(trimmed.toLowerCase());
 }
 
 // Filter param shapes — values are multi-select arrays (OR within, AND across)

--- a/frontend/components/my-content/apply-sort-filter.ts
+++ b/frontend/components/my-content/apply-sort-filter.ts
@@ -1,0 +1,149 @@
+import { Droplet, Playlist, Voyage } from "@/types";
+
+type WithName = { name: string };
+type WithDates = { createdAt?: string; updatedAt?: string };
+
+/**
+ * Generic sort over any array that has a `name` and optional date fields.
+ * Handles: name:asc, name:desc, createdAt:asc, createdAt:desc,
+ *          updatedAt:asc, updatedAt:desc.
+ * Returns a new array — does not mutate the input.
+ */
+export function applySort<T extends WithName & WithDates>(
+  items: T[],
+  sortKey: string,
+): T[] {
+  const [field, direction] = sortKey.split(":");
+  const sorted = [...items];
+
+  sorted.sort((a, b) => {
+    if (field === "name") {
+      const cmp = a.name.localeCompare(b.name);
+      return direction === "asc" ? cmp : -cmp;
+    }
+
+    if (field === "createdAt" || field === "updatedAt") {
+      const aVal = field === "createdAt" ? a.createdAt : a.updatedAt;
+      const bVal = field === "createdAt" ? b.createdAt : b.updatedAt;
+      const aTime = aVal ? new Date(aVal).getTime() : 0;
+      const bTime = bVal ? new Date(bVal).getTime() : 0;
+      return direction === "asc" ? aTime - bTime : bTime - aTime;
+    }
+
+    return 0;
+  });
+
+  return sorted;
+}
+
+/**
+ * Case-insensitive substring search on item.name.
+ * Returns true when query is empty.
+ */
+export function matchesSearch(item: WithName, query: string): boolean {
+  if (!query) return true;
+  return item.name.toLowerCase().includes(query.toLowerCase());
+}
+
+// Filter param shapes — values are multi-select arrays (OR within, AND across)
+export type DropletFilterParams = {
+  status?: string[];
+  visibility?: string[];
+  focusArea?: string[];
+  type?: string[];
+  difficulty?: string[];
+};
+
+export type PlaylistFilterParams = {
+  visibility?: string[];
+  public?: string[];
+};
+
+export type VoyageFilterParams = {
+  visibility?: string[];
+};
+
+/**
+ * Returns true when the droplet passes ALL active filters.
+ * Within each filter the check is OR (any selected value matches).
+ */
+export function dropletMatchesFilters(
+  droplet: Droplet,
+  params: DropletFilterParams,
+): boolean {
+  const { status, visibility, focusArea, type, difficulty } = params;
+
+  if (status && status.length > 0) {
+    if (!status.includes(droplet.status)) return false;
+  }
+
+  if (visibility && visibility.length > 0) {
+    const isArchived = droplet.isHidden ?? false;
+    const matches =
+      (visibility.includes("archived") && isArchived) ||
+      (visibility.includes("active") && !isArchived);
+    if (!matches) return false;
+  }
+
+  if (focusArea && focusArea.length > 0) {
+    if (!focusArea.includes(droplet.focusArea)) return false;
+  }
+
+  if (type && type.length > 0) {
+    if (!type.includes(droplet.type)) return false;
+  }
+
+  if (difficulty && difficulty.length > 0) {
+    if (!difficulty.includes(droplet.difficulty)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Returns true when the playlist passes ALL active filters.
+ */
+export function playlistMatchesFilters(
+  playlist: Playlist,
+  params: PlaylistFilterParams,
+): boolean {
+  const { visibility, public: publicFilter } = params;
+
+  if (visibility && visibility.length > 0) {
+    const isArchived = playlist.isArchived ?? false;
+    const matches =
+      (visibility.includes("archived") && isArchived) ||
+      (visibility.includes("active") && !isArchived);
+    if (!matches) return false;
+  }
+
+  if (publicFilter && publicFilter.length > 0) {
+    const isPublic = playlist.isPublic;
+    const matches =
+      (publicFilter.includes("public") && isPublic) ||
+      (publicFilter.includes("private") && !isPublic);
+    if (!matches) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Returns true when the voyage passes ALL active filters.
+ */
+export function voyageMatchesFilters(
+  voyage: Voyage,
+  params: VoyageFilterParams,
+): boolean {
+  const { visibility } = params;
+
+  if (visibility && visibility.length > 0) {
+    const isArchived = voyage.isArchived ?? false;
+    const matches =
+      (visibility.includes("archived") && isArchived) ||
+      (visibility.includes("active") && !isArchived);
+    if (!matches) return false;
+  }
+
+  return true;
+}

--- a/frontend/components/my-content/droplets-creator-grid.tsx
+++ b/frontend/components/my-content/droplets-creator-grid.tsx
@@ -45,8 +45,6 @@ export function DropletsCreatorGrid({ droplets }: DropletsCreatorGridProps) {
     return sorted
       .filter((d) => matchesSearch(d, q))
       .filter((d) => dropletMatchesFilters(d, filterParams));
-    // filterParams is rebuilt each render from searchParams — stable via useMemo dep below
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [droplets, sortKey, q, searchParams]);
 
   const clearFilters = () => {

--- a/frontend/components/my-content/droplets-creator-grid.tsx
+++ b/frontend/components/my-content/droplets-creator-grid.tsx
@@ -13,19 +13,10 @@ import {
   dropletMatchesFilters,
   DropletFilterParams,
 } from "@/components/my-content/apply-sort-filter";
-import { CREATOR_DEFAULT_SORT } from "@/components/my-content/sort-filter-options";
-
-// URL params that apply only to the droplets tab
-const DROPLET_PARAM_KEYS = [
-  "tab",
-  "q",
-  "sort",
-  "status",
-  "visibility",
-  "focusArea",
-  "type",
-  "difficulty",
-];
+import {
+  CREATOR_DEFAULT_SORT,
+  TAB_ALLOWED_PARAMS,
+} from "@/components/my-content/sort-filter-options";
 
 interface DropletsCreatorGridProps {
   droplets: Droplet[];
@@ -60,16 +51,9 @@ export function DropletsCreatorGrid({ droplets }: DropletsCreatorGridProps) {
 
   const clearFilters = () => {
     const params = new URLSearchParams(searchParams);
-    // Keep only non-filter params
-    [
-      "q",
-      "sort",
-      "status",
-      "visibility",
-      "focusArea",
-      "type",
-      "difficulty",
-    ].forEach((key) => params.delete(key));
+    TAB_ALLOWED_PARAMS.droplets
+      .filter((key) => key !== "tab")
+      .forEach((key) => params.delete(key));
     router.push(`${pathname}?${params.toString()}`);
   };
 
@@ -124,5 +108,3 @@ export function DropletsCreatorGrid({ droplets }: DropletsCreatorGridProps) {
     </ul>
   );
 }
-
-export { DROPLET_PARAM_KEYS };

--- a/frontend/components/my-content/droplets-creator-grid.tsx
+++ b/frontend/components/my-content/droplets-creator-grid.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Droplet } from "@/types";
+import { DropletTile } from "@/components/droplets/droplet-tile";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
+import { IconDroplet } from "@tabler/icons-react";
+import {
+  applySort,
+  matchesSearch,
+  dropletMatchesFilters,
+  DropletFilterParams,
+} from "@/components/my-content/apply-sort-filter";
+import { CREATOR_DEFAULT_SORT } from "@/components/my-content/sort-filter-options";
+
+// URL params that apply only to the droplets tab
+const DROPLET_PARAM_KEYS = [
+  "tab",
+  "q",
+  "sort",
+  "status",
+  "visibility",
+  "focusArea",
+  "type",
+  "difficulty",
+];
+
+interface DropletsCreatorGridProps {
+  droplets: Droplet[];
+}
+
+export function DropletsCreatorGrid({ droplets }: DropletsCreatorGridProps) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const q = searchParams.get("q") ?? "";
+  const sortKey = searchParams.get("sort") ?? CREATOR_DEFAULT_SORT.slug;
+
+  const filterParams: DropletFilterParams = {
+    status: searchParams.get("status")?.split(",").filter(Boolean) ?? [],
+    visibility:
+      searchParams.get("visibility")?.split(",").filter(Boolean) ?? [],
+    focusArea: searchParams.get("focusArea")?.split(",").filter(Boolean) ?? [],
+    type: searchParams.get("type")?.split(",").filter(Boolean) ?? [],
+    difficulty:
+      searchParams.get("difficulty")?.split(",").filter(Boolean) ?? [],
+  };
+
+  const filtered = useMemo(() => {
+    const sorted = applySort(droplets, sortKey);
+    return sorted
+      .filter((d) => matchesSearch(d, q))
+      .filter((d) => dropletMatchesFilters(d, filterParams));
+    // filterParams is rebuilt each render from searchParams — stable via useMemo dep below
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [droplets, sortKey, q, searchParams]);
+
+  const clearFilters = () => {
+    const params = new URLSearchParams(searchParams);
+    // Keep only non-filter params
+    [
+      "q",
+      "sort",
+      "status",
+      "visibility",
+      "focusArea",
+      "type",
+      "difficulty",
+    ].forEach((key) => params.delete(key));
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
+  if (droplets.length === 0) {
+    return (
+      <EmptyState
+        icon={
+          <IconDroplet
+            className="h-7 w-7 text-[#475569] dark:text-slate-400"
+            stroke={1.5}
+          />
+        }
+        title="No droplets yet"
+        message="Create a new droplet to get started."
+      />
+    );
+  }
+
+  if (filtered.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-4">
+        <EmptyState
+          icon={
+            <IconDroplet
+              className="h-7 w-7 text-[#475569] dark:text-slate-400"
+              stroke={1.5}
+            />
+          }
+          title="No matching droplets"
+          message="No droplets match your current search or filters."
+          className="w-full"
+        />
+        <Button variant="outline" size="sm" onClick={clearFilters}>
+          Clear filters
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="grid grid-flow-row grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {filtered.map((droplet) => (
+        <DropletTile
+          key={droplet.id}
+          droplet={droplet}
+          isArchived={droplet.isHidden ?? false}
+          isCreator={true}
+          creatorArchive={true}
+          showCreatedDate={true}
+        />
+      ))}
+    </ul>
+  );
+}
+
+export { DROPLET_PARAM_KEYS };

--- a/frontend/components/my-content/my-content-tabs.tsx
+++ b/frontend/components/my-content/my-content-tabs.tsx
@@ -11,6 +11,7 @@ import { MyContentToolbar } from "@/components/my-content/my-content-toolbar";
 import { DropletsCreatorGrid } from "@/components/my-content/droplets-creator-grid";
 import { PlaylistsCreatorGrid } from "@/components/my-content/playlists-creator-grid";
 import { VoyagesCreatorGrid } from "@/components/my-content/voyages-creator-grid";
+import { TAB_ALLOWED_PARAMS } from "@/components/my-content/sort-filter-options";
 
 interface MyContentTabsProps {
   droplets: Droplet[];
@@ -26,22 +27,6 @@ const tabs = [
   { id: "playlists", label: "Playlists" },
   { id: "voyages", label: "Voyages" },
 ] as const;
-
-// Params allowed on each tab (used to clear stale params on tab switch)
-const TAB_ALLOWED_PARAMS: Record<string, string[]> = {
-  droplets: [
-    "tab",
-    "q",
-    "sort",
-    "status",
-    "visibility",
-    "focusArea",
-    "type",
-    "difficulty",
-  ],
-  playlists: ["tab", "q", "sort", "visibility", "public"],
-  voyages: ["tab", "q", "sort", "visibility"],
-};
 
 export function MyContentTabs({
   droplets,

--- a/frontend/components/my-content/my-content-tabs.tsx
+++ b/frontend/components/my-content/my-content-tabs.tsx
@@ -60,8 +60,14 @@ export function MyContentTabs({
   useEffect(() => {
     const ids = visibleTabs.map((t) => t.id);
     if (!ids.includes(activeTab)) {
-      const params = new URLSearchParams(searchParams.toString());
-      params.set("tab", ids[0] ?? "droplets");
+      const fallbackTab = (ids[0] ?? "droplets") as (typeof tabIds)[number];
+      const allowed = TAB_ALLOWED_PARAMS[fallbackTab] ?? [];
+      const params = new URLSearchParams();
+      allowed.forEach((key) => {
+        const value = searchParams.get(key);
+        if (value !== null) params.set(key, value);
+      });
+      params.set("tab", fallbackTab);
       router.replace(`${pathname}?${params.toString()}`);
     }
   }, [activeTab, visibleTabs, searchParams, pathname, router]);

--- a/frontend/components/my-content/my-content-tabs.tsx
+++ b/frontend/components/my-content/my-content-tabs.tsx
@@ -1,17 +1,16 @@
 "use client";
 
-import { useQueryState, parseAsStringLiteral } from "nuqs";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { PlusIcon } from "lucide-react";
 import Link from "next/link";
-import { DropletTile } from "@/components/droplets/droplet-tile";
-import { PlaylistCard } from "@/components/playlists/playlist-card";
-import { VoyageCard } from "@/components/voyages/voyage-card";
 import { Droplet, Playlist, Voyage } from "@/types";
 import { cn } from "@/lib/utils";
-import { EmptyState } from "@/components/ui/empty-state";
-import { IconDroplet, IconLayoutList, IconMap } from "@tabler/icons-react";
 import { useEffect, useMemo } from "react";
+import { MyContentToolbar } from "@/components/my-content/my-content-toolbar";
+import { DropletsCreatorGrid } from "@/components/my-content/droplets-creator-grid";
+import { PlaylistsCreatorGrid } from "@/components/my-content/playlists-creator-grid";
+import { VoyagesCreatorGrid } from "@/components/my-content/voyages-creator-grid";
 
 interface MyContentTabsProps {
   droplets: Droplet[];
@@ -28,6 +27,22 @@ const tabs = [
   { id: "voyages", label: "Voyages" },
 ] as const;
 
+// Params allowed on each tab (used to clear stale params on tab switch)
+const TAB_ALLOWED_PARAMS: Record<string, string[]> = {
+  droplets: [
+    "tab",
+    "q",
+    "sort",
+    "status",
+    "visibility",
+    "focusArea",
+    "type",
+    "difficulty",
+  ],
+  playlists: ["tab", "q", "sort", "visibility", "public"],
+  voyages: ["tab", "q", "sort", "visibility"],
+};
+
 export function MyContentTabs({
   droplets,
   playlists,
@@ -37,10 +52,14 @@ export function MyContentTabs({
   currentUserId,
 }: MyContentTabsProps) {
   const tabIds = tabs.map((t) => t.id);
-  const [activeTab, setActiveTab] = useQueryState(
-    "tab",
-    parseAsStringLiteral(tabIds).withDefault("droplets"),
-  );
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const rawTab = searchParams.get("tab");
+  const activeTab = tabIds.includes(rawTab as (typeof tabIds)[number])
+    ? (rawTab as (typeof tabIds)[number])
+    : "droplets";
 
   const visibleTabs = useMemo(
     () =>
@@ -56,9 +75,26 @@ export function MyContentTabs({
   useEffect(() => {
     const ids = visibleTabs.map((t) => t.id);
     if (!ids.includes(activeTab)) {
-      setActiveTab(ids[0] ?? "droplets");
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", ids[0] ?? "droplets");
+      router.replace(`${pathname}?${params.toString()}`);
     }
-  }, [activeTab, visibleTabs, setActiveTab]);
+  }, [activeTab, visibleTabs, searchParams, pathname, router]);
+
+  const handleTabChange = (newTab: (typeof tabIds)[number]) => {
+    const allowed = TAB_ALLOWED_PARAMS[newTab] ?? [];
+    const params = new URLSearchParams(searchParams.toString());
+
+    // Remove params not applicable to the new tab
+    Array.from(params.keys()).forEach((key) => {
+      if (!allowed.includes(key)) {
+        params.delete(key);
+      }
+    });
+
+    params.set("tab", newTab);
+    router.push(`${pathname}?${params.toString()}`);
+  };
 
   return (
     <div className="w-full">
@@ -75,7 +111,7 @@ export function MyContentTabs({
             return (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
+                onClick={() => handleTabChange(tab.id)}
                 className={cn(
                   "rounded-full border px-4 py-1.5 text-sm font-medium transition-colors",
                   activeTab === tab.id
@@ -124,94 +160,26 @@ export function MyContentTabs({
         )}
       </div>
 
+      {/* Toolbar: search + filters + sort */}
+      <div className="mt-4">
+        <MyContentToolbar
+          tab={activeTab as "droplets" | "playlists" | "voyages"}
+        />
+      </div>
+
       {/* Tab content */}
       <div className="mt-6">
-        {activeTab === "droplets" &&
-          (droplets.length === 0 ? (
-            <EmptyState
-              icon={
-                <IconDroplet
-                  className="h-7 w-7 text-[#475569] dark:text-slate-400"
-                  stroke={1.5}
-                />
-              }
-              title="No droplets yet"
-              message="Create a new droplet to get started."
-            />
-          ) : (
-            <ul className="grid grid-flow-row grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-              {droplets.map((droplet) => (
-                <DropletTile
-                  key={droplet.id}
-                  droplet={droplet}
-                  isArchived={droplet.isHidden ?? false}
-                  isCreator={true}
-                  creatorArchive={true}
-                />
-              ))}
-            </ul>
-          ))}
+        {activeTab === "droplets" && (
+          <DropletsCreatorGrid droplets={droplets} />
+        )}
 
-        {activeTab === "playlists" &&
-          showPlaylists &&
-          (playlists.length === 0 ? (
-            <EmptyState
-              icon={
-                <IconLayoutList
-                  className="h-7 w-7 text-[#475569] dark:text-slate-400"
-                  stroke={1.5}
-                />
-              }
-              title="No playlists yet"
-              message="Create a new playlist to get started."
-            />
-          ) : (
-            <ul className="grid grid-flow-row grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-              {playlists.map((playlist) => (
-                <PlaylistCard
-                  key={playlist.id}
-                  playlist={playlist}
-                  toDraft={true}
-                  dashboardPage={true}
-                  isCreator={true}
-                  isArchived={playlist.isArchived ?? false}
-                />
-              ))}
-            </ul>
-          ))}
+        {activeTab === "playlists" && showPlaylists && (
+          <PlaylistsCreatorGrid playlists={playlists} />
+        )}
 
-        {activeTab === "voyages" &&
-          showVoyages &&
-          (voyages.length === 0 ? (
-            <EmptyState
-              icon={
-                <IconMap
-                  className="h-7 w-7 text-[#475569] dark:text-slate-400"
-                  stroke={1.5}
-                />
-              }
-              title="No voyages yet"
-              message="Create a new voyage to get started."
-            />
-          ) : (
-            <ul className="grid grid-flow-row grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-              {voyages.map((voyage) => (
-                <li key={voyage.id}>
-                  <VoyageCard
-                    voyage={voyage}
-                    isArchived={voyage.isArchived ?? false}
-                    isCreator={
-                      currentUserId
-                        ? voyage.authors?.some((a) => a.id === currentUserId) ??
-                          false
-                        : false
-                    }
-                    dashboardPage={true}
-                  />
-                </li>
-              ))}
-            </ul>
-          ))}
+        {activeTab === "voyages" && showVoyages && (
+          <VoyagesCreatorGrid voyages={voyages} currentUserId={currentUserId} />
+        )}
       </div>
     </div>
   );

--- a/frontend/components/my-content/my-content-toolbar.tsx
+++ b/frontend/components/my-content/my-content-toolbar.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useQueryState } from "nuqs";
+import { SearchBar } from "@/components/admin/search-bar";
+import { Filter } from "@/components/explore/filter";
+import { Sort } from "@/components/explore/sort";
+import {
+  dropletCreatorSorting,
+  playlistCreatorSorting,
+  voyageCreatorSorting,
+  DROPLET_CREATOR_FILTERS,
+  PLAYLIST_CREATOR_FILTERS,
+  VOYAGE_CREATOR_FILTERS,
+  CREATOR_DEFAULT_SORT,
+} from "@/components/my-content/sort-filter-options";
+
+interface MyContentToolbarProps {
+  tab: "droplets" | "playlists" | "voyages";
+}
+
+export function MyContentToolbar({ tab }: MyContentToolbarProps) {
+  const [q, setQ] = useQueryState("q", { defaultValue: "", throttleMs: 300 });
+
+  const sortOptions =
+    tab === "droplets"
+      ? dropletCreatorSorting
+      : tab === "playlists"
+        ? playlistCreatorSorting
+        : voyageCreatorSorting;
+
+  const filterDefs =
+    tab === "droplets"
+      ? DROPLET_CREATOR_FILTERS
+      : tab === "playlists"
+        ? PLAYLIST_CREATOR_FILTERS
+        : VOYAGE_CREATOR_FILTERS;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <SearchBar
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        placeholder="Search..."
+        className="w-full md:w-64"
+        inputClassName="h-9"
+      />
+
+      {filterDefs.map((f) => (
+        <Filter
+          key={f.name}
+          name={f.name}
+          label={f.label}
+          options={f.options}
+        />
+      ))}
+
+      <Sort options={sortOptions} defaultValue={CREATOR_DEFAULT_SORT} />
+    </div>
+  );
+}

--- a/frontend/components/my-content/playlists-creator-grid.tsx
+++ b/frontend/components/my-content/playlists-creator-grid.tsx
@@ -41,7 +41,6 @@ export function PlaylistsCreatorGrid({ playlists }: PlaylistsCreatorGridProps) {
     return sorted
       .filter((p) => matchesSearch(p, q))
       .filter((p) => playlistMatchesFilters(p, filterParams));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [playlists, sortKey, q, searchParams]);
 
   const clearFilters = () => {

--- a/frontend/components/my-content/playlists-creator-grid.tsx
+++ b/frontend/components/my-content/playlists-creator-grid.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Playlist } from "@/types";
+import { PlaylistCard } from "@/components/playlists/playlist-card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
+import { IconLayoutList } from "@tabler/icons-react";
+import {
+  applySort,
+  matchesSearch,
+  playlistMatchesFilters,
+  PlaylistFilterParams,
+} from "@/components/my-content/apply-sort-filter";
+import { CREATOR_DEFAULT_SORT } from "@/components/my-content/sort-filter-options";
+
+interface PlaylistsCreatorGridProps {
+  playlists: Playlist[];
+}
+
+export function PlaylistsCreatorGrid({ playlists }: PlaylistsCreatorGridProps) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const q = searchParams.get("q") ?? "";
+  const sortKey = searchParams.get("sort") ?? CREATOR_DEFAULT_SORT.slug;
+
+  const filterParams: PlaylistFilterParams = {
+    visibility:
+      searchParams.get("visibility")?.split(",").filter(Boolean) ?? [],
+    public: searchParams.get("public")?.split(",").filter(Boolean) ?? [],
+  };
+
+  const filtered = useMemo(() => {
+    const sorted = applySort(playlists, sortKey);
+    return sorted
+      .filter((p) => matchesSearch(p, q))
+      .filter((p) => playlistMatchesFilters(p, filterParams));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playlists, sortKey, q, searchParams]);
+
+  const clearFilters = () => {
+    const params = new URLSearchParams(searchParams);
+    ["q", "sort", "visibility", "public"].forEach((key) => params.delete(key));
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
+  if (playlists.length === 0) {
+    return (
+      <EmptyState
+        icon={
+          <IconLayoutList
+            className="h-7 w-7 text-[#475569] dark:text-slate-400"
+            stroke={1.5}
+          />
+        }
+        title="No playlists yet"
+        message="Create a new playlist to get started."
+      />
+    );
+  }
+
+  if (filtered.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-4">
+        <EmptyState
+          icon={
+            <IconLayoutList
+              className="h-7 w-7 text-[#475569] dark:text-slate-400"
+              stroke={1.5}
+            />
+          }
+          title="No matching playlists"
+          message="No playlists match your current search or filters."
+          className="w-full"
+        />
+        <Button variant="outline" size="sm" onClick={clearFilters}>
+          Clear filters
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="grid grid-flow-row grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {filtered.map((playlist) => (
+        <PlaylistCard
+          key={playlist.id}
+          playlist={playlist}
+          toDraft={true}
+          dashboardPage={true}
+          isCreator={true}
+          isArchived={playlist.isArchived ?? false}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/frontend/components/my-content/playlists-creator-grid.tsx
+++ b/frontend/components/my-content/playlists-creator-grid.tsx
@@ -13,7 +13,10 @@ import {
   playlistMatchesFilters,
   PlaylistFilterParams,
 } from "@/components/my-content/apply-sort-filter";
-import { CREATOR_DEFAULT_SORT } from "@/components/my-content/sort-filter-options";
+import {
+  CREATOR_DEFAULT_SORT,
+  TAB_ALLOWED_PARAMS,
+} from "@/components/my-content/sort-filter-options";
 
 interface PlaylistsCreatorGridProps {
   playlists: Playlist[];
@@ -43,7 +46,9 @@ export function PlaylistsCreatorGrid({ playlists }: PlaylistsCreatorGridProps) {
 
   const clearFilters = () => {
     const params = new URLSearchParams(searchParams);
-    ["q", "sort", "visibility", "public"].forEach((key) => params.delete(key));
+    TAB_ALLOWED_PARAMS.playlists
+      .filter((key) => key !== "tab")
+      .forEach((key) => params.delete(key));
     router.push(`${pathname}?${params.toString()}`);
   };
 

--- a/frontend/components/my-content/sort-filter-options.ts
+++ b/frontend/components/my-content/sort-filter-options.ts
@@ -103,3 +103,23 @@ export const VOYAGE_CREATOR_FILTERS: {
     options: VISIBILITY_OPTIONS,
   },
 ];
+
+// Allowed URL params per tab — used by tab switching (to clear stale params)
+// and by each grid's clearFilters handler
+export const TAB_ALLOWED_PARAMS: Record<
+  "droplets" | "playlists" | "voyages",
+  string[]
+> = {
+  droplets: [
+    "tab",
+    "q",
+    "sort",
+    "status",
+    "visibility",
+    "focusArea",
+    "type",
+    "difficulty",
+  ],
+  playlists: ["tab", "q", "sort", "visibility", "public"],
+  voyages: ["tab", "q", "sort", "visibility"],
+};

--- a/frontend/components/my-content/sort-filter-options.ts
+++ b/frontend/components/my-content/sort-filter-options.ts
@@ -84,7 +84,7 @@ export const PLAYLIST_CREATOR_FILTERS: {
   },
   {
     name: "public",
-    label: "Availability",
+    label: "Public/Private",
     options: [
       { label: "Public", value: "public" },
       { label: "Private", value: "private" },

--- a/frontend/components/my-content/sort-filter-options.ts
+++ b/frontend/components/my-content/sort-filter-options.ts
@@ -1,0 +1,105 @@
+import { FilterOption, SortFilterItem } from "@/lib/globals";
+
+// Sort options shared across all creator tabs
+const BASE_CREATOR_SORTING: SortFilterItem[] = [
+  { label: "A–Z", slug: "name:asc", sortKey: "name:asc" },
+  { label: "Z–A", slug: "name:desc", sortKey: "name:desc" },
+  { label: "Newest", slug: "createdAt:desc", sortKey: "createdAt:desc" },
+  { label: "Oldest", slug: "createdAt:asc", sortKey: "createdAt:asc" },
+  {
+    label: "Recently Updated",
+    slug: "updatedAt:desc",
+    sortKey: "updatedAt:desc",
+  },
+];
+
+export const dropletCreatorSorting: SortFilterItem[] = BASE_CREATOR_SORTING;
+export const playlistCreatorSorting: SortFilterItem[] = BASE_CREATOR_SORTING;
+export const voyageCreatorSorting: SortFilterItem[] = BASE_CREATOR_SORTING;
+
+// Default sort for creator pages: Recently Updated
+export const CREATOR_DEFAULT_SORT: SortFilterItem = BASE_CREATOR_SORTING[4];
+
+// Shared visibility options (applies to droplets, playlists, voyages)
+const VISIBILITY_OPTIONS: FilterOption[] = [
+  { label: "Active", value: "active" },
+  { label: "Archived", value: "archived" },
+];
+
+export const DROPLET_CREATOR_FILTERS: {
+  name: string;
+  label: string;
+  options: FilterOption[];
+}[] = [
+  {
+    name: "status",
+    label: "Status",
+    options: [
+      { label: "Draft", value: "draft" },
+      { label: "Published", value: "published" },
+    ],
+  },
+  {
+    name: "visibility",
+    label: "Visibility",
+    options: VISIBILITY_OPTIONS,
+  },
+  {
+    name: "focusArea",
+    label: "Focus Area",
+    options: [
+      { label: "Personal", value: "personal" },
+      { label: "Professional", value: "professional" },
+      { label: "Technical", value: "technical" },
+    ],
+  },
+  {
+    name: "type",
+    label: "Type",
+    options: [
+      { label: "Knowledge", value: "knowledge" },
+      { label: "Skill", value: "skill" },
+    ],
+  },
+  {
+    name: "difficulty",
+    label: "Difficulty",
+    options: [
+      { label: "Beginner", value: "beginner" },
+      { label: "Intermediate", value: "intermediate" },
+      { label: "Advanced", value: "advanced" },
+    ],
+  },
+];
+
+export const PLAYLIST_CREATOR_FILTERS: {
+  name: string;
+  label: string;
+  options: FilterOption[];
+}[] = [
+  {
+    name: "visibility",
+    label: "Visibility",
+    options: VISIBILITY_OPTIONS,
+  },
+  {
+    name: "public",
+    label: "Availability",
+    options: [
+      { label: "Public", value: "public" },
+      { label: "Private", value: "private" },
+    ],
+  },
+];
+
+export const VOYAGE_CREATOR_FILTERS: {
+  name: string;
+  label: string;
+  options: FilterOption[];
+}[] = [
+  {
+    name: "visibility",
+    label: "Visibility",
+    options: VISIBILITY_OPTIONS,
+  },
+];

--- a/frontend/components/my-content/voyages-creator-grid.tsx
+++ b/frontend/components/my-content/voyages-creator-grid.tsx
@@ -13,7 +13,10 @@ import {
   voyageMatchesFilters,
   VoyageFilterParams,
 } from "@/components/my-content/apply-sort-filter";
-import { CREATOR_DEFAULT_SORT } from "@/components/my-content/sort-filter-options";
+import {
+  CREATOR_DEFAULT_SORT,
+  TAB_ALLOWED_PARAMS,
+} from "@/components/my-content/sort-filter-options";
 
 interface VoyagesCreatorGridProps {
   voyages: Voyage[];
@@ -46,7 +49,9 @@ export function VoyagesCreatorGrid({
 
   const clearFilters = () => {
     const params = new URLSearchParams(searchParams);
-    ["q", "sort", "visibility"].forEach((key) => params.delete(key));
+    TAB_ALLOWED_PARAMS.voyages
+      .filter((key) => key !== "tab")
+      .forEach((key) => params.delete(key));
     router.push(`${pathname}?${params.toString()}`);
   };
 

--- a/frontend/components/my-content/voyages-creator-grid.tsx
+++ b/frontend/components/my-content/voyages-creator-grid.tsx
@@ -44,7 +44,6 @@ export function VoyagesCreatorGrid({
     return sorted
       .filter((v) => matchesSearch(v, q))
       .filter((v) => voyageMatchesFilters(v, filterParams));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [voyages, sortKey, q, searchParams]);
 
   const clearFilters = () => {

--- a/frontend/components/my-content/voyages-creator-grid.tsx
+++ b/frontend/components/my-content/voyages-creator-grid.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Voyage } from "@/types";
+import { VoyageCard } from "@/components/voyages/voyage-card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
+import { IconMap } from "@tabler/icons-react";
+import {
+  applySort,
+  matchesSearch,
+  voyageMatchesFilters,
+  VoyageFilterParams,
+} from "@/components/my-content/apply-sort-filter";
+import { CREATOR_DEFAULT_SORT } from "@/components/my-content/sort-filter-options";
+
+interface VoyagesCreatorGridProps {
+  voyages: Voyage[];
+  currentUserId?: number;
+}
+
+export function VoyagesCreatorGrid({
+  voyages,
+  currentUserId,
+}: VoyagesCreatorGridProps) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const q = searchParams.get("q") ?? "";
+  const sortKey = searchParams.get("sort") ?? CREATOR_DEFAULT_SORT.slug;
+
+  const filterParams: VoyageFilterParams = {
+    visibility:
+      searchParams.get("visibility")?.split(",").filter(Boolean) ?? [],
+  };
+
+  const filtered = useMemo(() => {
+    const sorted = applySort(voyages, sortKey);
+    return sorted
+      .filter((v) => matchesSearch(v, q))
+      .filter((v) => voyageMatchesFilters(v, filterParams));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [voyages, sortKey, q, searchParams]);
+
+  const clearFilters = () => {
+    const params = new URLSearchParams(searchParams);
+    ["q", "sort", "visibility"].forEach((key) => params.delete(key));
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
+  if (voyages.length === 0) {
+    return (
+      <EmptyState
+        icon={
+          <IconMap
+            className="h-7 w-7 text-[#475569] dark:text-slate-400"
+            stroke={1.5}
+          />
+        }
+        title="No voyages yet"
+        message="Create a new voyage to get started."
+      />
+    );
+  }
+
+  if (filtered.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-4">
+        <EmptyState
+          icon={
+            <IconMap
+              className="h-7 w-7 text-[#475569] dark:text-slate-400"
+              stroke={1.5}
+            />
+          }
+          title="No matching voyages"
+          message="No voyages match your current search or filters."
+          className="w-full"
+        />
+        <Button variant="outline" size="sm" onClick={clearFilters}>
+          Clear filters
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="grid grid-flow-row grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {filtered.map((voyage) => (
+        <li key={voyage.id}>
+          <VoyageCard
+            voyage={voyage}
+            isArchived={voyage.isArchived ?? false}
+            isCreator={
+              currentUserId
+                ? voyage.authors?.some((a) => a.id === currentUserId) ?? false
+                : false
+            }
+            dashboardPage={true}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/lib/globals.ts
+++ b/frontend/lib/globals.ts
@@ -121,6 +121,8 @@ export type SortFilterItem = {
     | "name:desc"
     | "createdAt:asc"
     | "createdAt:desc"
+    | "updatedAt:asc"
+    | "updatedAt:desc"
     | "completion:asc"
     | "completion:desc"
     | "rating:asc"

--- a/frontend/lib/requests/user-populates.ts
+++ b/frontend/lib/requests/user-populates.ts
@@ -90,10 +90,20 @@ export const USER_POPULATES = {
           "focusArea",
           "difficulty",
           "isHidden",
+          "createdAt",
+          "updatedAt",
         ],
       },
       created_playlists: {
-        fields: ["id", "name", "slug", "isPublic", "isArchived"],
+        fields: [
+          "id",
+          "name",
+          "slug",
+          "isPublic",
+          "isArchived",
+          "createdAt",
+          "updatedAt",
+        ],
         populate: {
           droplets: {
             fields: ["id", "name", "slug"],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "odyssey",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "odyssey",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "@aarkue/tiptap-math-extension": "^1.3.4",
         "@anthropic-ai/sdk": "^0.54.0",
@@ -1865,6 +1865,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2382,6 +2383,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.10.1.tgz",
       "integrity": "sha512-YY/u+RsjLVhcUaIn+wv6vjMx8kldO7SzFFnRu0iuC+QW57VrlqUzqz5PR6CenphwJHuqGM5b3SCr4K2ZPjN8jQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2558,6 +2560,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.10.1.tgz",
       "integrity": "sha512-LhTRI+bECLFqitWN821A7faVFVw5OitFGWn45LIIRc/1Jg3lkqsaqx3LcLN1sjXd+f/vfoeXLKSD6VJvv/B/nQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -2636,6 +2639,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.10.1.tgz",
       "integrity": "sha512-YY/u+RsjLVhcUaIn+wv6vjMx8kldO7SzFFnRu0iuC+QW57VrlqUzqz5PR6CenphwJHuqGM5b3SCr4K2ZPjN8jQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2683,6 +2687,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.10.1.tgz",
       "integrity": "sha512-LhTRI+bECLFqitWN821A7faVFVw5OitFGWn45LIIRc/1Jg3lkqsaqx3LcLN1sjXd+f/vfoeXLKSD6VJvv/B/nQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -2941,6 +2946,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
       "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -3117,6 +3123,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3139,6 +3146,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3160,6 +3168,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3293,6 +3302,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3336,6 +3346,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3416,7 +3427,6 @@
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -3441,7 +3451,6 @@
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -3458,7 +3467,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3472,7 +3480,6 @@
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -3491,6 +3498,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -3597,7 +3605,6 @@
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
@@ -3613,7 +3620,6 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -3628,8 +3634,7 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@iconicicons/react": {
       "version": "1.5.1",
@@ -4859,6 +4864,7 @@
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.6.tgz",
       "integrity": "sha512-paTl+0x+O/QtgMtqVJaG8maD8sfiOdgPmLOyG485FmeGZ1L3KMdEkhxZtmdGlDFsLXhmMGQ57ducT90bvhXX5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "clsx": "^2.1.1",
@@ -4890,6 +4896,7 @@
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.6.tgz",
       "integrity": "sha512-liHfaWXHAkLjJy+Bkr29UsCwAoDQ/a64WrM67lksx8F0qqyjR5RQH8zVlhuOjdpQnwtlUkE/YiTvbJiPcoI0bw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -4978,6 +4985,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.4.tgz",
       "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.4",
@@ -5088,6 +5096,7 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.3.tgz",
       "integrity": "sha512-Lqq3emZr5IzRLKaHPuMaLBDVaGvxoh6z7HMWd1RPKawBM5uMRaQ4ImsmmgXWtwJdfZux5eugfDhXJUo2mliS8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/private-theming": "^7.3.3",
@@ -5804,6 +5813,7 @@
       "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.4.6.tgz",
       "integrity": "sha512-6ujAriBZMfQ16n6M6Ad9g32KJUa1CzqIVaHN/tymadr/3m8hrr7xDw6z50pVjpCRq2PaaA1hT8Hx7EFU3f2z3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@internationalized/date": "3.6.0",
         "@nextui-org/react-utils": "2.1.3",
@@ -5877,6 +5887,7 @@
       "resolved": "https://registry.npmjs.org/@nextui-org/theme/-/theme-2.4.5.tgz",
       "integrity": "sha512-c7Y17n+hBGiFedxMKfg7Qyv93iY5MteamLXV4Po4c1VF1qZJI6I+IKULFh3FxPWzAoz96r6NdYT7OLFjrAJdWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nextui-org/shared-utils": "2.1.2",
         "clsx": "^1.2.1",
@@ -6024,6 +6035,7 @@
       "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.55.1"
       },
@@ -9233,6 +9245,7 @@
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.13.0.tgz",
       "integrity": "sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
@@ -10229,6 +10242,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.11.7.tgz",
       "integrity": "sha512-zN+NFFxLsxNEL8Qioc+DL6b8+Tt2bmRbXH22Gk6F6nD30x83eaUSFlSv3wqvgyCq3I1i1NO394So+Agmayx6rQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -10311,6 +10325,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.11.7.tgz",
       "integrity": "sha512-To/y/2H04VWqiANy53aXjV7S6fA86c2759RsH1hTIe57jA1KyE7I5tlAofljOLZK/covkGmPeBddSPHGJbz++Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -10590,6 +10605,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.11.7.tgz",
       "integrity": "sha512-LHO6DBg/9SkCQFdWlVfw9nolUmw+Cid94WkTY+7IwrpyG2+ZGQxnKpCJCKyeaFNbDoYAtvu0vuTsSXeCkgShcA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -10616,6 +10632,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.11.7.tgz",
       "integrity": "sha512-7gEEfz2Q6bYKXM07vzLUD0vqXFhC5geWRA6LCozTiLdVFDdHWiBrvb2rtkL5T7mfLq03zc1QhH7rI3F6VntOEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.2.1",
         "prosemirror-collab": "^1.3.1",
@@ -10751,8 +10768,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -11071,6 +11087,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
       "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -11119,6 +11136,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -11139,6 +11157,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -11265,6 +11284,7 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -11815,6 +11835,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11839,7 +11860,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -11881,7 +11901,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12498,6 +12517,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -12748,6 +12768,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
       "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -13539,8 +13560,7 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -13700,7 +13720,6 @@
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -13713,8 +13732,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -14340,6 +14358,7 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -14534,7 +14553,6 @@
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -14565,7 +14583,6 @@
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -14582,7 +14599,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14611,7 +14627,6 @@
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -14643,7 +14658,6 @@
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -14657,7 +14671,6 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -14848,8 +14861,7 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
@@ -14926,7 +14938,6 @@
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -14970,7 +14981,6 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -15000,7 +15010,6 @@
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -15015,8 +15024,7 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -15421,8 +15429,7 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -15822,6 +15829,7 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -15977,7 +15985,6 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -16433,7 +16440,6 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -17925,7 +17931,6 @@
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -17990,8 +17995,7 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -18004,16 +18008,14 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -18077,7 +18079,6 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -18126,7 +18127,6 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -18204,7 +18204,6 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -18279,6 +18278,7 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -18312,6 +18312,7 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
       "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -19414,7 +19415,6 @@
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.6.3.tgz",
       "integrity": "sha512-gRY08RjcnzgFYLemUZ1lo/e9RkBxR+6d4BRvoeZDSeArG4XQXERSPapKl3LNQRu22Sndjf1h+iavgY0O4NrYqA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "motion-utils": "^12.6.3"
       }
@@ -19423,8 +19423,7 @@
       "version": "12.6.3",
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.6.3.tgz",
       "integrity": "sha512-R/b3Ia2VxtTNZ4LTEO5pKYau1OUNHOuUfxuP0WFCTDYdHkeTBR9UtxR1cc8mDmKr8PEhmmfnTKGz3rSMjNRoRg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -19472,6 +19471,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
       "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
@@ -19959,7 +19959,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -20032,7 +20031,6 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -20408,6 +20406,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -20586,6 +20585,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.4.tgz",
       "integrity": "sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -20615,7 +20615,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -20626,7 +20625,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -20642,7 +20640,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -20655,8 +20652,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/printj": {
       "version": "1.1.2",
@@ -20694,6 +20690,7 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -20881,6 +20878,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -20910,6 +20908,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -20958,6 +20957,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
       "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -21064,6 +21064,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -21261,6 +21262,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -21330,6 +21332,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.55.0.tgz",
       "integrity": "sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -22009,7 +22012,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -22027,7 +22029,6 @@
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -22989,6 +22990,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -23092,8 +23094,7 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -23163,6 +23164,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23294,6 +23296,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -23393,7 +23396,6 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -23506,6 +23508,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23728,7 +23731,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -24198,7 +24200,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24482,6 +24483,7 @@
       "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
       "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.85"
       },
@@ -24573,6 +24575,7 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
       "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odyssey",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/types/index.d.ts
+++ b/frontend/types/index.d.ts
@@ -252,6 +252,8 @@ export type Droplet = {
   usersFavorited?: AuthorizedUser[];
   datasets?: Dataset[];
   presentationEnabled?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
 };
 
 export type QuizAnswerOption = {
@@ -310,6 +312,8 @@ export interface Playlist {
   authors?: AuthorizedUser[];
   users_archived?: AuthorizedUser[];
   isArchived?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export type PlaylistListResponse = {


### PR DESCRIPTION
## Description

Adds sort, filter, and search to the /my-content creator page grid. Each tab (Droplets, Playlists, Voyages) now has a toolbar with debounced name search, per-tab filter chips, and a sort dropdown. All state is URL-driven. Droplet tiles on the creator page display a "Created on" date. Also bumps version to 2.4.1.

## Motivation and Context

As creators build up a library of content, the flat unsorted grid on `/my-content` becomes hard to navigate — there was no way to find a specific draft, filter by type, or surface recently-edited work. This brings the creator grid in line with the `/explore` page experience. Version bump reflects this as the first feature release since v2.4.0.

## Screenshots (if appropriate):

None

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.