### PR TITLE
improvement/handle Tab key in quiz question code blocks

### DIFF
--- a/frontend/components/ui/blocknote/blocks/quiz-rich-text-input.tsx
+++ b/frontend/components/ui/blocknote/blocks/quiz-rich-text-input.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useEditor, EditorContent, ReactNodeViewRenderer } from "@tiptap/react";
+import { Extension } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
@@ -10,6 +11,20 @@ import { all, createLowlight } from "lowlight";
 
 // createLowlight(all) is expensive — keep it outside the component.
 const lowlight = createLowlight(all);
+
+// Insert two spaces on Tab inside a code block; fall through elsewhere so
+// the browser's normal focus-advancement behaviour is preserved.
+const TabHandler = Extension.create({
+  name: "tabHandler",
+  addKeyboardShortcuts() {
+    return {
+      Tab: () => {
+        if (!this.editor.isActive("codeBlock")) return false;
+        return this.editor.commands.insertContent("  ");
+      },
+    };
+  },
+});
 
 // BASE_EXTENSIONS is stable across renders. TipTap reconfigures the editor
 // when the extensions array changes identity, causing position errors.
@@ -32,6 +47,7 @@ const BASE_EXTENSIONS = [
     defaultLanguage: "python",
     HTMLAttributes: { class: "hljs" },
   }),
+  TabHandler,
 ];
 
 interface QuizRichTextInputProps {


### PR DESCRIPTION
## Summary

- Adds a `TabHandler` TipTap extension to `QuizRichTextInput` that inserts two spaces when Tab is pressed inside a code block, preventing the browser from shifting focus to the next element
- Outside code blocks, Tab falls through to normal browser behaviour unchanged
- Scoped entirely to `QuizRichTextInput` — v1 TipTap blocks, code block, notebook, and live sandbox blocks are unaffected

## Changes

- `frontend/components/ui/blocknote/blocks/quiz-rich-text-input.tsx` — new `TabHandler` extension added to `BASE_EXTENSIONS`

## Acceptance Criteria

- [x] Tab inside a code block in a v2 quiz question inserts two spaces
- [x] Tab outside a code block still moves focus normally
- [x] No regressions to v1 lesson blocks or other v2 block types
- [x] Prettier, ESLint, and Jest pass

## Test Plan

- [x] CI passes locally
- [x] Manual: open a v2 quiz block, add a fenced code block, press Tab — confirm two spaces are inserted
- [x] Manual: press Tab outside the code block — confirm focus moves to next element normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)