### PR TITLE
Feature/ody 445 update mcq questions to support inline code and code blocks

### DIFF
--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -1785,9 +1785,7 @@ export interface ApiVoyageVoyage extends Schema.CollectionType {
       'manyToMany',
       'api::group.group'
     >;
-    isArchived: Attribute.Boolean &
-      Attribute.Required &
-      Attribute.DefaultTo<false>;
+    isArchived: Attribute.Boolean & Attribute.DefaultTo<false>;
     isSequential: Attribute.Boolean &
       Attribute.Required &
       Attribute.DefaultTo<false>;

--- a/docs/plans/ODY-445.md
+++ b/docs/plans/ODY-445.md
@@ -30,7 +30,7 @@ So the bug is **not** "we need to add a rich-text editor" — the editor is alre
 - Replacing TipTap with another editor.
 - Adding image/video/math support to answer options (already supported by the editor, but not in scope to verify).
 - Touching the BlockNote (v2) lesson renderer. MCQ rendering is dispatched from the v1 block path; v2 lessons are converted to v1 blocks before rendering (`convertBlockNoteToV1Blocks` in `lesson-renderer.tsx`), so the same fix covers both.
-- Open-ended quiz (`droplets.open-ended-quiz`) — that block has its own renderer; not part of this ticket.
+- ~~Open-ended quiz (`droplets.open-ended-quiz`) — that block has its own renderer; not part of this ticket.~~ **Addressed during implementation** — see reviewer note below.
 
 ## Design Decisions
 
@@ -95,7 +95,12 @@ So the bug is **not** "we need to add a rich-text editor" — the editor is alre
   - **Context:** Mock data should mimic Strapi v4 _flattened_ output (i.e., already-flattened `question.content: string`, `question.answerOptions: [{ id, content, isCorrect }]`). `fetchAPI()` auto-flattens, so tests should match the shape components actually receive.
   - **Verify:** `cd frontend && npm test -- quiz-question`.
 
-- [ ] **Task 6: Manual creator-side smoke test (no code change — checklist for the implementer)**
+- [x] **Task 6a: Open-ended quiz — sanitize learner renderer and enable rich text (scope expansion)**
+
+  - **What:** `open-ended-quiz-question-block.tsx` replaced bare `dangerouslySetInnerHTML` with `<RenderedContent>` (DOMPurify + syntax highlighting). Answer comparison now strips HTML via `stripHtmlTags()` before the case-insensitive match so plain typed responses still work. Revealed correct answer rendered via `RenderedContent`. Both v1 (`open-ended-quiz.tsx`) and v2 (`quiz-open-ended-block.tsx`) editor correct-answer fields upgraded from plain `<textarea>` to `TipTapEditor` / `QuizRichTextInput`.
+  - **Why added:** Code review identified the unsanitized `dangerouslySetInnerHTML` as a security gap; bringing the renderer in line with MCQ/T-F was lower risk than leaving it inconsistent.
+
+- [ ] **Task 6b: Manual creator-side smoke test (no code change — checklist for the implementer)**
   - Create a draft droplet → add a Quiz block → write a question containing inline `` `code` `` (Cmd+E) and a triple-backtick code block. Add three answers, one with inline code, one plain, one with a code block.
   - Save, publish, view as a learner. Confirm: question and all answers render formatting; selecting a wrong answer and reviewing shows formatted HTML; the "Try Again" / "View Answer" flow works.
   - Repeat with a True/False question; confirm the heading stays "True/False Quiz" after editing.
@@ -103,11 +108,14 @@ So the bug is **not** "we need to add a rich-text editor" — the editor is alre
 ## Files Touched (summary)
 
 - `frontend/lib/utils.ts` — add `isTrueFalseQuestion`, `isTrueFalseAnswerSeed`
-- `frontend/components/droplets/lessons/quiz-question.tsx` — sanitize + reflow answer wrappers
+- `frontend/components/droplets/lessons/quiz-question.tsx` — sanitize + reflow answer wrappers via `RenderedContent`
+- `frontend/components/droplets/lessons/open-ended-quiz-question-block.tsx` — `RenderedContent` for question + revealed answer; `stripHtmlTags` for comparison
 - `frontend/components/draft/lesson/blocks/quiz.tsx` — use new T/F detector
 - `frontend/components/draft/lesson/blocks/quiz-question-editor.tsx` — use new T/F detector
-- `frontend/__tests__/lib/utils.test.ts` — new/updated
-- `frontend/__tests__/components/droplets/lessons/quiz-question.test.tsx` — new
+- `frontend/components/draft/lesson/blocks/open-ended-quiz.tsx` — correct answer field → `TipTapEditor`
+- `frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx` — question + correct answer fields → `QuizRichTextInput`
+- `frontend/tests/lib/utils.test.ts` — new/updated
+- `frontend/tests/components/droplets/quiz-question.test.tsx` — new
 
 ## Files NOT Touched (and why)
 

--- a/docs/plans/ODY-445.md
+++ b/docs/plans/ODY-445.md
@@ -1,0 +1,116 @@
+# ODY-445: Update MCQ questions to support inline code and code blocks
+
+## Problem
+
+Quiz questions (MCQ + True/False) and their answer choices currently render as plain text for learners, even though creators frequently need to embed inline code (`` `foo` ``) or code blocks in both the question stem and the answer options. This is a recurring need for any technical droplet (e.g., "What does this `print(x)` output?" with code-formatted answers).
+
+## What Already Exists (Important Context)
+
+Code formatting is **mostly already wired up**, but it has gaps. Before planning, the codebase already does the following:
+
+1. **Backend schema** — `backend/src/components/quizzes/question.json` stores `content` as a CKEditor HTML field. `backend/src/components/quizzes/answer-option.json` stores `content` as a plain `string` (no markup constraint — anything written there is preserved).
+2. **Editor (creator-side)** — `frontend/components/draft/lesson/blocks/quiz-question-editor.tsx` already uses `<GenericBlockInput>` (TipTap) for **both** the question stem and each answer option. TipTap's `StarterKit` provides the inline `code` mark (Cmd+E) and the toolbar (`general-toolbar.tsx`) already exposes a `CodeTool` button for code blocks via `@tiptap/extension-code-block-lowlight`.
+3. **Renderer (learner-side)** — `frontend/components/droplets/lessons/quiz-question.tsx` already uses `dangerouslySetInnerHTML` for question content (line 176), the wrong-answer review list (line 222), the radio answer label (line 276), and the checkbox answer label (line 309). The wrapping element uses `prose-code:text-inherit` on the question, but **answer options have no `prose` wrapper** — so HTML output by TipTap (e.g., `<p>True</p>`, `<code>foo</code>`, `<pre><code>...</code></pre>`) renders unstyled and with invalid nesting (`<pre>` inside `<span>` inside a label).
+
+So the bug is **not** "we need to add a rich-text editor" — the editor is already there. The bug is that the answer rendering pipeline produces broken/unstyled output for anything beyond plain text, and there is no sanitization or true/false safety net.
+
+## Acceptance Criteria
+
+- [ ] A creator can use the inline-code button (or Cmd+E) and the code-block button in the TipTap toolbar inside both the **question stem** and any **answer option** (already true; verify and add explicit tests).
+- [ ] When a learner views an MCQ/True-False question that contains inline code or a code block in the question stem, it renders with the same monospace + syntax-highlighted styling used elsewhere in lessons (`prose-code` styles, dark `<pre>` for code blocks).
+- [ ] When a learner views an MCQ/True-False question whose **answer options** contain inline code or code blocks, the formatting renders correctly with the same styling, no invalid HTML nesting (no `<pre>` inside `<span>`), and reasonable layout (no extra blank lines from `<p>` wrappers around short answers).
+- [ ] The "View wrong answer" review list (the list of selections shown when the learner gets a question wrong) renders inline code / code blocks correctly.
+- [ ] All HTML rendered to learners from quiz `content` fields is run through `DOMPurify.sanitize()` (matching the pattern in `expandable` blocks and droplet `overview`).
+- [ ] True/False detection still works after a creator opens an existing T/F question in the editor (the current detection compares `answerOptions[0].content === "True"`, which breaks the moment TipTap wraps the seed value in `<p>True</p>`).
+- [ ] Existing MCQ/T-F questions in the database (with plain-text answers) continue to render unchanged.
+
+## Out of Scope
+
+- Adding new Strapi schema fields. Both `content` fields already accept HTML/strings.
+- Replacing TipTap with another editor.
+- Adding image/video/math support to answer options (already supported by the editor, but not in scope to verify).
+- Touching the BlockNote (v2) lesson renderer. MCQ rendering is dispatched from the v1 block path; v2 lessons are converted to v1 blocks before rendering (`convertBlockNoteToV1Blocks` in `lesson-renderer.tsx`), so the same fix covers both.
+- Open-ended quiz (`droplets.open-ended-quiz`) — that block has its own renderer; not part of this ticket.
+
+## Design Decisions
+
+**Stay with TipTap HTML output, sanitize on render.** The editor already produces HTML, the question already renders HTML, and the rest of the lesson renderer (overview, expandable, callout) follows the same pattern. Switching to markdown-in-plain-text would be a larger migration with no benefit. The right fix is small and additive.
+
+**Sanitize with `isomorphic-dompurify` everywhere quiz HTML is rendered.** The current code passes `question.content` and `answer.content` to `dangerouslySetInnerHTML` _without_ `DOMPurify.sanitize()`. The droplet overview and `expandable` block already sanitize — quiz content should follow the same pattern (defense-in-depth + consistency).
+
+**Wrap answer HTML in a `prose` `<div>` (not `<span>`).** Today answers are wrapped in a `<span>` inside a `FormLabel`. TipTap may emit `<p>` and `<pre>` — both block-level — which is invalid inside a `<span>`. Switch to a `<div className="prose prose-sm prose-code:text-inherit prose-p:my-0 max-w-none">` so block elements are valid and short single-paragraph answers don't get extra vertical spacing. The `FormLabel` is already a `<label>`, which can contain block-level descendants per modern HTML.
+
+**Fix True/False detection to be HTML-tolerant.** Replace the brittle `answerOptions[0].content === "True"` check with a helper `stripHtmlTags(content).trim().toLowerCase() === "true"`. `stripHtmlTags()` already exists in `lib/utils.ts`. Apply this in three places in `quiz.tsx` and `quiz-question-editor.tsx`.
+
+**Do not seed True/False answer content with HTML.** Continue seeding `"True"` / `"False"` as plain strings on creation. Detection now tolerates whichever form they take after a round-trip through the editor.
+
+## Implementation Tasks
+
+- [x] **Task 1: Add an HTML-tolerant True/False detector helper** (independent)
+
+  - **Read:** `frontend/lib/utils.ts` (confirm `stripHtmlTags` exists and what it does)
+  - **Modify:** `frontend/lib/utils.ts`
+  - **What:** Add and export `isTrueFalseQuestion(question: QuizQuestion): boolean` that returns true if the question has exactly two answer options whose stripped, lower-cased text equals `"true"` and `"false"` (in either order). Add and export `isTrueFalseAnswerSeed(content: string): "true" | "false" | null` for the simpler "is this single answer the True option?" check. Pure function, no side effects.
+  - **Context:** The current detection (`answerOptions[0].content === "True"`) lives in two files — see Task 4.
+  - **Verify:** Add a Jest test in `frontend/__tests__/lib/utils.test.ts` (create if missing) covering: plain `"True"/"False"`, `"<p>True</p>"/"<p>False</p>"`, lowercase, swapped order, three-option MCQ → false.
+
+- [x] **Task 2: Sanitize and properly wrap answer HTML in the learner-side renderer** (depends on Task 1 only for the True/False detector import; otherwise independent)
+
+  - **Read:** `frontend/components/droplets/lessons/quiz-question.tsx`, `frontend/components/droplets/lessons/lesson-renderer.tsx` (to see the existing DOMPurify import pattern, line 43 + 466)
+  - **Modify:** `frontend/components/droplets/lessons/quiz-question.tsx`
+  - **What:**
+    1. Import `DOMPurify from "isomorphic-dompurify"` at the top of the file.
+    2. Wrap the question content `dangerouslySetInnerHTML` call (line 176) so the inner HTML is `DOMPurify.sanitize(question.content)`.
+    3. For each of the three answer-rendering sites (review list line 222, radio label line 276, checkbox label line 309): replace the `<span dangerouslySetInnerHTML={{ __html: ... }} />` with `<div className="prose prose-sm prose-code:text-inherit prose-p:my-0 max-w-none dark:text-slate-300" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }} />`.
+    4. For the review list (`<ul><li>`), keep the `<li>` and put the new `<div>` inside it. Do not nest `<li>` inside `<div>`.
+  - **Context:** `FormLabel` from `components/ui/form` resolves to a Radix `<Label>` which renders a `<label>` element. `<label>` is permitted to contain block-level descendants, so swapping the inner `<span>` for a `<div>` is valid. Verify in DevTools no React hydration warning appears.
+  - **Verify:** Run `cd frontend && npm test`. Manually create a draft droplet with an MCQ that has inline `<code>` and a `<pre><code>` block in both question and answers; confirm the styling matches lesson body code blocks.
+
+- [x] **Task 3: Replace prose classes on the question stem with the same set used elsewhere** (part of Task 2, but small enough to call out)
+
+  - **Modify:** `frontend/components/droplets/lessons/quiz-question.tsx` (the `role="question"` div, line 173-177)
+  - **What:** Keep the existing `prose prose-sky prose-table:text-left prose-p:text-center prose-strong:text-inherit prose-code:text-inherit prose-headings:text-inherit` class set. Confirm `prose-code:text-inherit` is present (it is) and that adding `prose-pre:my-2` keeps the code block from being centered (the parent has `prose-p:text-center` which would otherwise affect the `<pre>` wrapper's siblings, but `<pre>` is left-aligned by default — verify in browser).
+  - **Verify:** Code block left-aligns, inline code stays centered with the rest of the question text.
+
+- [x] **Task 4: Replace fragile True/False detection in editor and renderer** (depends on Task 1)
+
+  - **Read:** `frontend/components/draft/lesson/blocks/quiz.tsx` (lines 26-28, 87-89), `frontend/components/draft/lesson/blocks/quiz-question-editor.tsx` (lines 76, 106-110)
+  - **Modify:**
+    - `frontend/components/draft/lesson/blocks/quiz.tsx`
+    - `frontend/components/draft/lesson/blocks/quiz-question-editor.tsx`
+  - **What:** Replace every `answerOptions[0].content === "True"` (and the symmetrical `[1].content === "False"` check at quiz-question-editor.tsx:108-109) with calls to the new `isTrueFalseQuestion(question)` helper from Task 1. The "Add Question" branch in `quiz.tsx` should still seed plain `"True"` / `"False"` strings — no change needed there.
+  - **Context:** This bug is _triggered_ by ODY-445: the moment a creator focuses any True/False answer in the new TipTap editor, the saved content becomes `<p>True</p>`, and the next render thinks the quiz is a regular MCQ. The fix decouples detection from exact string equality.
+  - **Verify:** Open an existing T/F question, click into the "True" answer to focus the TipTap editor (this triggers the wrap), save, reload — heading still says "True/False Quiz" and the "Add Answer Option" button stays hidden.
+
+- [x] **Task 5: Add Jest tests for quiz rendering with formatted content** (depends on Tasks 2, 4)
+
+  - **Read:** existing test patterns in `frontend/__tests__/` (if any) for components that use `dangerouslySetInnerHTML`
+  - **Modify/Create:** `frontend/__tests__/components/droplets/lessons/quiz-question.test.tsx`
+  - **What:** Test cases:
+    1. Renders question with inline `<code>` — asserts a `<code>` element is in the DOM.
+    2. Renders question with `<pre><code>` — asserts a `<pre>` element is in the DOM.
+    3. Renders answer options with inline code — asserts `<code>` inside the radio label.
+    4. Strips dangerous HTML (e.g., a `<script>` tag in `question.content` is not rendered).
+    5. True/False detection: a question with `<p>True</p>` / `<p>False</p>` answers is treated as T/F (this can also live in the utils test from Task 1).
+  - **Context:** Mock data should mimic Strapi v4 _flattened_ output (i.e., already-flattened `question.content: string`, `question.answerOptions: [{ id, content, isCorrect }]`). `fetchAPI()` auto-flattens, so tests should match the shape components actually receive.
+  - **Verify:** `cd frontend && npm test -- quiz-question`.
+
+- [ ] **Task 6: Manual creator-side smoke test (no code change — checklist for the implementer)**
+  - Create a draft droplet → add a Quiz block → write a question containing inline `` `code` `` (Cmd+E) and a triple-backtick code block. Add three answers, one with inline code, one plain, one with a code block.
+  - Save, publish, view as a learner. Confirm: question and all answers render formatting; selecting a wrong answer and reviewing shows formatted HTML; the "Try Again" / "View Answer" flow works.
+  - Repeat with a True/False question; confirm the heading stays "True/False Quiz" after editing.
+
+## Files Touched (summary)
+
+- `frontend/lib/utils.ts` — add `isTrueFalseQuestion`, `isTrueFalseAnswerSeed`
+- `frontend/components/droplets/lessons/quiz-question.tsx` — sanitize + reflow answer wrappers
+- `frontend/components/draft/lesson/blocks/quiz.tsx` — use new T/F detector
+- `frontend/components/draft/lesson/blocks/quiz-question-editor.tsx` — use new T/F detector
+- `frontend/__tests__/lib/utils.test.ts` — new/updated
+- `frontend/__tests__/components/droplets/lessons/quiz-question.test.tsx` — new
+
+## Files NOT Touched (and why)
+
+- `backend/src/components/quizzes/question.json` — already CKEditor HTML.
+- `backend/src/components/quizzes/answer-option.json` — `string` is fine; HTML is just a string. Adding a CKEditor field would force a Strapi migration with no rendering benefit (the frontend uses TipTap, not CKEditor, anyway).
+- `frontend/components/ui/tiptap/*` — already supports inline code + code blocks.

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,9 +1,9 @@
+/* Light mode: github light theme. Dark mode tokens are overridden below. */
+@import "highlight.js/styles/github.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Light mode: github light theme. Dark mode tokens are overridden below. */
-@import "highlight.js/styles/github.css";
 
 :root {
   --foreground-rgb: 0, 0, 0;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -79,8 +79,8 @@
 }
 
 /* Specific fix for callout bullet list items in dark mode */
-.dark .pt-3.pl-3 * {
-  color: #334155 !important;
+.dark .callout-bullet-list li {
+  color: #334155;
 }
 
 /* Dark background for sky-50 elements */

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2,8 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
-@import "highlight.js/styles/github-dark.css";
-/* or any other theme you prefer */
+/* Light mode: github light theme. Dark mode tokens are overridden below. */
+@import "highlight.js/styles/github.css";
 
 :root {
   --foreground-rgb: 0, 0, 0;
@@ -61,17 +61,12 @@
   color: #334155;
 }
 
-/* Fix for invisible text in dark mode */
+/* Fix for invisible text in dark mode (non-code elements only).
+   Code blocks handle their own dark-mode colors via .dark .hljs below. */
 .dark .prose blockquote,
 .dark .prose blockquote *,
 .dark .bg-sky-50,
-.dark .bg-sky-50 *,
-.dark pre,
-.dark pre *,
-.dark code,
-.dark code *,
-.dark .hljs,
-.dark .hljs * {
+.dark .bg-sky-50 * {
   color: white;
 }
 
@@ -172,6 +167,22 @@ html:not(.dark) .sp-wrapper .cm-editor ::selection {
   color: #e06b85;
 }
 
+/* Fenced code block backgrounds: light by default, dark in dark mode.
+   Tailwind Typography hardcodes a dark pre background; override it here
+   so rendered lessons and quiz blocks both respect the site theme.
+   .hljs background is forced transparent so the pre background wins. */
+.hljs {
+  background: transparent;
+}
+.prose pre {
+  background-color: #f6f8fa;
+  border: 1px solid #e1e4e8;
+}
+.dark .prose pre {
+  background-color: #161b22;
+  border-color: #30363d;
+}
+
 /* driver.js tour — custom popover styling */
 .draft-tour-popover.driver-popover {
   border-radius: 12px;
@@ -254,4 +265,85 @@ html:not(.dark) .sp-wrapper .cm-editor ::selection {
 
 .draft-tour-popover .driver-popover-close-btn:hover {
   color: #374151;
+}
+
+/* Dark-mode syntax highlighting: github-dark token colors.
+   These override the github.css light theme imported at the top.
+   Placed last so they win on equal specificity. */
+.dark .hljs {
+  color: #c9d1d9;
+  background: transparent;
+}
+.dark .hljs-doctag,
+.dark .hljs-keyword,
+.dark .hljs-meta .hljs-keyword,
+.dark .hljs-template-tag,
+.dark .hljs-template-variable,
+.dark .hljs-type,
+.dark .hljs-variable.language_ {
+  color: #ff7b72;
+}
+.dark .hljs-title,
+.dark .hljs-title.class_,
+.dark .hljs-title.class_.inherited__,
+.dark .hljs-title.function_ {
+  color: #d2a8ff;
+}
+.dark .hljs-attr,
+.dark .hljs-attribute,
+.dark .hljs-literal,
+.dark .hljs-meta,
+.dark .hljs-number,
+.dark .hljs-operator,
+.dark .hljs-variable,
+.dark .hljs-selector-attr,
+.dark .hljs-selector-class,
+.dark .hljs-selector-id {
+  color: #79c0ff;
+}
+.dark .hljs-regexp,
+.dark .hljs-string,
+.dark .hljs-meta .hljs-string {
+  color: #a5d6ff;
+}
+.dark .hljs-built_in,
+.dark .hljs-symbol {
+  color: #ffa657;
+}
+.dark .hljs-code,
+.dark .hljs-comment,
+.dark .hljs-formula {
+  color: #8b949e;
+}
+.dark .hljs-name,
+.dark .hljs-quote,
+.dark .hljs-selector-tag,
+.dark .hljs-selector-pseudo {
+  color: #7ee787;
+}
+.dark .hljs-subst {
+  color: #c9d1d9;
+}
+.dark .hljs-section {
+  color: #1f6feb;
+  font-weight: bold;
+}
+.dark .hljs-bullet {
+  color: #f2cc60;
+}
+.dark .hljs-emphasis {
+  color: #c9d1d9;
+  font-style: italic;
+}
+.dark .hljs-strong {
+  color: #c9d1d9;
+  font-weight: bold;
+}
+.dark .hljs-addition {
+  color: #aff5b4;
+  background-color: #033a16;
+}
+.dark .hljs-deletion {
+  color: #ffdcd7;
+  background-color: #67060c;
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -177,10 +177,12 @@ html:not(.dark) .sp-wrapper .cm-editor ::selection {
 .prose pre {
   background-color: #f6f8fa;
   border: 1px solid #e1e4e8;
+  color: #24292e; /* Typography's --tw-prose-pre-code defaults to light gray for dark bg; override for our light bg */
 }
 .dark .prose pre {
   background-color: #161b22;
   border-color: #30363d;
+  color: #c9d1d9; /* Restore readable light text for dark background */
 }
 
 /* github.css was designed for #ffffff — three of its token colors fall

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -183,6 +183,25 @@ html:not(.dark) .sp-wrapper .cm-editor ::selection {
   border-color: #30363d;
 }
 
+/* github.css was designed for #ffffff — three of its token colors fall
+   below 4.5:1 contrast on our #f6f8fa background. These are GitHub's
+   own updated accessible values from their current light syntax theme. */
+.hljs-built_in,
+.hljs-symbol {
+  color: #953800; /* was #e36209 (3.1:1) → now 6.3:1 */
+}
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  color: #116329; /* was #22863a (4.1:1) → now 7.0:1 */
+}
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  color: #57606a; /* was #6a737d (4.1:1) → now 5.4:1 */
+}
+
 /* driver.js tour — custom popover styling */
 .draft-tour-popover.driver-popover {
   border-radius: 12px;

--- a/frontend/components/draft/lesson/blocks/open-ended-quiz.tsx
+++ b/frontend/components/draft/lesson/blocks/open-ended-quiz.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { OpenEndedQuizQuestion } from "@/types";
 import { TrashIcon, PlusIcon, Trash2Icon } from "lucide-react";
 import { GenericBlockInput as TipTapEditor } from "@/components/ui/tiptap/generic-block-input";
@@ -110,16 +109,12 @@ export function OpenEndedQuizEditor({
 
             <div className="space-y-4 pt-4">
               <h5 className="font-semibold">Correct Answer</h5>
-              <Textarea
-                value={question.correctAnswer}
-                onChange={(e) =>
-                  updateQuestion(index, {
-                    ...question,
-                    correctAnswer: e.target.value,
-                  })
+              <TipTapEditor
+                initialContent={question.correctAnswer}
+                updateContent={(content) =>
+                  updateQuestion(index, { ...question, correctAnswer: content })
                 }
-                placeholder="Enter the correct answer..."
-                className="min-h-[100px]"
+                revalidate={() => {}}
               />
             </div>
           </div>

--- a/frontend/components/draft/lesson/blocks/quiz-question-editor.tsx
+++ b/frontend/components/draft/lesson/blocks/quiz-question-editor.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { TrashIcon, PlusIcon, Trash2Icon } from "lucide-react";
 import { GenericBlockInput as TipTapEditor } from "@/components/ui/tiptap/generic-block-input";
 import { Checkbox } from "@/components/ui/checkbox";
+import { isTrueFalseQuestion } from "@/lib/utils";
 
 interface QuizQuestionEditorProps {
   question: QuizQuestion;
@@ -73,7 +74,7 @@ export function QuizQuestionEditor({
 
       <div className="space-y-4 pt-4">
         <h5 className="font-semibold">
-          {question.answerOptions[0]?.content === "True"
+          {isTrueFalseQuestion(question)
             ? "Answer Options"
             : "Answer Options (choose multiple if applicable)"}
         </h5>
@@ -103,11 +104,7 @@ export function QuizQuestionEditor({
           ))}
         </div>
 
-        {!(
-          question.answerOptions.length === 2 &&
-          question.answerOptions[0].content === "True" &&
-          question.answerOptions[1].content === "False"
-        ) && (
+        {!isTrueFalseQuestion(question) && (
           <Button variant="outline" size="sm" onClick={addAnswer}>
             <PlusIcon className="mr-2 h-4 w-4" />
             Add Answer Option

--- a/frontend/components/draft/lesson/blocks/quiz.tsx
+++ b/frontend/components/draft/lesson/blocks/quiz.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { PlusIcon, Trash2Icon } from "lucide-react";
 import { QuizQuestionEditor } from "./quiz-question-editor";
+import { isTrueFalseQuestion } from "@/lib/utils";
 
 interface QuizEditorProps {
   block: Extract<Block, { __component: "droplets.quiz" }>;
@@ -23,8 +24,7 @@ export function QuizEditor({
     let question = null;
     // Check if this is a True/False quiz
     const isTrueFalse =
-      questions.length > 0 &&
-      questions[0]?.answerOptions?.[0]?.content === "True";
+      questions.length > 0 && isTrueFalseQuestion(questions[0]);
 
     if (isTrueFalse) {
       const newQuestion: QuizQuestion = {
@@ -85,8 +85,7 @@ export function QuizEditor({
 
   // Determine quiz type safely
   const isTrueFalse =
-    questions.length > 0 &&
-    questions[0]?.answerOptions?.[0]?.content === "True";
+    questions.length > 0 && isTrueFalseQuestion(questions[0]);
 
   return (
     <div className="w-full pb-4">

--- a/frontend/components/draft/lesson/blocks/quiz.tsx
+++ b/frontend/components/draft/lesson/blocks/quiz.tsx
@@ -84,8 +84,7 @@ export function QuizEditor({
   };
 
   // Determine quiz type safely
-  const isTrueFalse =
-    questions.length > 0 && isTrueFalseQuestion(questions[0]);
+  const isTrueFalse = questions.length > 0 && isTrueFalseQuestion(questions[0]);
 
   return (
     <div className="w-full pb-4">

--- a/frontend/components/droplets/lessons/generic-block-renderer.tsx
+++ b/frontend/components/droplets/lessons/generic-block-renderer.tsx
@@ -233,20 +233,29 @@ const GenericBlockRenderer: React.FC<GenericBlockRendererProps> = ({
         const code = pre.querySelector("code");
         if (!code) return;
 
-        const lines = (code.textContent?.match(/\n/g) || []).length + 1;
+        const rawLines = code.textContent?.split("\n") ?? [];
+        if (rawLines[rawLines.length - 1] === "") rawLines.pop();
+        const lineCount = rawLines.length;
 
-        // Read the pre's actual computed padding-top so the gutter aligns
-        // with the first line of code regardless of what Typography sets.
+        // Force code line-height to match gutter — prose-lg sets ~1.777
+        // which causes lines to drift out of sync with the 1.25rem gutter.
+        code.style.lineHeight = "1.25rem";
+        code.style.display = "block";
+        code.style.padding = "0";
+        code.style.margin = "0";
+
         pre.style.position = "relative";
+        pre.style.paddingTop = "0.75rem";
+        pre.style.paddingBottom = "0.75rem";
         pre.style.paddingLeft = "3rem";
-        const paddingTop = getComputedStyle(pre).paddingTop;
+        pre.style.paddingRight = "1rem";
 
         const lineNumbers = document.createElement("div");
         lineNumbers.className =
           "absolute left-0 top-0 bottom-0 min-w-[2.5rem] flex flex-col text-sm border-r border-gray-200 bg-gray-100 text-gray-400 select-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400";
-        lineNumbers.style.paddingTop = paddingTop;
+        lineNumbers.style.paddingTop = "0.75rem";
 
-        for (let i = 1; i <= lines; i++) {
+        for (let i = 1; i <= lineCount; i++) {
           const line = document.createElement("div");
           line.className = "pr-2 text-right font-mono";
           line.style.lineHeight = "1.25rem";

--- a/frontend/components/droplets/lessons/generic-block-renderer.tsx
+++ b/frontend/components/droplets/lessons/generic-block-renderer.tsx
@@ -223,7 +223,9 @@ const GenericBlockRenderer: React.FC<GenericBlockRendererProps> = ({
           codeBlock.classList.remove("language-plaintext");
         }
       });
-      hljs.highlightAll();
+      contentRef.current.querySelectorAll("pre code").forEach((block) => {
+        hljs.highlightElement(block as HTMLElement);
+      });
 
       const preBlocks = contentRef.current.querySelectorAll("pre");
 
@@ -233,26 +235,26 @@ const GenericBlockRenderer: React.FC<GenericBlockRendererProps> = ({
 
         const lines = (code.textContent?.match(/\n/g) || []).length + 1;
 
-        const lineNumbers = document.createElement("div");
-        lineNumbers.className =
-          "absolute left-0 top-0 bottom-0 min-w-[2.5rem] flex flex-col text-slate-500 text-sm border-r border-slate-300 bg-slate-50 select-none";
-
-        const lineContainer = document.createElement("div");
-        lineContainer.className = "pt-3 pl-3";
-
-        for (let i = 1; i <= lines; i++) {
-          const line = document.createElement("span");
-          line.className = "text-right pr-2 leading-5 block";
-          line.style.paddingTop = "0.15rem";
-          line.style.paddingBottom = "0.18rem";
-          line.textContent = `${i}`;
-          lineContainer.appendChild(line);
-        }
-
-        lineNumbers.appendChild(lineContainer);
+        // Read the pre's actual computed padding-top so the gutter aligns
+        // with the first line of code regardless of what Typography sets.
         pre.style.position = "relative";
         pre.style.paddingLeft = "3rem";
-        pre.style.paddingTop = "0rem";
+        const paddingTop = getComputedStyle(pre).paddingTop;
+
+        const lineNumbers = document.createElement("div");
+        lineNumbers.className =
+          "absolute left-0 top-0 bottom-0 min-w-[2.5rem] flex flex-col text-sm border-r border-gray-200 bg-gray-100 text-gray-400 select-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400";
+        lineNumbers.style.paddingTop = paddingTop;
+
+        for (let i = 1; i <= lines; i++) {
+          const line = document.createElement("div");
+          line.className = "pr-2 text-right font-mono";
+          line.style.lineHeight = "1.25rem";
+          line.style.height = "1.25rem";
+          line.textContent = `${i}`;
+          lineNumbers.appendChild(line);
+        }
+
         pre.insertBefore(lineNumbers, pre.firstChild);
       });
       const blockHighlights = highlights.filter((h) => {
@@ -716,9 +718,6 @@ const GenericBlockRenderer: React.FC<GenericBlockRendererProps> = ({
           onMouseDown={(e) => handleMouseDown(e)}
           onClick={handleContentClick}
           className="prose prose-lg prose-sky prose-table:block prose-code:text-inherit prose-table:overflow-x-scroll prose-p:my-1 prose-li:my-1 prose-headings:text-inherit prose-strong:text-inherit max-w-none select-text dark:text-slate-300"
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(nonTableContent),
-          }}
         ></div>
       )}
 

--- a/frontend/components/droplets/lessons/open-ended-quiz-question-block.tsx
+++ b/frontend/components/droplets/lessons/open-ended-quiz-question-block.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { RenderedContent } from "@/components/ui/rendered-content";
+import { stripHtmlTags } from "@/lib/utils";
 import { ArrowLeftIcon } from "lucide-react";
 import posthog from "posthog-js";
 declare global {
@@ -51,7 +52,7 @@ export function OpenEndedQuizQuestionBlock({
   const checkAnswer = () => {
     const isAnswerCorrect =
       userAnswer.trim().toLowerCase() ===
-      question.correctAnswer.trim().toLowerCase();
+      stripHtmlTags(question.correctAnswer).trim().toLowerCase();
     setIsCorrect(isAnswerCorrect);
 
     if (!isAnswerCorrect) {
@@ -139,9 +140,11 @@ export function OpenEndedQuizQuestionBlock({
         </div>
       ) : revealAnswer ? (
         <>
-          <p className="mt-4 pb-2 font-medium">
-            Correct Answer: {question.correctAnswer}
-          </p>
+          <p className="mt-4 pb-2 font-medium">Correct Answer:</p>
+          <RenderedContent
+            html={question.correctAnswer}
+            className="prose prose-sm prose-code:text-inherit prose-pre:text-base prose-p:my-0 max-w-none dark:text-slate-300"
+          />
           <Button
             before={<ArrowLeftIcon />}
             variant="outline"

--- a/frontend/components/droplets/lessons/open-ended-quiz-question-block.tsx
+++ b/frontend/components/droplets/lessons/open-ended-quiz-question-block.tsx
@@ -3,6 +3,7 @@ import { OpenEndedQuizQuestion } from "@/types";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
+import { RenderedContent } from "@/components/ui/rendered-content";
 import { ArrowLeftIcon } from "lucide-react";
 import posthog from "posthog-js";
 declare global {
@@ -99,9 +100,9 @@ export function OpenEndedQuizQuestionBlock({
 
   return (
     <>
-      <div
-        className="prose prose-sky prose-table:text-left prose-p:text-center dark:text-slate-300"
-        dangerouslySetInnerHTML={{ __html: question.content }}
+      <RenderedContent
+        html={question.content}
+        className="prose prose-sky prose-table:text-left prose-p:text-center prose-strong:text-inherit prose-code:text-inherit prose-headings:text-inherit prose-pre:my-2 prose-pre:text-base dark:text-slate-300"
       />
 
       {showResult ? (

--- a/frontend/components/droplets/lessons/quiz-question.tsx
+++ b/frontend/components/droplets/lessons/quiz-question.tsx
@@ -13,6 +13,7 @@ import {
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { QuizQuestion } from "@/types";
 import { zodResolver } from "@hookform/resolvers/zod";
+import DOMPurify from "isomorphic-dompurify";
 import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
 import { useMemo, useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -172,8 +173,8 @@ export function QuizQuestionBlock({
     <>
       <div
         role="question"
-        className="prose prose-sky prose-table:text-left prose-p:text-center prose-strong:text-inherit prose-code:text-inherit prose-headings:text-inherit dark:text-slate-300"
-        dangerouslySetInnerHTML={{ __html: question.content }}
+        className="prose prose-sky prose-table:text-left prose-p:text-center prose-strong:text-inherit prose-code:text-inherit prose-headings:text-inherit prose-pre:my-2 dark:text-slate-300"
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(question.content) }}
       ></div>
 
       {showResult ? (
@@ -216,12 +217,14 @@ export function QuizQuestionBlock({
                       (opt) => String(opt.id) === id,
                     );
                     return selectedAnswer ? (
-                      <li
-                        key={id}
-                        dangerouslySetInnerHTML={{
-                          __html: selectedAnswer.content,
-                        }}
-                      />
+                      <li key={id}>
+                        <div
+                          className="prose prose-sm prose-code:text-inherit prose-p:my-0 max-w-none dark:text-slate-300"
+                          dangerouslySetInnerHTML={{
+                            __html: DOMPurify.sanitize(selectedAnswer.content),
+                          }}
+                        />
+                      </li>
                     ) : null;
                   })}
                 </ul>
@@ -271,9 +274,10 @@ export function QuizQuestionBlock({
                               />
                             </FormControl>
                             <FormLabel className="flex-1 cursor-pointer">
-                              <span
+                              <div
+                                className="prose prose-sm prose-code:text-inherit prose-p:my-0 max-w-none dark:text-slate-300"
                                 dangerouslySetInnerHTML={{
-                                  __html: answer.content,
+                                  __html: DOMPurify.sanitize(answer.content),
                                 }}
                               />
                             </FormLabel>
@@ -305,9 +309,10 @@ export function QuizQuestionBlock({
                               />
                             </FormControl>
                             <FormLabel className="flex-1 cursor-pointer">
-                              <span
+                              <div
+                                className="prose prose-sm prose-code:text-inherit prose-p:my-0 max-w-none dark:text-slate-300"
                                 dangerouslySetInnerHTML={{
-                                  __html: answer.content,
+                                  __html: DOMPurify.sanitize(answer.content),
                                 }}
                               />
                             </FormLabel>

--- a/frontend/components/droplets/lessons/quiz-question.tsx
+++ b/frontend/components/droplets/lessons/quiz-question.tsx
@@ -11,9 +11,9 @@ import {
   FormLabel,
 } from "@/components/ui/form";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { RenderedContent } from "@/components/ui/rendered-content";
 import { QuizQuestion } from "@/types";
 import { zodResolver } from "@hookform/resolvers/zod";
-import DOMPurify from "isomorphic-dompurify";
 import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
 import { useMemo, useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -171,11 +171,11 @@ export function QuizQuestionBlock({
 
   return (
     <>
-      <div
+      <RenderedContent
         role="question"
+        html={question.content}
         className="prose prose-sky prose-table:text-left prose-p:text-center prose-strong:text-inherit prose-code:text-inherit prose-headings:text-inherit prose-pre:my-2 prose-pre:text-base dark:text-slate-300"
-        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(question.content) }}
-      ></div>
+      />
 
       {showResult ? (
         <div className="mt-4 rounded-md border border-slate-200 px-8 py-12 text-center">
@@ -218,11 +218,9 @@ export function QuizQuestionBlock({
                     );
                     return selectedAnswer ? (
                       <li key={id}>
-                        <div
+                        <RenderedContent
+                          html={selectedAnswer.content}
                           className="prose prose-sm prose-code:text-inherit prose-pre:text-base prose-p:my-0 max-w-none dark:text-slate-300"
-                          dangerouslySetInnerHTML={{
-                            __html: DOMPurify.sanitize(selectedAnswer.content),
-                          }}
                         />
                       </li>
                     ) : null;
@@ -274,11 +272,9 @@ export function QuizQuestionBlock({
                               />
                             </FormControl>
                             <FormLabel className="flex-1 cursor-pointer">
-                              <div
+                              <RenderedContent
+                                html={answer.content}
                                 className="prose prose-sm prose-code:text-inherit prose-pre:text-base prose-p:my-0 max-w-none dark:text-slate-300"
-                                dangerouslySetInnerHTML={{
-                                  __html: DOMPurify.sanitize(answer.content),
-                                }}
                               />
                             </FormLabel>
                           </FormItem>
@@ -309,11 +305,9 @@ export function QuizQuestionBlock({
                               />
                             </FormControl>
                             <FormLabel className="flex-1 cursor-pointer">
-                              <div
+                              <RenderedContent
+                                html={answer.content}
                                 className="prose prose-sm prose-code:text-inherit prose-pre:text-base prose-p:my-0 max-w-none dark:text-slate-300"
-                                dangerouslySetInnerHTML={{
-                                  __html: DOMPurify.sanitize(answer.content),
-                                }}
                               />
                             </FormLabel>
                           </FormItem>

--- a/frontend/components/droplets/lessons/quiz-question.tsx
+++ b/frontend/components/droplets/lessons/quiz-question.tsx
@@ -173,7 +173,7 @@ export function QuizQuestionBlock({
     <>
       <div
         role="question"
-        className="prose prose-sky prose-table:text-left prose-p:text-center prose-strong:text-inherit prose-code:text-inherit prose-headings:text-inherit prose-pre:my-2 dark:text-slate-300"
+        className="prose prose-sky prose-table:text-left prose-p:text-center prose-strong:text-inherit prose-code:text-inherit prose-headings:text-inherit prose-pre:my-2 prose-pre:text-base dark:text-slate-300"
         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(question.content) }}
       ></div>
 
@@ -219,7 +219,7 @@ export function QuizQuestionBlock({
                     return selectedAnswer ? (
                       <li key={id}>
                         <div
-                          className="prose prose-sm prose-code:text-inherit prose-p:my-0 max-w-none dark:text-slate-300"
+                          className="prose prose-sm prose-code:text-inherit prose-pre:text-base prose-p:my-0 max-w-none dark:text-slate-300"
                           dangerouslySetInnerHTML={{
                             __html: DOMPurify.sanitize(selectedAnswer.content),
                           }}
@@ -275,7 +275,7 @@ export function QuizQuestionBlock({
                             </FormControl>
                             <FormLabel className="flex-1 cursor-pointer">
                               <div
-                                className="prose prose-sm prose-code:text-inherit prose-p:my-0 max-w-none dark:text-slate-300"
+                                className="prose prose-sm prose-code:text-inherit prose-pre:text-base prose-p:my-0 max-w-none dark:text-slate-300"
                                 dangerouslySetInnerHTML={{
                                   __html: DOMPurify.sanitize(answer.content),
                                 }}
@@ -310,7 +310,7 @@ export function QuizQuestionBlock({
                             </FormControl>
                             <FormLabel className="flex-1 cursor-pointer">
                               <div
-                                className="prose prose-sm prose-code:text-inherit prose-p:my-0 max-w-none dark:text-slate-300"
+                                className="prose prose-sm prose-code:text-inherit prose-pre:text-base prose-p:my-0 max-w-none dark:text-slate-300"
                                 dangerouslySetInnerHTML={{
                                   __html: DOMPurify.sanitize(answer.content),
                                 }}

--- a/frontend/components/droplets/lessons/quiz.tsx
+++ b/frontend/components/droplets/lessons/quiz.tsx
@@ -30,7 +30,7 @@ export function QuizBlock({
             <div
               key={question.id}
               id="quiz-question"
-              className="mx-auto mt-8 w-full max-w-lg divide-slate-200 rounded-md border border-slate-200 bg-white p-6 dark:border-slate-500 dark:bg-slate-900"
+              className="mx-auto mt-8 w-full max-w-2xl divide-slate-200 rounded-md border border-slate-200 bg-white p-6 dark:border-slate-500 dark:bg-slate-900"
             >
               <QuizQuestionBlock
                 question={question}

--- a/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
@@ -2,6 +2,7 @@ import { createReactBlockSpec } from "@blocknote/react";
 import { defaultProps } from "@blocknote/core";
 import { Trash2Icon, PlusIcon, XIcon } from "lucide-react";
 import React from "react";
+import { QuizRichTextInput } from "./quiz-rich-text-input";
 
 interface AnswerOption {
   id: string;
@@ -51,17 +52,15 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
         ];
       }
 
-      const handleQuestionChange = (
-        e: React.ChangeEvent<HTMLTextAreaElement>,
-      ) => {
+      const handleQuestionChange = (html: string) => {
         props.editor.updateBlock(props.block, {
-          props: { question: e.target.value },
+          props: { question: html },
         });
       };
 
-      const handleOptionTextChange = (id: string, text: string) => {
+      const handleOptionTextChange = (id: string, html: string) => {
         const updatedOptions = options.map((opt: AnswerOption) =>
-          opt.id === id ? { ...opt, text } : opt,
+          opt.id === id ? { ...opt, text: html } : opt,
         );
         props.editor.updateBlock(props.block, {
           props: {
@@ -133,11 +132,10 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
               <label className="mb-2 block text-left text-sm font-medium text-gray-700 dark:text-gray-300">
                 Question:
               </label>
-              <textarea
+              <QuizRichTextInput
                 value={question}
                 onChange={handleQuestionChange}
-                placeholder="Nothing here yet..."
-                className="resize-vertical min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                minHeight="80px"
               />
             </div>
 
@@ -159,14 +157,16 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
                     />
 
                     {/* Option text */}
-                    <textarea
-                      value={option.text}
-                      onChange={(e) =>
-                        handleOptionTextChange(option.id, e.target.value)
-                      }
-                      placeholder={`Option ${index + 1}`}
-                      className="resize-vertical min-h-[60px] flex-1 rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-                    />
+                    <div className="flex-1">
+                      <QuizRichTextInput
+                        key={option.id}
+                        value={option.text}
+                        onChange={(html) =>
+                          handleOptionTextChange(option.id, html)
+                        }
+                        minHeight="60px"
+                      />
+                    </div>
 
                     {/* Delete option button */}
                     {options.length > 2 && (

--- a/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
@@ -147,7 +147,7 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
                 Answer Options:
               </label>
               <div className="space-y-3">
-                {options.map((option: AnswerOption, index: number) => (
+                {options.map((option: AnswerOption) => (
                   <div key={option.id} className="flex items-start gap-2">
                     {/* Checkbox for correct answer */}
                     <input

--- a/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-multiple-choice-block.tsx
@@ -117,7 +117,9 @@ export const MultipleChoiceQuiz = createReactBlockSpec(
         <div className="w-full rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800">
           {/* Header */}
           <div className="mb-4 flex w-full flex-row items-center justify-between p-4">
-            <h2 className="text-lg">Multiple Choice Quiz</h2>
+            <h2 className="text-sm font-semibold tracking-wide text-black dark:text-white">
+              Multiple Choice Quiz
+            </h2>
             <Trash2Icon
               className="cursor-pointer text-red-600 hover:text-red-700"
               onClick={handleDelete}

--- a/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
@@ -28,11 +28,9 @@ export const OpenEndedQuiz = createReactBlockSpec(
         });
       };
 
-      const handleCorrectAnswerChange = (
-        e: React.ChangeEvent<HTMLTextAreaElement>,
-      ) => {
+      const handleCorrectAnswerChange = (html: string) => {
         props.editor.updateBlock(props.block, {
-          props: { correctAnswer: e.target.value },
+          props: { correctAnswer: html },
         });
       };
 
@@ -73,15 +71,14 @@ export const OpenEndedQuiz = createReactBlockSpec(
               <label className="mb-2 block text-left text-sm font-medium text-gray-700 dark:text-gray-300">
                 Correct Answer:
               </label>
-              <textarea
+              <QuizRichTextInput
                 value={correctAnswer}
                 onChange={handleCorrectAnswerChange}
                 placeholder="Enter the correct answer..."
-                className="resize-vertical min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
               />
               <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
                 Student answers will be checked for exact match
-                (case-insensitive)
+                (case-insensitive, HTML stripped)
               </p>
             </div>
           </div>

--- a/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
@@ -45,7 +45,9 @@ export const OpenEndedQuiz = createReactBlockSpec(
         <div className="w-full rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800">
           {/* Header */}
           <div className="mb-4 flex w-full flex-row items-center justify-between p-4">
-            <h2 className="text-lg">Open-Ended Quiz</h2>
+            <h2 className="text-sm font-semibold tracking-wide text-black dark:text-white">
+              Open-Ended Quiz
+            </h2>
             <Trash2Icon
               className="cursor-pointer text-red-600 hover:text-red-700"
               onClick={handleDelete}

--- a/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-open-ended-block.tsx
@@ -2,6 +2,7 @@ import { createReactBlockSpec } from "@blocknote/react";
 import { defaultProps } from "@blocknote/core";
 import { Trash2Icon } from "lucide-react";
 import React from "react";
+import { QuizRichTextInput } from "./quiz-rich-text-input";
 
 export const OpenEndedQuiz = createReactBlockSpec(
   {
@@ -21,11 +22,9 @@ export const OpenEndedQuiz = createReactBlockSpec(
     render: (props) => {
       const { question, correctAnswer } = props.block.props;
 
-      const handleQuestionChange = (
-        e: React.ChangeEvent<HTMLTextAreaElement>,
-      ) => {
+      const handleQuestionChange = (html: string) => {
         props.editor.updateBlock(props.block, {
-          props: { question: e.target.value },
+          props: { question: html },
         });
       };
 
@@ -62,11 +61,10 @@ export const OpenEndedQuiz = createReactBlockSpec(
               <label className="mb-2 block text-left text-sm font-medium text-gray-700 dark:text-gray-300">
                 Question:
               </label>
-              <textarea
+              <QuizRichTextInput
                 value={question}
                 onChange={handleQuestionChange}
                 placeholder="Nothing here yet..."
-                className="resize-vertical min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
               />
             </div>
 

--- a/frontend/components/ui/blocknote/blocks/quiz-rich-text-input.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-rich-text-input.tsx
@@ -74,7 +74,7 @@ export function QuizRichTextInput({
     if (value?.trim()) {
       editor.commands.setContent(value, false);
     }
-  }, [editor]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [editor]); // intentional: one-shot init, value prop is not reactive
 
   return (
     <div

--- a/frontend/components/ui/blocknote/blocks/quiz-rich-text-input.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-rich-text-input.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { BlockNoteSchema, defaultBlockSpecs } from "@blocknote/core";
+import { useCreateBlockNote } from "@blocknote/react";
+import { BlockNoteView } from "@blocknote/mantine";
+import { useTheme } from "next-themes";
+import "@blocknote/mantine/style.css";
+
+const quizSchema = BlockNoteSchema.create({
+  blockSpecs: {
+    paragraph: defaultBlockSpecs.paragraph,
+    codeBlock: defaultBlockSpecs.codeBlock,
+  },
+});
+
+interface QuizRichTextInputProps {
+  value: string;
+  onChange: (html: string) => void;
+  minHeight?: string;
+}
+
+export function QuizRichTextInput({
+  value,
+  onChange,
+  minHeight = "60px",
+}: QuizRichTextInputProps) {
+  const { resolvedTheme } = useTheme();
+  const editor = useCreateBlockNote({ schema: quizSchema });
+  const initialized = useRef(false);
+  const lastEmittedHtml = useRef<string>(value);
+
+  useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+    if (!value?.trim()) return;
+
+    const blocks = editor.tryParseHTMLToBlocks(value);
+    editor.replaceBlocks(editor.document, blocks);
+    // Re-sync so the onChange triggered by replaceBlocks doesn't propagate
+    // up as a user edit.
+    lastEmittedHtml.current = editor.blocksToHTMLLossy(editor.document);
+    // Only runs once on mount — value changes after mount are user-driven
+    // and handled by the editor itself.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div
+      className="quiz-rich-text-input overflow-hidden rounded-md border border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-800"
+      style={{ minHeight }}
+      // Prevent the outer BlockNote editor from intercepting mouse events
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <BlockNoteView
+        editor={editor}
+        slashMenu={false}
+        theme={resolvedTheme === "dark" ? "dark" : "light"}
+        onChange={() => {
+          const html = editor.blocksToHTMLLossy(editor.document);
+          if (html !== lastEmittedHtml.current) {
+            lastEmittedHtml.current = html;
+            onChange(html);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/components/ui/blocknote/blocks/quiz-rich-text-input.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-rich-text-input.tsx
@@ -1,69 +1,55 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { BlockNoteSchema, defaultBlockSpecs } from "@blocknote/core";
-import { useCreateBlockNote } from "@blocknote/react";
-import { BlockNoteView } from "@blocknote/mantine";
-import { useTheme } from "next-themes";
-import "@blocknote/mantine/style.css";
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
 
-const quizSchema = BlockNoteSchema.create({
-  blockSpecs: {
-    paragraph: defaultBlockSpecs.paragraph,
-    codeBlock: defaultBlockSpecs.codeBlock,
-  },
-});
+// StarterKit includes: paragraph, inline code mark (Cmd+E), code block,
+// bold, italic, and other sensible defaults. We disable the list and
+// heading extensions to keep the quiz editor focused.
+const extensions = (placeholder: string) => [
+  StarterKit.configure({
+    heading: false,
+    bulletList: false,
+    orderedList: false,
+    listItem: false,
+    blockquote: false,
+    horizontalRule: false,
+  }),
+  Placeholder.configure({ placeholder }),
+];
 
 interface QuizRichTextInputProps {
   value: string;
   onChange: (html: string) => void;
+  placeholder?: string;
   minHeight?: string;
 }
 
 export function QuizRichTextInput({
   value,
   onChange,
+  placeholder = "Type here...",
   minHeight = "60px",
 }: QuizRichTextInputProps) {
-  const { resolvedTheme } = useTheme();
-  const editor = useCreateBlockNote({ schema: quizSchema });
-  const initialized = useRef(false);
-  const lastEmittedHtml = useRef<string>(value);
-
-  useEffect(() => {
-    if (initialized.current) return;
-    initialized.current = true;
-    if (!value?.trim()) return;
-
-    const blocks = editor.tryParseHTMLToBlocks(value);
-    editor.replaceBlocks(editor.document, blocks);
-    // Re-sync so the onChange triggered by replaceBlocks doesn't propagate
-    // up as a user edit.
-    lastEmittedHtml.current = editor.blocksToHTMLLossy(editor.document);
-    // Only runs once on mount — value changes after mount are user-driven
-    // and handled by the editor itself.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const editor = useEditor({
+    extensions: extensions(placeholder),
+    content: value || "",
+    onUpdate({ editor: e }) {
+      onChange(e.getHTML());
+    },
+    // Prevent TipTap from stealing focus on mount
+    autofocus: false,
+  });
 
   return (
     <div
-      className="quiz-rich-text-input overflow-hidden rounded-md border border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-800"
+      className="quiz-rich-text-input w-full rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus-within:ring-2 focus-within:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
       style={{ minHeight }}
-      // Prevent the outer BlockNote editor from intercepting mouse events
+      // Stop the outer BlockNote editor from claiming mousedown events
       onMouseDown={(e) => e.stopPropagation()}
     >
-      <BlockNoteView
-        editor={editor}
-        slashMenu={false}
-        theme={resolvedTheme === "dark" ? "dark" : "light"}
-        onChange={() => {
-          const html = editor.blocksToHTMLLossy(editor.document);
-          if (html !== lastEmittedHtml.current) {
-            lastEmittedHtml.current = html;
-            onChange(html);
-          }
-        }}
-      />
+      <EditorContent editor={editor} />
     </div>
   );
 }

--- a/frontend/components/ui/blocknote/blocks/quiz-rich-text-input.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-rich-text-input.tsx
@@ -1,13 +1,19 @@
 "use client";
 
-import { useEditor, EditorContent } from "@tiptap/react";
+import { useEffect, useRef } from "react";
+import { useEditor, EditorContent, ReactNodeViewRenderer } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
+import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
+import { CodeBlockComponent } from "@/components/ui/tiptap/toolbar/tools/code-tool/code-tool";
+import { all, createLowlight } from "lowlight";
 
-// StarterKit includes: paragraph, inline code mark (Cmd+E), code block,
-// bold, italic, and other sensible defaults. We disable the list and
-// heading extensions to keep the quiz editor focused.
-const extensions = (placeholder: string) => [
+// createLowlight(all) is expensive — keep it outside the component.
+const lowlight = createLowlight(all);
+
+// BASE_EXTENSIONS is stable across renders. TipTap reconfigures the editor
+// when the extensions array changes identity, causing position errors.
+const BASE_EXTENSIONS = [
   StarterKit.configure({
     heading: false,
     bulletList: false,
@@ -15,8 +21,17 @@ const extensions = (placeholder: string) => [
     listItem: false,
     blockquote: false,
     horizontalRule: false,
+    codeBlock: false, // replaced by CodeBlockLowlight below
   }),
-  Placeholder.configure({ placeholder }),
+  CodeBlockLowlight.extend({
+    addNodeView() {
+      return ReactNodeViewRenderer(CodeBlockComponent);
+    },
+  }).configure({
+    lowlight,
+    defaultLanguage: "python",
+    HTMLAttributes: { class: "hljs" },
+  }),
 ];
 
 interface QuizRichTextInputProps {
@@ -32,21 +47,39 @@ export function QuizRichTextInput({
   placeholder = "Type here...",
   minHeight = "60px",
 }: QuizRichTextInputProps) {
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
   const editor = useEditor({
-    extensions: extensions(placeholder),
-    content: value || "",
+    extensions: [...BASE_EXTENSIONS, Placeholder.configure({ placeholder })],
+    content: "",
     onUpdate({ editor: e }) {
-      onChange(e.getHTML());
+      if (!e.isDestroyed) {
+        onChangeRef.current(e.getHTML());
+      }
     },
-    // Prevent TipTap from stealing focus on mount
     autofocus: false,
+    editorProps: {
+      attributes: {
+        class:
+          "prose prose-sm prose-sky max-w-none prose-p:my-1 prose-code:text-inherit prose-strong:text-inherit prose-headings:text-inherit outline-none dark:text-slate-300",
+      },
+    },
   });
+
+  const initialized = useRef(false);
+  useEffect(() => {
+    if (!editor || initialized.current) return;
+    initialized.current = true;
+    if (value?.trim()) {
+      editor.commands.setContent(value, false);
+    }
+  }, [editor]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div
       className="quiz-rich-text-input w-full rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus-within:ring-2 focus-within:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
       style={{ minHeight }}
-      // Stop the outer BlockNote editor from claiming mousedown events
       onMouseDown={(e) => e.stopPropagation()}
     >
       <EditorContent editor={editor} />

--- a/frontend/components/ui/blocknote/blocks/quiz-true-false-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-true-false-block.tsx
@@ -43,7 +43,9 @@ export const TrueFalseQuiz = createReactBlockSpec(
         <div className="w-full rounded-lg border-2 border-gray-200 bg-white pb-4 dark:border-gray-700 dark:bg-gray-800">
           {/* Header matching QuizEditor */}
           <div className="mb-4 flex w-full flex-row items-center justify-between p-4">
-            <h2 className="text-lg">True/False Quiz</h2>
+            <h2 className="text-sm font-semibold tracking-wide text-black dark:text-white">
+              True/False Quiz
+            </h2>
             <Trash2Icon
               className="cursor-pointer text-red-600 hover:text-red-700"
               onClick={handleDelete}

--- a/frontend/components/ui/blocknote/blocks/quiz-true-false-block.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-true-false-block.tsx
@@ -2,6 +2,7 @@ import { createReactBlockSpec } from "@blocknote/react";
 import { defaultProps } from "@blocknote/core";
 import { Trash2Icon } from "lucide-react";
 import React from "react";
+import { QuizRichTextInput } from "./quiz-rich-text-input";
 
 export const TrueFalseQuiz = createReactBlockSpec(
   {
@@ -22,11 +23,9 @@ export const TrueFalseQuiz = createReactBlockSpec(
     render: (props) => {
       const { question, correctAnswer } = props.block.props;
 
-      const handleQuestionChange = (
-        e: React.ChangeEvent<HTMLTextAreaElement>,
-      ) => {
+      const handleQuestionChange = (html: string) => {
         props.editor.updateBlock(props.block, {
-          props: { question: e.target.value },
+          props: { question: html },
         });
       };
 
@@ -59,11 +58,10 @@ export const TrueFalseQuiz = createReactBlockSpec(
               <label className="mb-2 block text-left text-sm font-medium text-gray-700 dark:text-gray-300">
                 Question:
               </label>
-              <textarea
+              <QuizRichTextInput
                 value={question}
                 onChange={handleQuestionChange}
-                placeholder="Nothing here yet..."
-                className="resize-vertical min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-3 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                minHeight="80px"
               />
             </div>
 

--- a/frontend/components/ui/rendered-content.tsx
+++ b/frontend/components/ui/rendered-content.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+import DOMPurify from "isomorphic-dompurify";
+import hljs from "highlight.js";
+
+interface RenderedContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  html: string;
+}
+
+/**
+ * Renders sanitized HTML and post-processes fenced code blocks to match the
+ * editor's CodeBlockComponent exactly: syntax highlighting via highlight.js
+ * and a line-number gutter with 1.25rem line height on both sides.
+ *
+ * Critical layout values (padding, top, lineHeight) are set as inline styles
+ * so Tailwind Typography cannot override them regardless of prose context.
+ */
+export function RenderedContent({ html, ...divProps }: RenderedContentProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    ref.current.innerHTML = DOMPurify.sanitize(html);
+
+    ref.current.querySelectorAll("pre").forEach((pre) => {
+      const code = pre.querySelector("code");
+      if (!code) return;
+
+      const rawText = code.textContent ?? "";
+      const lines = rawText.split("\n");
+      if (lines[lines.length - 1] === "") lines.pop();
+
+      const langClass = Array.from(code.classList).find((c) =>
+        c.startsWith("language-"),
+      );
+      const lang = langClass?.replace("language-", "");
+
+      let highlightedHtml: string;
+      try {
+        highlightedHtml = lang
+          ? hljs.highlight(rawText, { language: lang }).value
+          : hljs.highlightAuto(rawText).value;
+      } catch {
+        highlightedHtml = rawText
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+      }
+
+      // --- new <pre> ---
+      // Inline styles own all layout so Typography can never shift them.
+      // Tailwind classes only provide colors/border (lower stakes).
+      const newPre = document.createElement("pre");
+      newPre.className =
+        "rounded-b-md rounded-tl-md border border-gray-200 bg-gray-50 dark:border-slate-700 dark:bg-slate-900";
+      newPre.style.position = "relative";
+      newPre.style.margin = "0";
+      newPre.style.overflowX = "auto";
+      newPre.style.paddingTop = "0.75rem";
+      newPre.style.paddingBottom = "0.75rem";
+      newPre.style.paddingRight = "1rem";
+      newPre.style.paddingLeft = "3rem";
+
+      // --- gutter ---
+      // top/bottom match pre's inline padding so numbers align with code lines.
+      const gutter = document.createElement("div");
+      gutter.className =
+        "flex min-w-[2.5rem] flex-col border-r border-gray-200 bg-gray-100 text-sm text-gray-400 select-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400";
+      gutter.style.position = "absolute";
+      gutter.style.top = "0.75rem";
+      gutter.style.bottom = "0.75rem";
+      gutter.style.left = "0";
+
+      lines.forEach((_, i) => {
+        const lineEl = document.createElement("div");
+        lineEl.className = "pr-2 text-right font-mono";
+        lineEl.style.lineHeight = "1.25rem";
+        lineEl.style.height = "1.25rem";
+        lineEl.textContent = String(i + 1);
+        gutter.appendChild(lineEl);
+      });
+
+      // --- code ---
+      const newCode = document.createElement("code");
+      newCode.className =
+        "font-mono text-sm whitespace-pre text-gray-800 dark:text-slate-50 hljs";
+      if (lang) newCode.classList.add(`language-${lang}`);
+      newCode.style.display = "block";
+      newCode.style.margin = "0";
+      newCode.style.padding = "0";
+      newCode.style.lineHeight = "1.25rem";
+      newCode.innerHTML = highlightedHtml;
+
+      newPre.appendChild(gutter);
+      newPre.appendChild(newCode);
+
+      const wrapper = document.createElement("div");
+      wrapper.className = "not-prose my-2";
+      wrapper.appendChild(newPre);
+
+      pre.parentNode?.replaceChild(wrapper, pre);
+    });
+  }, [html]);
+
+  return <div ref={ref} {...divProps} />;
+}

--- a/frontend/components/ui/tiptap/toolbar/tools/code-tool/code-tool.tsx
+++ b/frontend/components/ui/tiptap/toolbar/tools/code-tool/code-tool.tsx
@@ -29,25 +29,30 @@ function CodeBlockComponent({
   const lineCount = (node.textContent.match(/\n/g) || []).length + 1;
 
   return (
-    <NodeViewWrapper className="code-block my-4">
-      <select
-        contentEditable={false}
-        defaultValue={defaultLanguage}
-        onChange={(event) => updateAttributes({ language: event.target.value })}
-        className="mb-2 rounded-md border border-gray-300 bg-white px-2 py-1 text-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-      >
-        <option value="null">auto</option>
-        <option disabled>—</option>
-        {extension.options.lowlight
-          .listLanguages()
-          .map((lang: string, index: number) => (
-            <option key={index} value={lang}>
-              {lang}
-            </option>
-          ))}
-      </select>
-      <pre className="relative overflow-x-auto rounded-md bg-slate-900 py-3 pr-4 pl-12 dark:bg-slate-950">
-        <div className="absolute top-3 bottom-3 left-0 flex min-w-[2.5rem] flex-col border-r border-slate-700 bg-slate-800 text-sm text-slate-400 select-none dark:border-slate-800 dark:bg-slate-900">
+    <NodeViewWrapper className="code-block my-2">
+      <div className="flex justify-end">
+        <select
+          contentEditable={false}
+          defaultValue={defaultLanguage}
+          onChange={(event) =>
+            updateAttributes({ language: event.target.value })
+          }
+          className="rounded-t border border-b-0 border-gray-300 bg-white px-2 py-0.5 text-xs text-gray-600 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300"
+        >
+          <option value="null">auto</option>
+          <option disabled>—</option>
+          {extension.options.lowlight
+            .listLanguages()
+            .map((lang: string, index: number) => (
+              <option key={index} value={lang}>
+                {lang}
+              </option>
+            ))}
+        </select>
+      </div>
+      {/* mt-0 overrides Tailwind Typography's default pre margin-top */}
+      <pre className="relative mt-0 overflow-x-auto rounded-tl-md rounded-b-md border border-gray-200 bg-gray-50 py-3 pr-4 pl-12 dark:border-slate-700 dark:bg-slate-900">
+        <div className="absolute top-3 bottom-3 left-0 flex min-w-[2.5rem] flex-col border-r border-gray-200 bg-gray-100 text-sm text-gray-400 select-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400">
           {Array.from({ length: lineCount }).map((_, i) => (
             <div
               key={i}
@@ -63,7 +68,7 @@ function CodeBlockComponent({
         </div>
         <NodeViewContent
           as="code"
-          className="block font-mono text-sm whitespace-pre text-slate-50"
+          className="block font-mono text-sm whitespace-pre text-gray-800 dark:text-slate-50"
           style={{ lineHeight: "1.25rem" }}
         />
       </pre>

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -18,6 +18,7 @@ e2e/
 ```
 
 Each role directory contains:
+
 - `allowed-features.spec.ts` — Pages and workflows the role CAN access
 - `blocked-features.spec.ts` — Pages and workflows the role should NOT access
 - `auth.json` — Saved authentication state (gitignored, must be generated locally)
@@ -35,6 +36,7 @@ Role-based tests require an `auth.json` file with saved session cookies. Generat
 ### Step-by-step:
 
 1. **Run the save script** for the role you need:
+
    ```bash
    cd frontend
    npm run save:user           # Opens codegen browser — log in as a regular user
@@ -54,24 +56,26 @@ Role-based tests require an `auth.json` file with saved session cookies. Generat
 
 ### Available save/load scripts:
 
-| Script                   | Role              |
-|--------------------------|-------------------|
-| `npm run save:unauth`    | Unauthorized user |
-| `npm run save:user`      | Regular user      |
-| `npm run save:contentCreator`  | Content Creator |
-| `npm run save:contentEditor`   | Content Editor  |
-| `npm run save:faculty`         | Faculty         |
-| `npm run save:systemAdmin`     | System Admin    |
+| Script                        | Role              |
+| ----------------------------- | ----------------- |
+| `npm run save:unauth`         | Unauthorized user |
+| `npm run save:user`           | Regular user      |
+| `npm run save:contentCreator` | Content Creator   |
+| `npm run save:contentEditor`  | Content Editor    |
+| `npm run save:faculty`        | Faculty           |
+| `npm run save:systemAdmin`    | System Admin      |
 
 ## Running Tests
 
 ### All E2E tests (via Docker):
+
 ```bash
 cd frontend
 npm run test:e2e
 ```
 
 ### Tests by role/category:
+
 ```bash
 npm run test:e2e-public          # Public pages (no auth needed)
 npm run test:e2e-footer          # Footer tests
@@ -84,6 +88,7 @@ npm run test:e2e-faculty         # Faculty tests
 ```
 
 ### Run locally (without Docker):
+
 ```bash
 cd frontend
 npx playwright test                          # All tests
@@ -93,11 +98,13 @@ npx playwright test --grep "Explore"         # By test name
 ```
 
 ### View test report:
+
 ```bash
 npm run e2e:show
 ```
 
 ### Generate new tests interactively:
+
 ```bash
 npm run test:codegen    # Opens Playwright codegen on dev site
 ```
@@ -112,6 +119,7 @@ npm run test:codegen    # Opens Playwright codegen on dev site
 - Use `test.use({ storageState: "e2e/<role>/auth.json" })` for authenticated tests
 
 ### Example — Navigation test:
+
 ```typescript
 import { test, expect } from "@playwright/test";
 
@@ -132,6 +140,7 @@ test.describe("My Feature Tests", () => {
 ```
 
 ### Example — Form workflow with API mock:
+
 ```typescript
 test("submit form with mocked API", async ({ page }) => {
   await page.route("*/**/api/my-endpoint", async (route) => {
@@ -152,6 +161,7 @@ test("submit form with mocked API", async ({ page }) => {
 ## Configuration
 
 Playwright config is at `frontend/playwright.config.ts`:
+
 - **Browser**: Firefox (Chromium and Safari available but commented out)
 - **Parallelism**: Full parallel, 80% workers on CI
 - **Retries**: 2 on CI, 0 locally

--- a/frontend/lib/requests/lesson.ts
+++ b/frontend/lib/requests/lesson.ts
@@ -195,8 +195,11 @@ export async function updateLesson(
     const responseData = await response.json();
 
     if (!response.ok || (response.ok && responseData.error)) {
-      const errorPath = responseData.error.details.errors[0].path[0];
-      const errorMessage = `${responseData.error.message} (${errorPath})`;
+      const firstError = responseData.error?.details?.errors?.[0];
+      const errorPath = firstError?.path?.[0];
+      const errorMessage = errorPath
+        ? `${responseData.error.message} (${errorPath})`
+        : responseData.error?.message ?? "Failed to update lesson.";
       return { ok: false, error: errorMessage, data: null };
     }
 

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -568,6 +568,26 @@ export const stripHtmlTags = (html: string) => {
     .trim();
 };
 
+/**
+ * Returns true if the question is a True/False quiz.
+ * Tolerates HTML wrapping (e.g. `<p>True</p>`) produced by TipTap.
+ *
+ * @param question QuizQuestion to test
+ * @returns true when exactly two options whose stripped text is "true" and "false"
+ */
+export function isTrueFalseQuestion(question: {
+  answerOptions: { content: string }[];
+}): boolean {
+  if (question.answerOptions.length !== 2) return false;
+  const texts = question.answerOptions.map((o) =>
+    stripHtmlTags(o.content).toLowerCase(),
+  );
+  return (
+    (texts[0] === "true" && texts[1] === "false") ||
+    (texts[0] === "false" && texts[1] === "true")
+  );
+}
+
 export function parseSandpackFiles(
   json: string | null | undefined,
 ): Record<string, string> {

--- a/frontend/tests/components/draft/open-ended-quiz.test.tsx
+++ b/frontend/tests/components/draft/open-ended-quiz.test.tsx
@@ -73,7 +73,8 @@ describe("OpenEndedQuizEditor", () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId("update-content-button"));
+    // First update-content-button belongs to the question editor
+    fireEvent.click(screen.getAllByTestId("update-content-button")[0]);
 
     expect(mockUpdateBlock).toHaveBeenCalledWith({
       __component: "droplets.open-ended-quiz",
@@ -87,7 +88,7 @@ describe("OpenEndedQuizEditor", () => {
     });
   });
 
-  it("updates correct answer when textarea changes", () => {
+  it("updates correct answer when TipTap editor changes", () => {
     render(
       <OpenEndedQuizEditor
         block={mockBlock}
@@ -96,8 +97,8 @@ describe("OpenEndedQuizEditor", () => {
       />,
     );
 
-    const textarea = screen.getByRole("textbox");
-    fireEvent.change(textarea, { target: { value: "New answer" } });
+    // Second update-content-button belongs to the correct answer editor
+    fireEvent.click(screen.getAllByTestId("update-content-button")[1]);
 
     expect(mockUpdateBlock).toHaveBeenCalledWith({
       __component: "droplets.open-ended-quiz",
@@ -105,7 +106,7 @@ describe("OpenEndedQuizEditor", () => {
         {
           id: 1,
           content: "Test question",
-          correctAnswer: "New answer",
+          correctAnswer: "Updated content",
         },
       ],
     });

--- a/frontend/tests/components/droplets/generic-block-renderer.test.tsx
+++ b/frontend/tests/components/droplets/generic-block-renderer.test.tsx
@@ -6,6 +6,7 @@ import { Highlight, HighlightColor } from "@/types";
 
 jest.mock("highlight.js", () => ({
   highlightAll: jest.fn(),
+  highlightElement: jest.fn(),
 }));
 
 jest.mock("katex", () => ({
@@ -273,7 +274,7 @@ describe("GenericBlockRenderer", () => {
           }}
         />,
       );
-      expect(hljs.highlightAll).toHaveBeenCalled();
+      expect(hljs.highlightElement).toHaveBeenCalled();
     });
 
     it("removes language-plaintext class from code blocks", () => {
@@ -348,7 +349,7 @@ describe("GenericBlockRenderer", () => {
         />,
       );
 
-      expect(hljs.highlightAll).toHaveBeenCalled();
+      expect(hljs.highlightElement).toHaveBeenCalled();
     });
   });
 
@@ -1440,7 +1441,7 @@ describe("GenericBlockRenderer", () => {
         />,
       );
 
-      expect(hljs.highlightAll).toHaveBeenCalled();
+      expect(hljs.highlightElement).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/tests/components/droplets/quiz-question.test.tsx
+++ b/frontend/tests/components/droplets/quiz-question.test.tsx
@@ -506,10 +506,9 @@ describe("QuizQuestionBlock - formatted content (ODY-445)", () => {
 
   it("strips dangerous XSS content from question stem via DOMPurify.sanitize", () => {
     // Access the mock spy via requireMock (safe after hoisting)
-    const DOMPurify =
-      jest.requireMock<{ default: { sanitize: jest.Mock } }>(
-        "isomorphic-dompurify",
-      ).default;
+    const DOMPurify = jest.requireMock<{ default: { sanitize: jest.Mock } }>(
+      "isomorphic-dompurify",
+    ).default;
 
     // Override the mock to simulate DOMPurify stripping <script> tags
     DOMPurify.sanitize.mockImplementation((html: string) =>

--- a/frontend/tests/components/droplets/quiz-question.test.tsx
+++ b/frontend/tests/components/droplets/quiz-question.test.tsx
@@ -2,6 +2,16 @@ import { QuizQuestionBlock } from "@/components/droplets/lessons/quiz-question";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+// Mock isomorphic-dompurify so tests run in jsdom without the full JSDOM window.
+// The factory must be self-contained (jest.mock hoisting), so we define the spy
+// inside the factory using jest.fn(). Access via jest.requireMock() in tests.
+jest.mock("isomorphic-dompurify", () => ({
+  __esModule: true,
+  default: {
+    sanitize: jest.fn((html: string) => html),
+  },
+}));
+
 // Mock sessionStorage for testing since it's not available in Node/Jest environment
 const mockSessionStorage = (() => {
   let store: Record<string, string> = {};
@@ -437,5 +447,106 @@ describe("QuizQuestionBlock - Session Storage", () => {
       screen.getByRole("button", { name: /check answer/i }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});
+
+describe("QuizQuestionBlock - formatted content (ODY-445)", () => {
+  const mockLessonId = 99;
+
+  beforeEach(() => {
+    mockSessionStorage.clear();
+  });
+
+  it("renders inline <code> in the question stem", () => {
+    const question = {
+      id: 10,
+      content: "<p>What does <code>print(x)</code> output?</p>",
+      answerOptions: [
+        { id: 101, content: "42", isCorrect: true },
+        { id: 102, content: "None", isCorrect: false },
+      ],
+    };
+    render(<QuizQuestionBlock question={question} lessonId={mockLessonId} />);
+    // The <code> element should be in the DOM
+    expect(document.querySelector("code")).toBeInTheDocument();
+  });
+
+  it("renders a <pre><code> block in the question stem", () => {
+    const question = {
+      id: 11,
+      content: "<pre><code>def foo():\n  return 1</code></pre>",
+      answerOptions: [
+        { id: 111, content: "1", isCorrect: true },
+        { id: 112, content: "0", isCorrect: false },
+      ],
+    };
+    render(<QuizQuestionBlock question={question} lessonId={mockLessonId} />);
+    expect(document.querySelector("pre")).toBeInTheDocument();
+    expect(document.querySelector("code")).toBeInTheDocument();
+  });
+
+  it("renders inline code inside an answer option without invalid nesting", () => {
+    const question = {
+      id: 12,
+      content: "<p>Which snippet is correct?</p>",
+      answerOptions: [
+        { id: 121, content: "<code>x = 1</code>", isCorrect: true },
+        { id: 122, content: "<code>x == 1</code>", isCorrect: false },
+      ],
+    };
+    render(<QuizQuestionBlock question={question} lessonId={mockLessonId} />);
+    // Both code elements should appear (one per answer)
+    const codeElements = document.querySelectorAll("code");
+    expect(codeElements.length).toBeGreaterThanOrEqual(2);
+    // The code elements must NOT be inside a <span> (was the old broken wrapping)
+    codeElements.forEach((el) => {
+      expect(el.closest("span")).toBeNull();
+    });
+  });
+
+  it("strips dangerous XSS content from question stem via DOMPurify.sanitize", () => {
+    // Access the mock spy via requireMock (safe after hoisting)
+    const DOMPurify =
+      jest.requireMock<{ default: { sanitize: jest.Mock } }>(
+        "isomorphic-dompurify",
+      ).default;
+
+    // Override the mock to simulate DOMPurify stripping <script> tags
+    DOMPurify.sanitize.mockImplementation((html: string) =>
+      html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, ""),
+    );
+
+    const question = {
+      id: 13,
+      content: '<p>Hello</p><script>alert("xss")</script>',
+      answerOptions: [
+        { id: 131, content: "A", isCorrect: true },
+        { id: 132, content: "B", isCorrect: false },
+      ],
+    };
+    render(<QuizQuestionBlock question={question} lessonId={mockLessonId} />);
+    // script should not be in the rendered DOM after sanitization
+    expect(document.querySelector("script")).toBeNull();
+    // DOMPurify.sanitize should have been called with the original content
+    expect(DOMPurify.sanitize).toHaveBeenCalledWith(
+      '<p>Hello</p><script>alert("xss")</script>',
+    );
+
+    // Restore default mock behaviour for other tests
+    DOMPurify.sanitize.mockImplementation((html: string) => html);
+  });
+
+  it("plain-text legacy answers still render correctly", () => {
+    const question = {
+      id: 14,
+      content: "<p>What is 1 + 1?</p>",
+      answerOptions: [
+        { id: 141, content: "2", isCorrect: true },
+        { id: 142, content: "3", isCorrect: false },
+      ],
+    };
+    render(<QuizQuestionBlock question={question} lessonId={mockLessonId} />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/ui/tiptap/code-tool.test.tsx
+++ b/frontend/tests/components/ui/tiptap/code-tool.test.tsx
@@ -325,10 +325,10 @@ describe("CodeBlockComponent", () => {
       render(<CodeBlockComponent {...baseProps} />);
 
       const select = screen.getByRole("combobox");
-      expect(select).toHaveClass("rounded-md");
+      expect(select).toHaveClass("rounded-t");
       expect(select).toHaveClass("border-gray-300");
       expect(select).toHaveClass(
-        "mb-2 rounded-md border border-gray-300 bg-white px-2 py-1 text-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white",
+        "rounded-t border border-b-0 border-gray-300 bg-white px-2 py-0.5 text-xs text-gray-600 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300",
       );
     });
 
@@ -336,8 +336,8 @@ describe("CodeBlockComponent", () => {
       render(<CodeBlockComponent {...baseProps} />);
 
       const select = screen.getByRole("combobox");
-      expect(select).toHaveClass("focus:border-blue-500");
-      expect(select).toHaveClass("focus:ring-2");
+      expect(select).toHaveClass("focus:ring-blue-500");
+      expect(select).toHaveClass("focus:ring-1");
     });
 
     it("line numbers have correct styling", () => {
@@ -345,10 +345,7 @@ describe("CodeBlockComponent", () => {
 
       const lineNumbers = container.querySelector(".select-none");
       expect(lineNumbers).toHaveClass(
-        "absolute top-3 bottom-3 left-0 flex min-w-[2.5rem] flex-col border-r border-slate-700 bg-slate-800 text-sm text-slate-400 select-none dark:border-slate-800 dark:bg-slate-900",
-      );
-      expect(lineNumbers).toHaveClass(
-        "absolute top-3 bottom-3 left-0 flex min-w-[2.5rem] flex-col border-r border-slate-700 bg-slate-800 text-sm text-slate-400 select-none dark:border-slate-800 dark:bg-slate-900",
+        "absolute top-3 bottom-3 left-0 flex min-w-[2.5rem] flex-col border-r border-gray-200 bg-gray-100 text-sm text-gray-400 select-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400",
       );
     });
 

--- a/frontend/tests/lib/utils.test.ts
+++ b/frontend/tests/lib/utils.test.ts
@@ -1,0 +1,79 @@
+import { isTrueFalseQuestion, stripHtmlTags } from "@/lib/utils";
+
+describe("stripHtmlTags", () => {
+  it("strips simple HTML tags", () => {
+    expect(stripHtmlTags("<p>Hello</p>")).toBe("Hello");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripHtmlTags("")).toBe("");
+  });
+});
+
+describe("isTrueFalseQuestion", () => {
+  it("returns true for plain 'True'/'False' answers", () => {
+    const question = {
+      answerOptions: [
+        { content: "True" },
+        { content: "False" },
+      ],
+    };
+    expect(isTrueFalseQuestion(question)).toBe(true);
+  });
+
+  it("returns true when TipTap wraps values in <p> tags", () => {
+    const question = {
+      answerOptions: [
+        { content: "<p>True</p>" },
+        { content: "<p>False</p>" },
+      ],
+    };
+    expect(isTrueFalseQuestion(question)).toBe(true);
+  });
+
+  it("returns true for lowercase 'true'/'false'", () => {
+    const question = {
+      answerOptions: [
+        { content: "true" },
+        { content: "false" },
+      ],
+    };
+    expect(isTrueFalseQuestion(question)).toBe(true);
+  });
+
+  it("returns true when options are in swapped order (False first)", () => {
+    const question = {
+      answerOptions: [
+        { content: "False" },
+        { content: "True" },
+      ],
+    };
+    expect(isTrueFalseQuestion(question)).toBe(true);
+  });
+
+  it("returns false for a three-option MCQ", () => {
+    const question = {
+      answerOptions: [
+        { content: "A" },
+        { content: "B" },
+        { content: "C" },
+      ],
+    };
+    expect(isTrueFalseQuestion(question)).toBe(false);
+  });
+
+  it("returns false for a two-option MCQ whose values are not true/false", () => {
+    const question = {
+      answerOptions: [
+        { content: "Yes" },
+        { content: "No" },
+      ],
+    };
+    expect(isTrueFalseQuestion(question)).toBe(false);
+  });
+
+  it("returns false for an empty options array", () => {
+    const question = { answerOptions: [] };
+    expect(isTrueFalseQuestion(question)).toBe(false);
+  });
+});

--- a/frontend/tests/lib/utils.test.ts
+++ b/frontend/tests/lib/utils.test.ts
@@ -13,61 +13,42 @@ describe("stripHtmlTags", () => {
 describe("isTrueFalseQuestion", () => {
   it("returns true for plain 'True'/'False' answers", () => {
     const question = {
-      answerOptions: [
-        { content: "True" },
-        { content: "False" },
-      ],
+      answerOptions: [{ content: "True" }, { content: "False" }],
     };
     expect(isTrueFalseQuestion(question)).toBe(true);
   });
 
   it("returns true when TipTap wraps values in <p> tags", () => {
     const question = {
-      answerOptions: [
-        { content: "<p>True</p>" },
-        { content: "<p>False</p>" },
-      ],
+      answerOptions: [{ content: "<p>True</p>" }, { content: "<p>False</p>" }],
     };
     expect(isTrueFalseQuestion(question)).toBe(true);
   });
 
   it("returns true for lowercase 'true'/'false'", () => {
     const question = {
-      answerOptions: [
-        { content: "true" },
-        { content: "false" },
-      ],
+      answerOptions: [{ content: "true" }, { content: "false" }],
     };
     expect(isTrueFalseQuestion(question)).toBe(true);
   });
 
   it("returns true when options are in swapped order (False first)", () => {
     const question = {
-      answerOptions: [
-        { content: "False" },
-        { content: "True" },
-      ],
+      answerOptions: [{ content: "False" }, { content: "True" }],
     };
     expect(isTrueFalseQuestion(question)).toBe(true);
   });
 
   it("returns false for a three-option MCQ", () => {
     const question = {
-      answerOptions: [
-        { content: "A" },
-        { content: "B" },
-        { content: "C" },
-      ],
+      answerOptions: [{ content: "A" }, { content: "B" }, { content: "C" }],
     };
     expect(isTrueFalseQuestion(question)).toBe(false);
   });
 
   it("returns false for a two-option MCQ whose values are not true/false", () => {
     const question = {
-      answerOptions: [
-        { content: "Yes" },
-        { content: "No" },
-      ],
+      answerOptions: [{ content: "Yes" }, { content: "No" }],
     };
     expect(isTrueFalseQuestion(question)).toBe(false);
   });


### PR DESCRIPTION
## Summary

  - Adds inline code (Cmd+E) and fenced code block support to MCQ, True/False, and Open-Ended quiz questions in
  both the v1 (TipTap) and v2 (BlockNote) lesson editors
  - Learner-side quiz rendering now uses a shared `RenderedContent` component that sanitizes HTML via DOMPurify
  and applies syntax highlighting + line-number gutters consistent with the lesson body
  - Fixes True/False detection to be HTML-tolerant (`isTrueFalseQuestion` helper), restores v1 lesson code block
  line-number alignment, and improves light-mode syntax highlight contrast

  ## Changes

  **Frontend — Components**
  - `components/ui/rendered-content.tsx` — new shared sanitize + syntax-highlight component
  - `components/droplets/lessons/quiz-question.tsx` — uses RenderedContent for all quiz HTML
  - `components/droplets/lessons/open-ended-quiz-question-block.tsx` — sanitized rendering + rich text correct
  answer
  - `components/droplets/lessons/generic-block-renderer.tsx` — fixed v1 code block line alignment
  - `components/ui/blocknote/blocks/quiz-{multiple-choice,true-false,open-ended}-block.tsx` — rich text inputs,
  styled headers
  - `components/ui/blocknote/blocks/quiz-rich-text-input.tsx` — new TipTap-based rich text input for BlockNote
  quiz blocks
  - `components/draft/lesson/blocks/{quiz,quiz-question-editor,open-ended-quiz}.tsx` — HTML-tolerant T/F
  detection, rich text correct answer

  **Frontend — Lib & Styles**
  - `lib/utils.ts` — `isTrueFalseQuestion` helper
  - `lib/requests/lesson.ts` — guard against missing error.details
  - `app/globals.css` — light/dark syntax highlight theme, prose pre colors, contrast fixes

  **Tests**
  - `tests/lib/utils.test.ts` — isTrueFalseQuestion coverage
  - `tests/components/droplets/quiz-question.test.tsx` — rendering, sanitization, T/F detection

  ## Acceptance Criteria

  - [x] Inline code (Cmd+E) and code-block button work in question stem and answer options
  - [x] Question stem renders code with monospace + syntax highlighting in learner view
  - [x] Answer options render code without invalid HTML nesting
  - [x] "View wrong answer" list renders formatted HTML correctly
  - [x] All quiz HTML sanitized via DOMPurify
  - [x] True/False detection works after editor wraps values in `<p>` tags
  - [x] Existing plain-text MCQ/T-F questions render unchanged
  - [ ] Manual smoke test (ODY-464)

  ## Test Plan

  - [x] CI passes (Prettier, ESLint, 4438 Jest tests, Next.js build, Strapi build)
  - [ ] Creator: add MCQ with inline code and code block in question + answers, save, view as learner
  - [ ] Creator: open existing T/F question, click into answer, save — confirm heading stays "True/False Quiz"
  - [ ] Creator: add open-ended question with code block in both question and correct answer fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich-text editing for quiz questions and answers
  * Rendered, highlighted code blocks with line numbers in lesson content

* **Improvements**
  * Better HTML sanitization to prevent unsafe content
  * Improved light/dark theme styling and contrast for code
  * Updated quiz layout sizing and True/False detection

* **Documentation & Tests**
  * Added implementation plan and expanded unit/integration tests for formatted quiz content
<!-- end of auto-generated comment: release notes by coderabbit.ai -->